### PR TITLE
Use new unbranded dashboard page for getting a token

### DIFF
--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -173,7 +173,7 @@ export function initiateAuthFlow(): { connectUrl: string; resultId: string } | n
   const callbackUrl = new URL('/auth/callback', window.location.origin).toString();
 
   // Compose the connect URL (no redirect, just return)
-  const connectUrl = `${import.meta.env.VITE_CONNECT_URL || 'https://connect.fireproof.direct/fp/cloud/api/token'}?back_url=${encodeURIComponent(callbackUrl)}&result_id=${resultId}&countdownSecs=0&skipChooser`;
+  const connectUrl = `${import.meta.env.VITE_CONNECT_URL || 'https://connect.fireproof.direct/token'}?back_url=${encodeURIComponent(callbackUrl)}&result_id=${resultId}&countdownSecs=0&skipChooser`;
   return { connectUrl, resultId };
 }
 


### PR DESCRIPTION
To go with this: https://github.com/fireproof-storage/dashboard/commit/6c4040b49ef527015c40eabbe3bd444a6d90959b#diff-86963609bec6fda3d34233676d5ae33f6aa4b9bbe2758a10cd4863b704b37093R55

Which will remove the Fireproof dashboard UI from around the redirect.