### PR TITLE
Expire old openrouter key

### DIFF
--- a/app/hooks/useApiKey.ts
+++ b/app/hooks/useApiKey.ts
@@ -23,7 +23,7 @@ export function useApiKey() {
     if (storedKey) {
       try {
         const keyData = JSON.parse(storedKey);
-        const epochStart = 1753813877752; // 2025-07-29T00:00:00.000Z
+        const epochStart = 1753747200000; // 2025-07-29T00:00:00.000Z
 
         const isValid = keyData.key && typeof keyData.key === 'string' && keyData.hash;
         const isFromBefore = keyData.createdAt && keyData.createdAt < epochStart;

--- a/app/hooks/useApiKey.ts
+++ b/app/hooks/useApiKey.ts
@@ -23,12 +23,19 @@ export function useApiKey() {
     if (storedKey) {
       try {
         const keyData = JSON.parse(storedKey);
-        // Make sure we have a valid key object
-        if (keyData.key && typeof keyData.key === 'string' && keyData.hash) {
-          return keyData; // Return the full stored object if valid
+        const epochStart = 1753813877752; // 2025-07-29T00:00:00.000Z
+
+        const isValid = keyData.key && typeof keyData.key === 'string' && keyData.hash;
+        const isFromBefore = keyData.createdAt && keyData.createdAt < epochStart;
+
+        if (!isValid) {
+          throw new Error('Invalid key data');
         }
-        // If key is invalid, remove it
-        localStorage.removeItem(storageKey);
+        if (isFromBefore) {
+          throw new Error('Key is from before the current epoch');
+        }
+
+        return keyData;
       } catch (e) {
         localStorage.removeItem(storageKey); // Corrupted data
       }


### PR DESCRIPTION
Before this change, users from June or maybe early July could not get AI codegen to work. The end result is that the chat gets stuck on a "..." response, the open router completions endpoint is returning 401, and refreshing the page just asks for log in again and winds up at the same place.

After this change, users with a vibes-openrouter-key with a `createdAt` before today will get a new one.

This should bring back all our users from Atlanta.