### PR TITLE
Refactor large modules

### DIFF
--- a/app/hooks/checkCredits.ts
+++ b/app/hooks/checkCredits.ts
@@ -1,0 +1,59 @@
+import { getCredits } from '../config/provisioning';
+import type { RuntimeError } from './useRuntimeErrors';
+
+// Global request tracking to prevent duplicate credit check calls
+let pendingCreditsCheck: Promise<any> | null = null;
+
+export async function checkCredits(
+  apiKeyToCheck: string,
+  addError: (err: RuntimeError) => void,
+  setNeedsNewKey: (v: boolean) => void
+): Promise<boolean> {
+  if (!apiKeyToCheck) {
+    console.warn('checkCredits: No API key provided');
+    addError({
+      type: 'error',
+      message: 'API key is required to check credits.',
+      errorType: 'Other',
+      source: 'checkCredits',
+      timestamp: new Date().toISOString(),
+    });
+    return false;
+  }
+
+  try {
+    if (!pendingCreditsCheck) {
+      pendingCreditsCheck = getCredits(apiKeyToCheck);
+    }
+
+    const credits = await pendingCreditsCheck;
+    console.log('💳 Credits:', credits);
+    pendingCreditsCheck = null;
+
+    if (credits && credits.available <= 0.9) {
+      setNeedsNewKey(true);
+      addError({
+        type: 'error',
+        message: 'Low credits. A new API key might be required soon.',
+        errorType: 'Other',
+        source: 'checkCredits',
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    return true;
+  } catch (error: any) {
+    pendingCreditsCheck = null;
+    console.error('Error checking credits:', error);
+    setNeedsNewKey(true);
+    addError({
+      type: 'error',
+      message: error.message || 'Failed to check credits. A new API key might be needed.',
+      errorType: 'Other',
+      source: 'checkCredits',
+      timestamp: new Date().toISOString(),
+      stack: error.stack,
+    });
+    return false;
+  }
+}

--- a/app/hooks/sendMessage.ts
+++ b/app/hooks/sendMessage.ts
@@ -1,0 +1,192 @@
+import { parseContent } from '../utils/segmentParser';
+import { streamAI } from '../utils/streamHandler';
+import { generateTitle } from '../utils/titleGenerator';
+import { trackChatInputClick } from '../utils/analytics';
+import type {
+  ChatMessageDocument,
+  AiChatMessageDocument,
+  UserChatMessageDocument,
+} from '../types/chat';
+
+export interface SendMessageContext {
+  userMessage: ChatMessageDocument;
+  mergeUserMessage: (msg: Partial<UserChatMessageDocument>) => void;
+  setPendingUserDoc: (doc: ChatMessageDocument) => void;
+  setIsStreaming: (v: boolean) => void;
+  ensureApiKey: () => Promise<{ key: string } | null>;
+  setNeedsLogin: (v: boolean) => void;
+  setNeedsNewKey: (v: boolean) => void;
+  addError: (err: any) => void;
+  checkCredits: (key: string) => Promise<boolean>;
+  ensureSystemPrompt: () => Promise<string>;
+  submitUserMessage: () => Promise<any>;
+  buildMessageHistory: () => any[];
+  modelToUse: string;
+  throttledMergeAiMessage: (content: string) => void;
+  isProcessingRef: { current: boolean };
+  aiMessage: AiChatMessageDocument;
+  sessionDatabase: any;
+  setPendingAiMessage: (doc: ChatMessageDocument | null) => void;
+  setSelectedResponseId: (id: string) => void;
+  updateTitle: (title: string) => void;
+  setInput: (text: string) => void;
+  userId: string | undefined;
+  titleModel: string;
+}
+
+export async function sendMessage(ctx: SendMessageContext, textOverride?: string): Promise<void> {
+  const {
+    userMessage,
+    mergeUserMessage,
+    setPendingUserDoc,
+    setIsStreaming,
+    ensureApiKey,
+    setNeedsLogin,
+    setNeedsNewKey,
+    addError,
+    checkCredits,
+    ensureSystemPrompt,
+    submitUserMessage,
+    buildMessageHistory,
+    modelToUse,
+    throttledMergeAiMessage,
+    isProcessingRef,
+    aiMessage,
+    sessionDatabase,
+    setPendingAiMessage,
+    setSelectedResponseId,
+    updateTitle,
+    setInput,
+    userId,
+    titleModel,
+  } = ctx;
+
+  const promptText = textOverride || userMessage.text;
+  trackChatInputClick(promptText.length);
+
+  if (!promptText.trim()) return;
+
+  if (textOverride) {
+    mergeUserMessage({ text: textOverride });
+  }
+
+  setPendingUserDoc({
+    ...userMessage,
+    text: promptText,
+  });
+
+  setIsStreaming(true);
+
+  let currentApiKey: string;
+  try {
+    const keyObject = await ensureApiKey();
+    if (!keyObject?.key) {
+      throw new Error('API key not found after ensureApiKey call.');
+    }
+    currentApiKey = keyObject.key;
+  } catch (err) {
+    console.warn('sendMessage: Failed to ensure API key:', err);
+    setNeedsLogin(true);
+    setNeedsNewKey(true);
+    addError({
+      type: 'error',
+      message: 'API key is required. Please log in or ensure your key is valid.',
+      errorType: 'Other',
+      source: 'sendMessage',
+      timestamp: new Date().toISOString(),
+    });
+    setIsStreaming(false);
+    return;
+  }
+
+  const hasSufficientCredits = await checkCredits(currentApiKey);
+  if (!hasSufficientCredits) {
+    setIsStreaming(false);
+    return;
+  }
+
+  const currentSystemPrompt = await ensureSystemPrompt();
+
+  return submitUserMessage()
+    .then(async () => {
+      const messageHistory = buildMessageHistory();
+
+      return streamAI(
+        modelToUse,
+        currentSystemPrompt,
+        messageHistory,
+        promptText,
+        (content) => throttledMergeAiMessage(content),
+        currentApiKey,
+        userId,
+        setNeedsLogin
+      );
+    })
+    .then(async (finalContent) => {
+      isProcessingRef.current = true;
+
+      try {
+        if (typeof finalContent === 'string' && finalContent.startsWith('{')) {
+          try {
+            const parsedContent = JSON.parse(finalContent);
+
+            if (parsedContent.error) {
+              console.log('Error in API response:', parsedContent);
+              setNeedsNewKey(true);
+              setInput(promptText);
+              finalContent = `Error: ${JSON.stringify(parsedContent.error)}`;
+            } else {
+              finalContent = parsedContent;
+            }
+          } catch (jsonError) {
+            console.log('Error parsing JSON response:', jsonError, finalContent);
+          }
+        }
+
+        if (
+          !finalContent ||
+          (typeof finalContent === 'string' && finalContent.trim().length === 0)
+        ) {
+          console.log('[TOAST MESSAGE] Error occurred while processing the request');
+          setNeedsLogin(true);
+          return;
+        }
+
+        if (aiMessage?.text !== finalContent) {
+          aiMessage.text = finalContent;
+        }
+
+        aiMessage.model = modelToUse;
+        const { id } = (await sessionDatabase.put(aiMessage)) as { id: string };
+        setPendingAiMessage({ ...aiMessage, _id: id });
+        setSelectedResponseId(id);
+
+        const { segments } = parseContent(aiMessage?.text || '');
+        try {
+          console.log('sendMessage: Generating title...');
+          const title = await generateTitle(segments, titleModel, currentApiKey);
+          if (title) {
+            updateTitle(title);
+          }
+        } catch (titleError) {
+          console.warn('Failed to generate title:', titleError);
+        }
+      } finally {
+        isProcessingRef.current = false;
+      }
+    })
+    .catch((error: any) => {
+      console.log('Error:', error);
+      isProcessingRef.current = false;
+      setPendingAiMessage(null);
+      setSelectedResponseId('');
+    })
+    .finally(() => {
+      setIsStreaming(false);
+      if (currentApiKey) {
+        checkCredits(currentApiKey).catch((err) => {
+          console.warn('Failed to check credits in finally block:', err);
+        });
+      }
+    });
+}

--- a/app/hooks/useSimpleChat.ts
+++ b/app/hooks/useSimpleChat.ts
@@ -2,14 +2,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import type { ChatMessageDocument, ChatState } from '../types/chat';
 import type { UserSettings } from '../types/settings';
-import { trackChatInputClick } from '../utils/analytics';
-import { parseContent } from '../utils/segmentParser';
 
 import { useFireproof } from 'use-fireproof';
 import { FIREPROOF_CHAT_HISTORY } from '../config/env';
-import { getCredits } from '../config/provisioning';
-import { streamAI } from '../utils/streamHandler';
-import { generateTitle } from '../utils/titleGenerator';
 import { useApiKey } from './useApiKey';
 import { type ErrorCategory, type RuntimeError, useRuntimeErrors } from './useRuntimeErrors';
 import { useSession } from './useSession';
@@ -18,13 +13,13 @@ import { useMessageSelection } from './useMessageSelection';
 // Import our custom hooks
 import { useSystemPromptManager } from './useSystemPromptManager';
 import { useThrottledUpdates } from './useThrottledUpdates';
+import { checkCredits } from './checkCredits';
+import { sendMessage as sendChatMessage } from './sendMessage';
+import type { SendMessageContext } from './sendMessage';
 
 // Constants
 const CODING_MODEL = 'anthropic/claude-sonnet-4';
 const TITLE_MODEL = 'meta-llama/llama-3.1-8b-instruct';
-
-// Global request tracking to prevent duplicate credit check calls
-let pendingCreditsCheck: Promise<any> | null = null;
 
 /**
  * Simplified chat hook that focuses on data-driven state management
@@ -223,65 +218,8 @@ export function useSimpleChat(sessionId: string | undefined): ChatState {
     [mergeUserMessage]
   );
 
-  // Function to check credits and set needsNewKey if needed
-  const checkCredits = useCallback(
-    async (apiKeyToCheck: string): Promise<boolean> => {
-      if (!apiKeyToCheck) {
-        console.warn('checkCredits: No API key provided');
-        addError({
-          type: 'error',
-          message: 'API key is required to check credits.',
-          errorType: 'Other', // Using valid error type
-          source: 'checkCredits',
-          timestamp: new Date().toISOString(),
-        });
-        return false;
-      }
-
-      try {
-        // Deduplicate credits check requests across components
-        if (!pendingCreditsCheck) {
-          pendingCreditsCheck = getCredits(apiKeyToCheck);
-        }
-
-        // Wait for the existing or new request to complete
-        const credits = await pendingCreditsCheck;
-        console.log('💳 Credits:', credits);
-
-        // Reset the pending request after completion
-        pendingCreditsCheck = null;
-
-        if (credits && credits.available <= 0.9) {
-          setNeedsNewKey(true);
-          addError({
-            type: 'error',
-            message: 'Low credits. A new API key might be required soon.',
-            errorType: 'Other', // Using valid error type
-            source: 'checkCredits',
-            timestamp: new Date().toISOString(),
-          });
-          // Still return true since we have some credits
-        }
-
-        return true; // Credits check successful
-      } catch (error: any) {
-        // Reset the pending request on error
-        pendingCreditsCheck = null;
-
-        // If we can't check credits, we might need a new key
-        console.error('Error checking credits:', error);
-        setNeedsNewKey(true);
-        addError({
-          type: 'error',
-          message: error.message || 'Failed to check credits. A new API key might be needed.',
-          errorType: 'Other', // Using valid error type
-          source: 'checkCredits',
-          timestamp: new Date().toISOString(),
-          stack: error.stack,
-        });
-        return false; // Credits check failed
-      }
-    },
+  const boundCheckCredits = useCallback(
+    (key: string) => checkCredits(key, addError, setNeedsNewKey),
     [addError, setNeedsNewKey]
   );
 
@@ -290,171 +228,33 @@ export function useSimpleChat(sessionId: string | undefined): ChatState {
    * @param textOverride Optional text to use instead of the current userMessage
    */
   const sendMessage = useCallback(
-    async (textOverride?: string): Promise<void> => {
-      // Use provided text or fall back to userMessage.text
-      const promptText = textOverride || userMessage.text;
-
-      // Fire analytics for chat input
-      trackChatInputClick(promptText.length);
-
-      if (!promptText.trim()) return;
-
-      // Update user message with the text we're about to send if using an override
-      if (textOverride) {
-        mergeUserMessage({ text: textOverride });
-      }
-
-      // Save a copy of the user message for immediate display
-      setPendingUserDoc({
-        ...userMessage,
-        text: promptText,
-      });
-
-      // Set streaming state early for better UI feedback
-      setIsStreaming(true);
-
-      // Get API key - this is the core of the lazy key loading pattern
-      let currentApiKey: string;
-      try {
-        const keyObject = await ensureApiKey();
-        if (!keyObject?.key) {
-          throw new Error('API key not found after ensureApiKey call.');
-        }
-        currentApiKey = keyObject.key;
-      } catch (err) {
-        console.warn('sendMessage: Failed to ensure API key:', err);
-        setNeedsLogin(true); // Prompt for login if key cannot be obtained
-        setNeedsNewKey(true); // Also indicate a new key might be needed
-        addError({
-          type: 'error',
-          message: 'API key is required. Please log in or ensure your key is valid.',
-          errorType: 'Other', // Using valid error type
-          source: 'sendMessage',
-          timestamp: new Date().toISOString(),
-        });
-        setIsStreaming(false); // Reset streaming state on error
-        return;
-      }
-
-      // Check credits with the obtained key
-      const hasSufficientCredits = await checkCredits(currentApiKey);
-      if (!hasSufficientCredits) {
-        // Error is already added by checkCredits
-        setIsStreaming(false);
-        return;
-      }
-
-      // Ensure we have a system prompt
-      const currentSystemPrompt = await ensureSystemPrompt();
-
-      // Submit user message first
-      return submitUserMessage()
-        .then(async () => {
-          const messageHistory = buildMessageHistory();
-
-          return streamAI(
-            modelToUse,
-            currentSystemPrompt,
-            messageHistory,
-            promptText,
-            (content) => throttledMergeAiMessage(content),
-            currentApiKey, // Use the fetched apiKey from above
-            userId,
-            setNeedsLogin
-          );
-        })
-        .then(async (finalContent) => {
-          // Set processing flag to prevent infinite updates
-          isProcessingRef.current = true;
-
-          try {
-            // Check if finalContent is a string that could be JSON
-            if (typeof finalContent === 'string' && finalContent.startsWith('{')) {
-              try {
-                const parsedContent = JSON.parse(finalContent);
-
-                // Check if there's an error property
-                if (parsedContent.error) {
-                  console.log('Error in API response:', parsedContent);
-                  setNeedsNewKey(true);
-                  // Preserve the user message in case they want to retry
-                  setInput(promptText);
-                  // Return early with an error message
-                  finalContent = `Error: ${JSON.stringify(parsedContent.error)}`;
-                } else {
-                  // If no error, continue with the parsed content
-                  finalContent = parsedContent;
-                }
-              } catch (jsonError) {
-                console.log('Error parsing JSON response:', jsonError, finalContent);
-              }
-            }
-
-            // Log empty responses but don't show error messages in the chat
-            if (
-              !finalContent ||
-              (typeof finalContent === 'string' && finalContent.trim().length === 0)
-            ) {
-              console.log('[TOAST MESSAGE] Error occurred while processing the request');
-
-              // This is likely a credits/api key issue, set needsLogin to true
-              setNeedsLogin(true);
-
-              // Don't set any error message in the chat
-              return; // Exit early without updating the message
-            }
-
-            // Only do a final update if the current state doesn't match our final content
-            if (aiMessage?.text !== finalContent) {
-              aiMessage.text = finalContent;
-            }
-
-            aiMessage.model = modelToUse;
-            // Save to database
-            const { id } = (await sessionDatabase.put(aiMessage)) as { id: string };
-            // Update state with the saved message
-            setPendingAiMessage({ ...aiMessage, _id: id });
-            setSelectedResponseId(id);
-
-            // Generate title if needed
-            const { segments } = parseContent(aiMessage?.text || '');
-            // Make sure we still have a valid key for title generation
-            try {
-              console.log('sendMessage: Generating title...');
-              const title = await generateTitle(segments, TITLE_MODEL, currentApiKey);
-              // Update title with the generated title
-              if (title) {
-                updateTitle(title);
-              }
-            } catch (titleError) {
-              console.warn('Failed to generate title:', titleError);
-              // Non-critical error, don't need to show to user
-            }
-          } finally {
-            isProcessingRef.current = false;
-          }
-        })
-        .catch((error: any) => {
-          // Log the error for debugging
-          console.log('Error:', error);
-
-          // Reset processing state
-          isProcessingRef.current = false;
-          setPendingAiMessage(null);
-          setSelectedResponseId('');
-        })
-        .finally(() => {
-          // Reset streaming state first - checkCredits might fail if the API key is no longer valid
-          setIsStreaming(false);
-
-          // Check credits status if we still have a valid API key
-          if (currentApiKey) {
-            // Non-blocking check, we don't need to wait for this
-            checkCredits(currentApiKey).catch((err) => {
-              console.warn('Failed to check credits in finally block:', err);
-            });
-          }
-        });
+    (textOverride?: string) => {
+      const ctx: SendMessageContext = {
+        userMessage,
+        mergeUserMessage,
+        setPendingUserDoc,
+        setIsStreaming,
+        ensureApiKey,
+        setNeedsLogin,
+        setNeedsNewKey,
+        addError,
+        checkCredits: boundCheckCredits,
+        ensureSystemPrompt,
+        submitUserMessage,
+        buildMessageHistory,
+        modelToUse,
+        throttledMergeAiMessage,
+        isProcessingRef,
+        aiMessage,
+        sessionDatabase,
+        setPendingAiMessage,
+        setSelectedResponseId,
+        updateTitle,
+        setInput,
+        userId,
+        titleModel: TITLE_MODEL,
+      };
+      return sendChatMessage(ctx, textOverride);
     },
     [
       userMessage.text,
@@ -470,7 +270,7 @@ export function useSimpleChat(sessionId: string | undefined): ChatState {
       setPendingAiMessage,
       setSelectedResponseId,
       updateTitle,
-      checkCredits,
+      boundCheckCredits,
       ensureApiKey,
     ]
   );

--- a/app/utils/componentExportTransforms.ts
+++ b/app/utils/componentExportTransforms.ts
@@ -1,0 +1,41 @@
+export interface TransformState {
+  input: string;
+  patterns: { [key: string]: any };
+  hasAppDeclared: boolean;
+  beforeExport?: string;
+  afterExport?: string;
+}
+
+export function transformObjectLiteral(state: TransformState): string {
+  if (!state.patterns.objectLiteral) return state.input;
+  return `${state.beforeExport}
+const AppObject = ${state.patterns.objectLiteral};
+const App = AppObject.default || AppObject;
+export default App;${state.afterExport}`;
+}
+
+export function transformHOC(state: TransformState): string {
+  if (!state.patterns.hoc) return state.input;
+  return `${state.beforeExport}const App = ${state.patterns.hoc};
+export default App;`;
+}
+
+export function transformFunctionDeclaration(state: TransformState): string {
+  if (!state.patterns.functionDeclaration) return state.input;
+  return state.input.replace(
+    /export\s+default\s+function\s+\w+\s*(\([^)]*\))/g,
+    'export default function App$1'
+  );
+}
+
+export function transformClassDeclaration(state: TransformState): string {
+  if (!state.patterns.classDeclaration) return state.input;
+  return state.input.replace(/export\s+default\s+class\s+\w+/g, 'export default class App');
+}
+
+export function transformArrowFunction(state: TransformState): string {
+  if (!state.patterns.arrowFunction) return state.input;
+  const cleanedAfterExport = state.afterExport?.replace(/;\s*$/, '') || '';
+  return `${state.beforeExport}const App = ${cleanedAfterExport};
+export default App;`;
+}


### PR DESCRIPTION
## Summary
- factor `checkCredits` into its own module
- extract chat `sendMessage` into a helper
- factor component export transforms into separate file
- update imports to use the new modules

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_6840673df2a88323b15643f18cde1c0b