### PR TITLE
refactor: make system prompt template data-driven

### DIFF
--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -2,6 +2,7 @@ import type { ChangeEvent, KeyboardEvent } from 'react';
 import { useEffect, memo, useCallback, useRef, forwardRef, useImperativeHandle } from 'react';
 import type { ChatState } from '../types/chat';
 import VibesDIYLogo from './VibesDIYLogo';
+import { preloadLlmsText } from '../prompts';
 
 interface ChatInputProps {
   chatState: ChatState;
@@ -58,6 +59,10 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(({ chatState, onSend 
             if (chatState.setInput) {
               chatState.setInput(e.target.value);
             }
+          }}
+          onFocus={() => {
+            // Fire and forget: warm the LLMs text cache using raw imports
+            void preloadLlmsText();
           }}
           onKeyDown={(e: KeyboardEvent<HTMLTextAreaElement>) => {
             if (e.key === 'Enter' && !e.shiftKey && !chatState.isStreaming) {

--- a/app/llms/callai.json
+++ b/app/llms/callai.json
@@ -3,5 +3,7 @@
   "label": "callAI",
   "llmsTxtUrl": "https://use-fireproof.com/callai-llms.txt",
   "module": "openrouter",
-  "description": "easy API for LLM requests with streaming support"
+  "description": "easy API for LLM requests with streaming support",
+  "importModule": "call-ai",
+  "importName": "callAI"
 }

--- a/app/llms/callai.txt
+++ b/app/llms/callai.txt
@@ -1,0 +1,455 @@
+# CallAI Helper Function
+
+The `callAI` helper function provides an easy way to make AI requests to OpenAI-compatible model providers.
+
+## Installation
+
+```bash
+npm install call-ai
+```
+
+## API Key
+
+You can set the API key in the `window` object:
+
+```javascript
+window.CALLAI_API_KEY = "your-api-key";
+```
+
+Or pass it directly to the `callAI` function:
+
+```javascript
+const response = await callAI("Write a haiku", { apiKey: "your-api-key" });
+```
+
+## Basic Usage
+
+By default the function returns a Promise that resolves to the complete response:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Default behavior - returns a Promise<string>
+const response = await callAI("Write a haiku");
+
+// Use the complete response directly
+console.log(response); // Complete response text
+```
+
+## Streaming Mode
+
+If you prefer to receive the response incrementally as it's generated, set `stream: true`. This returns an AsyncGenerator which must be awaited:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Enable streaming mode explicitly - returns an AsyncGenerator
+const generator = await callAI("Write an epic poem", { stream: true });
+// Process the streaming response
+for await (const partialResponse of generator) {
+  console.log(partialResponse); // Updates incrementally
+}
+```
+
+## JSON Schema Responses
+
+To get structured JSON responses, provide a schema in the options:
+
+```javascript
+import { callAI } from 'call-ai';
+
+const todoResponse = await callAI("Give me a todo list for learning React", {
+  schema: {
+    name: "todo",  // Optional - defaults to "result" if not provided
+    properties: {
+      todos: {
+        type: "array",
+        items: { type: "string" }
+      }
+    }
+  }
+});
+const todoData = JSON.parse(todoResponse);
+console.log(todoData.todos); // Array of todo items
+```
+
+## JSON with Streaming
+
+In this example, we're using the `callAI` helper function to get weather data in a structured format with streaming preview:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Get weather data with streaming updates
+const generator = await callAI("What's the weather like in Paris today?", {
+  stream: true,
+  schema: {
+    properties: {
+      location: {
+        type: "string",
+        description: "City or location name"
+      },
+      temperature: {
+        type: "number",
+        description: "Temperature in Celsius"
+      },
+      conditions: {
+        type: "string",
+        description: "Weather conditions description"
+      }
+    }
+  }
+});
+
+// Preview streaming updates as they arrive, don't parse until the end
+const resultElement = document.getElementById('result');
+let finalResponse;
+
+for await (const partialResponse of generator) {
+  resultElement.textContent = partialResponse;
+  finalResponse = partialResponse;
+}
+
+// Parse final result
+try {
+  const weatherData = JSON.parse(finalResponse);
+  
+  // Access individual fields
+  const { location, temperature, conditions } = weatherData;
+  
+  // Update UI with formatted data
+  document.getElementById('location').textContent = location;
+  document.getElementById('temperature').textContent = `${temperature}°C`;
+  document.getElementById('conditions').textContent = conditions;
+} catch (error) {
+  console.error("Failed to parse response:", error);
+}
+```
+
+### Schema Structure Recommendations
+
+1. **Flat schemas perform better across all models**. If you need maximum compatibility, avoid deeply nested structures.
+
+2. **Field names matter**. Some models have preferences for certain property naming patterns:
+   - Use simple, common naming patterns like `name`, `type`, `items`, `price` 
+   - Avoid deeply nested object hierarchies (more than 2 levels deep)
+   - Keep array items simple (strings or flat objects)
+
+3. **Model-specific considerations**:
+   - **OpenAI models**: Best overall schema adherence and handle complex nesting well
+   - **Claude models**: Great for simple schemas, occasional JSON formatting issues with complex structures
+   - **Gemini models**: Good general performance, handles array properties well
+   - **Llama/Mistral/Deepseek**: Strong with flat schemas, but often ignore nesting structure and provide their own organization
+
+4. **For mission-critical applications** requiring schema adherence, use OpenAI models or implement fallback mechanisms.
+
+### Models for Structured Outputs
+
+- OpenAI models: Best overall schema adherence and handle complex nesting well
+- Claude models: Great for simple schemas, occasional JSON formatting issues with complex structures
+- Gemini models: Good general performance, handles array properties well
+- Llama/Mistral/Deepseek: Strong with flat schemas, but often ignore nesting structure and provide their own organization
+
+
+## Specifying a Model
+
+By default, the function uses `openrouter/auto` (automatic model selection). You can specify a different model:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Use a specific model via options
+const response = await callAI(
+  "Explain quantum computing in simple terms", 
+  { model: "openai/gpt-4o" }
+);
+
+console.log(response);
+```
+
+## Additional Options
+
+You can pass extra parameters to customize the request:
+
+```javascript
+import { callAI } from 'call-ai';
+
+const response = await callAI(
+  "Write a creative story",
+  {
+    model: "anthropic/claude-3-opus",
+    temperature: 0.8,     // Higher for more creativity (0-1)
+    max_tokens: 1000,     // Limit response length
+    top_p: 0.95           // Control randomness
+  }
+);
+
+console.log(response);
+```
+
+## Message History
+
+For multi-turn conversations, you can pass an array of messages:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Create a conversation
+const messages = [
+  { role: "system", content: "You are a helpful coding assistant." },
+  { role: "user", content: "How do I use React hooks?" },
+  { role: "assistant", content: "React hooks are functions that let you use state and other React features in functional components..." },
+  { role: "user", content: "Can you show me an example of useState?" }
+];
+
+// Pass the entire conversation history
+const response = await callAI(messages);
+console.log(response);
+
+// To continue the conversation, add the new response and send again
+messages.push({ role: "assistant", content: response });
+messages.push({ role: "user", content: "What about useEffect?" });
+
+// Call again with updated history
+const nextResponse = await callAI(messages);
+console.log(nextResponse);
+```
+
+## Using with OpenAI API
+
+You can use callAI with OpenAI's API directly by providing the appropriate endpoint and API key:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Use with OpenAI's API
+const response = await callAI(
+  "Explain the theory of relativity", 
+  {
+    model: "gpt-4",
+    apiKey: "sk-...", // Your OpenAI API key
+    endpoint: "https://api.openai.com/v1/chat/completions"
+  }
+);
+
+console.log(response);
+
+// Or with streaming
+const generator = callAI(
+  "Explain the theory of relativity", 
+  {
+    model: "gpt-4",
+    apiKey: "sk-...", // Your OpenAI API key
+    endpoint: "https://api.openai.com/v1/chat/completions",
+    stream: true
+  }
+);
+
+for await (const chunk of generator) {
+  console.log(chunk);
+}
+```
+
+## Custom Endpoints
+
+You can specify a custom endpoint for any OpenAI-compatible API:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Use with any OpenAI-compatible API
+const response = await callAI(
+  "Generate ideas for a mobile app",
+  {
+    model: "your-model-name",
+    apiKey: "your-api-key",
+    endpoint: "https://your-custom-endpoint.com/v1/chat/completions"
+  }
+);
+
+console.log(response);
+```
+
+## Recommended Models
+
+| Model | Best For | Speed vs Quality |
+|-------|----------|------------------|
+| `openrouter/auto` | Default, automatically selects | Adaptive |
+| `openai/gpt-4o-mini` | data generation | Fast, good quality |
+| `anthropic/claude-3-haiku` | Cost-effective | Fast, good quality |
+| `openai/gpt-4o` | Best overall quality | Medium speed, highest quality |
+| `anthropic/claude-3-opus` | Complex reasoning | Slower, highest quality |
+| `mistralai/mistral-large` | Open weights alternative | Good balance |
+
+## Automatic Retry Mechanism
+
+Call-AI has a built-in fallback mechanism that automatically retries with `openrouter/auto` if the requested model is invalid or unavailable. This ensures your application remains functional even when specific models experience issues.
+
+If you need to disable this behavior (for example, in test environments), you can use the `skipRetry` option:
+
+```javascript
+const response = await callAI("Your prompt", {
+  model: "your-model-name",
+  skipRetry: true  // Disable automatic fallback
+});
+```
+
+## Items with lists
+
+```javascript
+import { callAI } from 'call-ai';
+
+const generator = await callAI([
+  {
+    role: "user",
+    content: "Generate 3 JSON records with name, description, tags, and priority (0 is highest, 5 is lowest)."
+  }
+], {
+  stream: true,
+  schema: {
+    properties: {
+      records: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            description: { type: "string" },
+            tags: {
+              type: "array",
+              items: { type: "string" }
+            },
+            priority: { type: "integer" }
+          }
+        }
+      }
+    }
+  }
+});
+
+for await (const partialResponse of generator) {
+  console.log(partialResponse);
+}
+
+const recordData = JSON.parse(/* final response */);
+console.log(recordData.records); // Array of records
+```
+
+## Items with properties
+
+```javascript
+const demoData = await callAI("Generate 4 items with label, status, priority (low, medium, high, critical), and notes. Return as structured JSON with these fields.", {
+  schema: {
+    properties: {
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            label: { type: "string" },
+            status: { type: "string" },
+            priority: { type: "string" },
+            notes: { type: "string" }
+          }
+        }
+      }
+    }
+  }
+});
+```
+
+## Error Handling
+
+Errors are handled through standard JavaScript try/catch blocks:
+
+```javascript
+import { callAI } from 'call-ai';
+
+try {
+
+  const response = await callAI("Generate some content", {
+    apiKey: "invalid-key" // Invalid or missing API key
+  });
+  
+  // If no error was thrown, process the normal response
+  console.log(response);
+} catch (error) {
+  // API errors are standard Error objects with useful properties
+  console.error("API error:", error.message);
+  console.error("Status code:", error.status);
+  console.error("Error type:", error.errorType);
+  console.error("Error details:", error.details);
+}
+```
+
+For streaming mode, error handling works the same way:
+
+```javascript
+import { callAI } from 'call-ai';
+
+try {
+  const generator = await callAI("Generate some content", {
+    apiKey: "invalid-key", // Invalid or missing API key
+    stream: true
+  });
+  
+  // Any error during streaming will throw an exception
+  let finalResponse = '';
+  for await (const chunk of generator) {
+    finalResponse = chunk;
+    console.log("Chunk:", chunk);
+  }
+  
+  // Process the final response
+  console.log("Final response:", finalResponse);
+} catch (error) {
+  // Handle errors with standard try/catch
+  console.error("API error:", error.message);
+  console.error("Error properties:", {
+    status: error.status,
+    type: error.errorType,
+    details: error.details
+  });
+}
+```
+
+This approach is idiomatic and consistent with standard JavaScript practices. Errors provide rich information for better debugging and error handling in your applications.
+
+## Image Recognition Example
+
+Call-AI supports image recognition using multimodal models like GPT-4o. You can pass both text and image content to analyze images in the browser:
+
+```javascript
+import { callAI } from 'call-ai';
+
+// Function to analyze an image using GPT-4o
+async function analyzeImage(imageFile, prompt = 'Describe this image in detail') {
+  // Convert the image file to a data URL
+  const dataUrl = await fileToDataUrl(imageFile);
+  
+  const content = [
+    { type: 'text', text: prompt },
+    { type: 'image_url', image_url: { url: dataUrl } }
+  ];
+  
+  // Call the model with the multimodal content
+  const result = await callAI(
+    [{ role: 'user', content }],
+    {
+      model: 'openai/gpt-4o-2024-08-06', // Or 'openai/gpt-4o-latest'
+      apiKey: window.CALLAI_API_KEY,
+    }
+  );
+  
+  return result;
+}
+
+// Helper function to convert File to data URL
+async function fileToDataUrl(file) {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.readAsDataURL(file);
+  });
+}
+```

--- a/app/llms/fireproof.json
+++ b/app/llms/fireproof.json
@@ -3,5 +3,7 @@
   "label": "useFireproof",
   "llmsTxtUrl": "https://use-fireproof.com/llms-full.txt",
   "module": "use-fireproof",
-  "description": "local-first database with encrypted live sync"
+  "description": "local-first database with encrypted live sync",
+  "importModule": "use-fireproof",
+  "importName": "useFireproof"
 }

--- a/app/llms/fireproof.txt
+++ b/app/llms/fireproof.txt
@@ -1,0 +1,451 @@
+# Fireproof Database API Guide
+
+Fireproof is a lightweight embedded document database with encrypted live sync, designed to make browser apps easy. Use it in any JavaScript environment with a unified API that works both in React (with hooks) and as a standalone core API.
+
+## Key Features
+
+- **Apps run anywhere:** Bundle UI, data, and logic in one file.
+- **Real-Time & Offline-First:** Automatic persistence and live queries, runs in the browser - no loading or error states.
+- **Unified API:** TypeScript works with Deno, Bun, Node.js, and the browser.
+- **React Hooks:** Leverage `useLiveQuery` and `useDocument` for live collaboration.
+
+Fireproof enforces cryptographic causal consistency and ledger integrity using hash history, providing git-like versioning with lightweight blockchain-style verification. Data is stored and replicated as content-addressed encrypted blobs, making it safe and easy to sync via commodity object storage providers.
+
+## Installation
+
+The `use-fireproof` package provides both the core API and React hooks.
+
+```bash
+npm install use-fireproof
+```
+Works with ⚡️ ESM.sh:
+
+```js
+import { useFireproof } from "https://esm.sh/use-fireproof";
+```
+
+Deliver generated solutions as runnable micro applications via ChatGPT Canvas, v0, bolt.new, or Claude Artifacts. Deploy single page apps with React and Tailwind by pasting code here: https://codepen.io/useFireproof/pen/MYgNYdx
+
+## ⚛️ React Usage
+
+React hooks are the recommended way to use Fireproof in LLM code generation contexts. Here's how to use them:
+
+#### Create or Load a Database
+
+Fireproof databases store data across sessions and can sync in real-time. Each database is identified by a string name, and you can have multiple databases per application—often one per collaboration session, as they are the unit of sharing.
+
+```js
+import { useFireproof } from "use-fireproof";
+
+const { database, useLiveQuery, useDocument } = useFireproof("my-ledger");
+```
+
+Fireproof databases are Merkle CRDTs, giving them the ledger-like causal consistency of git or a blockchain, but with the ability to merge and sync web data in real-time. Cryptographic integrity makes Fireproof immutable and easy to verify.
+
+#### Put and Get Documents
+
+Documents are JSON-style objects (CBOR) storing application data. Each has an `_id`, which can be auto-generated or set explicitly. Auto-generation is recommended to ensure uniqueness and avoid conflicts. If multiple replicas update the same database, Fireproof merges them via CRDTs, deterministically choosing the winner for each `_id`.
+
+It is best to have more granular documents, e.g. one document per user action, so saving a form or clicking a button should typically create or update a single document, or just a few documents. Avoid patterns that require a single document to grow without bound.
+
+Fireproof is a local database, no loading states required, just empty data states.
+
+### Basic Example
+
+This example shows Fireproof's concise defaults. Here we only store user data, but get useful sorting without much code.
+
+```js
+const App = () => {
+  const { useDocument } = useFireproof("my-ledger");
+
+  const { doc, merge, submit } = useDocument({ text: "" });
+
+  // _id is roughly temporal, this is most recent
+  const { docs } = useLiveQuery("_id", { descending: true, limit: 100 });
+
+  return (
+    <div>
+      <form onSubmit={submit}>
+        <input
+          value={doc.text}
+          onChange={(e) => merge({ text: e.target.value })}
+          placeholder="New document"
+        />
+        <button type="submit">Submit</button>
+      </form>
+
+      <h3>Recent Documents</h3>
+      <ul>
+        {docs.map((doc) => (
+          <li key={doc._id}>
+            {doc.text}
+          </li>
+        ))} 
+      </ul>
+    </div>
+  );
+}
+```
+
+### Editing Documents
+
+Address documents by a known `_id` if you want to force conflict resolution or work with a real world resource, like a schedule slot or a user profile. In a complex app this might come from a route parameter or correspond to an outside identifier.
+
+```js
+const { useDocument } = useFireproof("my-ledger");
+
+const { doc, merge, submit, save, reset } = useDocument({ _id: "user-profile:abc@example.com" });
+```
+
+The `useDocument` hook provides several methods:
+- `merge(updates)`: Update the document with new fields
+- `submit(e)`: Handles form submission by preventing default, saving, and resetting
+- `save()`: Save the current document state
+- `reset()`: Reset to initial state
+
+For form-based creation flows, use `submit`:
+```js
+<form onSubmit={submit}>
+```
+
+ChatGPT note: Canvas sandboxes the form submit event, there you should use button click events instead:
+```js
+<button onClick={submit}>Save and Reset Fields</button>
+```
+
+When you call submit, the document is reset, so if you didn't provide an `_id` then you can use the form to create a stream of new documents as in the basic example above.
+
+### Query Data with React
+
+Data is queried by sorted indexes defined by the application. Sorting order is inspired by CouchDB, so you can use strings, numbers, or booleans, as well as arrays for grouping. Use numbers when possible for sorting continuous data.
+
+You can use the `_id` field for temporal sorting so you dont have to write code to get simple recent document lists, as in the basic example above.
+
+Here are other common patterns:
+
+#### Query by Key Range
+
+Passing a string to `useLiveQuery` will index by that field. You can use the key argument to filter by a specific value:
+```js
+const { docs } = useLiveQuery("agentName", { 
+  key: "agent-1"  // all docs where doc.agentName === "agent-1", sorted by _id
+});
+```
+
+You can also query a range within a key:
+```js
+const { docs } = useLiveQuery("agentRating", { 
+  range: [3, 5]
+});
+```
+
+### Custom Indexes
+
+For more complex query, you can write a custom index function. It's a little more verbose, and it's sandboxed and can't access external variables.
+
+#### Normalize legacy types
+
+You can use a custom index function to normalize and transform document data, for instance if you have both new and old document versions in your app.
+
+```js
+const { docs } = useLiveQuery(
+  (doc) => {
+    if (doc.type == 'listing_v1') {
+      return doc.sellerId;
+    } else if (doc.type == 'listing') {
+      return doc.userId;
+    }
+  }, 
+  { key : routeParams.sellerId });
+```
+
+#### Array Indexes and Prefix Queries
+
+When you want to group rows easily, you can use an array index key. This is great for grouping records my year / month / day or other paths. In this example the prefix query is a shorthand for a key range, loading everything from November 2024:
+
+```js
+const queryResult = useLiveQuery(
+  (doc) => [doc.date.getFullYear(), doc.date.getMonth(), doc.date.getDate()],
+  { prefix: [2024, 11] }
+);
+```
+
+#### Sortable Lists
+
+Sortable lists are a common pattern. Here's how to implement them using Fireproof:
+
+```js
+function App() {
+  const { database, useLiveQuery } = useFireproof("my-ledger");
+  
+  // Initialize list with evenly spaced positions
+  async function initializeList() {
+    await database.put({ list: "xyz", position: 1000 });
+    await database.put({ list: "xyz", position: 2000 });
+    await database.put({ list: "xyz", position: 3000 });
+  }
+  
+  // Query items on list xyz, sorted by position. Note that useLiveQuery('list', { key:'xyz' }) would be the same docs, sorted chronologically by _id
+  const queryResult = useLiveQuery(
+    (doc) => [doc.list, doc.position], 
+    { prefix: ["xyz"] }
+  );
+
+  // Insert between existing items using midpoint calculation
+  async function insertBetween(beforeDoc, afterDoc) {
+    const newPosition = (beforeDoc.position + afterDoc.position) / 2;
+    await database.put({ 
+      list: "xyz", 
+      position: newPosition 
+    });
+  }
+
+  return (
+    <div>
+      <h3>List xyz (Sorted)</h3>
+      <ul>
+        {queryResult.docs.map(doc => (
+          <li key={doc._id}>
+            {doc._id}: position {doc.position}
+          </li>
+        ))}
+      </ul>
+      <button onClick={initializeList}>Initialize List</button>
+      <button onClick={() => insertBetween(queryResult.docs[1], queryResult.docs[2])}>Insert new doc at 3rd position</button>
+    </div>
+  );
+}
+```
+
+## Architecture: Where's My Data?
+
+Fireproof is local-first, so it's always fast and your data is stored in the browser, so you can build apps without a cloud. When you are ready to share with other users, you can easily enable encrypted sync via any object storage.
+
+## Using Fireproof in JavaScript
+
+You can use the core API in HTML or on the backend. Instead of hooks, import the core API directly:
+
+```js
+import { fireproof } from "use-fireproof";
+
+const database = fireproof("my-ledger");
+```
+
+The document API is async, but doesn't require loading states or error handling.
+
+```js
+const ok = await database.put({ text: "Sample Data" });
+const doc = await database.get(ok.id);
+const latest = await database.query("_id", { limit: 10, descending: true });
+console.log("Latest documents:", latest.docs);
+```
+
+To subscribe to real-time updates, use the `subscribe` method. This is useful for building backend event handlers or other server-side logic. For instance to send an email when the user completes a todo:
+
+```js
+import { fireproof } from "use-firproof";
+
+const database = fireproof("todo-list-db");
+
+database.subscribe((changes) => {
+  console.log("Recent changes:", changes);
+  changes.forEach((change) => {
+    if (change.completed) {
+      sendEmail(change.email, "Todo completed", "You have completed a todo.");
+    }
+  });
+}, true);
+```
+
+### Working with Files
+
+Fireproof has built-in support for file attachments. Files are encrypted by default and synced on-demand. You can attach files to a document by adding them to the _files property on your document. For example:
+
+```html
+<input accept="image/*" title="save to Fireproof" type="file" id="files" multiple>
+```
+
+```js
+function handleFiles() {
+  const fileList = this.files;
+  const doc = {
+    type: "files",
+    _files: {}
+  };
+  for (const file of fileList) {
+    // Assign each File object to the document
+    doc._files[file.name] = file; 
+  }
+  database.put(doc);
+}
+
+document.getElementById("files").addEventListener("change", handleFiles, false);
+```
+
+When loading a document with attachments, you can retrieve each attachment's actual File object by calling its .file() method. This returns a Promise that resolves with the File data, which you can display in your app:
+
+```js
+const doc = await database.get("my-doc-id");
+for (const fileName in doc._files) {
+  const meta = doc._files[fileName];
+  if (meta.file) {
+    const fileObj = await meta.file();
+    console.log("Loaded file:", fileObj.name);
+  }
+}
+```
+
+See the final example application in this file for a working example.
+
+### Form Validation
+
+You can use React's `useState` to manage validation states and error messages. Validate inputs at the UI level before allowing submission.
+
+```javascript
+const [errors, setErrors] = useState({});
+
+function validateForm() {
+  const newErrors = {};
+  if (!doc.name.trim()) newErrors.name = "Name is required.";
+  if (!doc.email) newErrors.email = "Email is required.";
+  if (!doc.message.trim()) newErrors.message = "Message is required.";
+  setErrors(newErrors);
+  return Object.keys(newErrors).length === 0;
+}
+
+function handleSubmit(e) {
+  e.preventDefault();
+  if (validateForm()) submit();
+}
+```
+
+## Example React Application
+
+Code listing for todo tracker App.jsx:
+```js
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { useFireproof } from "use-fireproof";
+
+export default function App() {
+  const { useLiveQuery, useDocument, database } = useFireproof("todo-list-db");
+
+  const {
+    doc: newTodo,
+    merge: mergeNewTodo,
+    submit: submitNewTodo
+  } = useDocument({
+    todo: "",
+    type: "todo",
+    completed: false,
+    createdAt: Date.now()
+  });
+
+  const { docs: todos } = useLiveQuery("type", { 
+    key: "todo",
+    descending: true 
+  });
+
+  const handleInputChange = (e) => {
+    mergeNewTodo({ todo: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    submitNewTodo();
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4 bg-white shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">Todo List</h2>
+      <form onSubmit={handleSubmit} className="mb-4">
+        <label htmlFor="todo" className="block mb-2 font-semibold">Todo</label>
+        <input
+          className="w-full border border-gray-300 rounded px-2 py-1"
+          id="todo"
+          type="text"
+          onChange={handleInputChange}
+          value={newTodo.todo}
+        />
+      </form>
+      <ul className="space-y-3">
+        {todos.map((doc) => (
+          <li className="flex flex-col items-start p-2 border border-gray-200 rounded bg-gray-50" key={doc._id}>
+            <div className="flex items-center justify-between w-full">
+              <div className="flex items-center">
+                <input
+                  className="mr-2"
+                  type="checkbox"
+                  checked={doc.completed}
+                  onChange={() => database.put({ ...doc, completed: !doc.completed })}
+                />
+                <span className="font-medium">{doc.todo}</span>
+              </div>
+              <button
+                className="text-sm bg-red-500 text-white px-2 py-1 rounded"
+                onClick={() => database.del(doc._id)}
+              >
+                Delete
+              </button>
+            </div>
+            <div className="text-xs text-gray-500 mt-1">
+              {new Date(doc.createdAt).toISOString()}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+```
+
+### Example Image Uploader
+
+This React example shows a simple image uploader application that uses Fireproof to store and sort images by creation date. These APIs easily work with plain JavaScript also. 
+
+Code listing for App.jsx:
+```js
+import { useFireproof, ImgFile } from "use-fireproof";
+import { useState, useEffect } from "react";
+
+export default function App() {
+  const { useDocument, useLiveQuery } = useFireproof("image-uploads");
+  const { doc, merge, submit } = useDocument({ _files: {}, description: "" });
+  const { docs } = useLiveQuery("_id", { descending: true, limit: 5 });
+  const [error, setError] = useState(false);
+
+  return (
+    <div className="p-6 max-w-lg mx-auto bg-white shadow-lg rounded-lg">
+      <h2 className="text-2xl font-bold mb-4">Image Uploader</h2>
+      <input type="file" accept="image/*" onChange={e => e.target.files[0] && merge({ _files: { uploaded: e.target.files[0] } })} className="mb-2 border p-2 w-full rounded" />
+      <input 
+        type="text" 
+        placeholder="Enter description" 
+        value={doc.description} 
+        onChange={e => {setError(false); merge({ description: e.target.value });}}
+        className={`w-full p-2 border rounded mb-4 ${error ? "border-red-500" : "border-gray-300"}`}
+      />
+      <button onClick={() => doc.description.trim() ? submit() : setError(true)} className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">Upload</button>
+      <h3 className="text-lg font-semibold mt-6">Recent Uploads</h3>
+      <div className="grid grid-cols-2 gap-4 mt-2">
+        {docs.map(doc => (
+          <div key={doc._id} className="border p-2 rounded shadow-sm bg-gray-50">
+            {doc._files?.uploaded && <ImgFile file={doc._files.uploaded} alt="Uploaded Image" className="w-full h-auto rounded" />}
+            <p className="text-sm text-gray-700 mt-2">{doc.description || "No description"}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+## See Also
+
+See the lite docs at https://use-fireproof.com/llms-mini.txt and the basics at https://use-fireproof.com/llms.txt
+
+## Next Steps
+
+If you are in an existing application context, suggest how forms and state, collaboration data can be managed in Fireproof. If this is a new app, use the examples above and start with a running App.js if you can.
+
+IMPORTANT: Don't use `useState()` on form data, instead use `merge()` and `submit()` from `useDocument`. Only use `useState` for ephemeral UI state (active tabs, open/closed panels, cursor positions). Keep your data model in Fireproof.

--- a/app/llms/fireproof.txt
+++ b/app/llms/fireproof.txt
@@ -108,7 +108,7 @@ For form-based creation flows, use `submit`:
 <form onSubmit={submit}>
 ```
 
-ChatGPT note: Canvas sandboxes the form submit event, there you should use button click events instead:
+Note: In some sandboxed environments (e.g., embedded canvases), the form submit event may be blocked. Use a button click handler instead:
 ```js
 <button onClick={submit}>Save and Reset Fields</button>
 ```

--- a/app/llms/image-gen.json
+++ b/app/llms/image-gen.json
@@ -3,5 +3,7 @@
   "label": "Image Generation",
   "llmsTxtUrl": "https://use-fireproof.com/imggen-llms.txt",
   "module": "OpenAi",
-  "description": "Generate and edit images"
+  "description": "Generate and edit images",
+  "importModule": "use-vibes",
+  "importName": "ImgGen"
 }

--- a/app/llms/image-gen.txt
+++ b/app/llms/image-gen.txt
@@ -1,0 +1,128 @@
+# ImgGen Component
+
+## Basic Usage
+
+The ImgGen component can be used in three ways:
+
+1. **With no props** - Shows a form UI for users to enter a prompt and/or upload images:
+
+```jsx
+import { ImgGen } from 'use-vibes';
+
+function MyComponent() {
+  return <ImgGen />; // Shows built-in form for prompt entry and image upload
+}
+```
+
+2. **With a prompt prop** - Immediately generates an image (no form shown):
+
+```jsx
+import { ImgGen } from 'use-vibes';
+
+function MyComponent() {
+  return <ImgGen prompt="A sunset over mountains" />; // Direct generation, no form
+}
+```
+
+3. **With images prop** - Edits or combines images with AI (no form shown):
+
+```jsx
+import { ImgGen } from 'use-vibes';
+
+function MyComponent() {
+  const [files, setFiles] = useState([]);
+  return (
+    <ImgGen 
+      prompt="Create a gift basket with these items" 
+      images={files} // Array of File objects
+    />
+  );
+}
+```
+
+4. **With an _id prop** - Loads a specific image from the database (no form shown):
+
+If there is no image generated for the document yet, but it has a `prompt` field, it will generate a new image with the prompt. If there an images is stored, at doc._files.original, it will use that as the base image.
+
+```jsx
+import { ImgGen } from 'use-vibes';
+
+function MyComponent() {
+  return <ImgGen _id="my-image-id" />; // Loads specific image by ID
+}
+```
+
+
+## List by ID
+
+Images and prompts are tracked in a Fireproof database with a `type` of `image`. If a database is not provided, it uses `"ImgGen"` as the database name.
+
+Display stored images by their ID. Ensure you do this, so users can find the images they created.
+
+```jsx
+import { useFireproof } from 'use-fireproof';
+import { ImgGen } from 'use-vibes';
+
+function MyComponent() {
+  const { database, useLiveQuery } = useFireproof("my-db-name");
+   const { docs: imageDocuments } = useLiveQuery('type', {
+    key: 'image',
+    descending: true,
+  });
+
+  return (
+    <div>
+      <ImgGen database={database} />
+      {imageDocuments.length > 0 && (
+        <div className="history">
+          <h3>Previously Generated Images</h3>
+          <ul className="image-list">
+            {imageDocuments.map((doc) => (
+              <li key={doc._id} className="image-item">
+                <ImgGen _id={doc._id} database={database} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+## Styling
+
+ImgGen supports custom styling through CSS variables or custom class names:
+
+```jsx
+// With CSS variables in your styles
+:root {
+  --imggen-text-color: #222;
+  --imggen-accent: #0088ff;
+  --imggen-border-radius: 8px;
+}
+
+// With custom class names
+<ImgGen 
+  prompt="A landscape" 
+  className="my-custom-image"
+  classes={{
+    root: 'custom-container',
+    image: 'custom-img',
+    overlay: 'custom-overlay'
+  }}
+/>
+```
+
+#### Props
+
+- `prompt`: Text prompt for image generation (required unless `_id` is provided)
+- `_id`: Document ID to load a specific image instead of generating a new one
+- `database`: Database name or instance to use for storing images (default: `'ImgGen'`)- `options` (object, optional): Configuration options for image generation
+  - `model` (string, optional): Model to use for image generation, defaults to 'gpt-image-1'
+  - `size` (string, optional): Size of the generated image (Must be one of 1024x1024, 1536x1024 (landscape), 1024x1536 (portrait), or 'auto' (default value) for gpt-image-1, and one of 256x256, 512x512, or 1024x1024 for dall-e-2.)
+  - `quality` (string, optional): Quality of the generated image (high, medium and low are only supported for gpt-image-1. dall-e-2 only supports standard quality. Defaults to auto.)
+  - `debug` (boolean, optional): Enable debug logging, defaults to false
+- `onLoad`: Callback when image load completes successfully
+- `onError`: Callback when image load fails, receives the error as parameter
+- `className`: CSS class name for the image element (optional)- `classes`: Object containing custom CSS classes for styling component parts (see Styling section)

--- a/app/prompts.ts
+++ b/app/prompts.ts
@@ -45,7 +45,7 @@ export async function preloadLlmsText(): Promise<void> {
 }
 
 // Generate dynamic import statements from LLM configuration
-function generateImportStatements(llms: typeof llmsList) {
+export function generateImportStatements(llms: typeof llmsList) {
   const seen = new Set<string>();
   return llms
     .slice()

--- a/app/prompts.ts
+++ b/app/prompts.ts
@@ -26,6 +26,7 @@ async function loadLlmsTextByName(name: string): Promise<string | undefined> {
     return text || undefined;
   } catch (_err) {
     // In dev or test, the .txt may be missing until script runs. Swallow and let caller decide.
+    console.warn('Failed to load raw LLM text for:', name, _err);
     return undefined;
   }
 }

--- a/app/prompts.ts
+++ b/app/prompts.ts
@@ -19,23 +19,20 @@ const llmsList = Object.values(llmsModules).map(
 const llmsTextCache: Record<string, string> = {};
 
 // Generate dynamic import statements from LLM configuration
-function generateImportStatements(
-  llmsList: Array<{
-    name: string;
-    label: string;
-    llmsTxtUrl: string;
-    module: string;
-    importModule: string;
-    importName: string;
-  }>
-) {
-  let imports = '';
-  for (const llm of llmsList) {
-    if (llm.importModule && llm.importName) {
-      imports += `\nimport { ${llm.importName} } from "${llm.importModule}"`;
-    }
-  }
-  return imports;
+function generateImportStatements(llms: typeof llmsList) {
+  const seen = new Set<string>();
+  return llms
+    .slice()
+    .sort((a, b) => a.importModule.localeCompare(b.importModule))
+    .filter((l) => l.importModule && l.importName)
+    .filter((l) => {
+      const key = `${l.importModule}:${l.importName}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .map((l) => `\nimport { ${l.importName} } from "${l.importModule}"`)
+    .join('');
 }
 
 // Base system prompt for the AI

--- a/app/prompts.ts
+++ b/app/prompts.ts
@@ -15,8 +15,34 @@ const llmsList = Object.values(llmsModules).map(
     ).default
 );
 
-// Cache for LLM text documents to prevent redundant fetches
+// Cache for LLM text documents to prevent redundant fetches/imports
 const llmsTextCache: Record<string, string> = {};
+
+// Lazily load and cache raw text for a single LLM by name using Vite raw imports
+async function loadLlmsTextByName(name: string): Promise<string | undefined> {
+  try {
+    const mod = (await import(/* @vite-ignore */ `./llms/${name}.txt?raw`)) as { default: string };
+    const text = mod?.default ?? '';
+    return text || undefined;
+  } catch (_err) {
+    // In dev or test, the .txt may be missing until script runs. Swallow and let caller decide.
+    return undefined;
+  }
+}
+
+// Public: preload all llms text files (triggered on form focus)
+export async function preloadLlmsText(): Promise<void> {
+  await Promise.all(
+    llmsList.map(async (llm) => {
+      if (llmsTextCache[llm.name] || llmsTextCache[llm.llmsTxtUrl]) return;
+      const text = await loadLlmsTextByName(llm.name);
+      if (text) {
+        llmsTextCache[llm.name] = text;
+        llmsTextCache[llm.llmsTxtUrl] = text;
+      }
+    })
+  );
+}
 
 // Generate dynamic import statements from LLM configuration
 function generateImportStatements(llms: typeof llmsList) {
@@ -40,14 +66,19 @@ export async function makeBaseSystemPrompt(model: string, sessionDoc?: any) {
   let concatenatedLlmsTxt = '';
 
   for (const llm of llmsList) {
-    // Check if we already have this LLM text in cache
-    if (!llmsTextCache[llm.llmsTxtUrl]) {
-      llmsTextCache[llm.llmsTxtUrl] = await fetch(llm.llmsTxtUrl).then((res) => res.text());
+    // Prefer cached content (preloaded on focus). If missing, try dynamic raw import as a fallback.
+    let text = llmsTextCache[llm.name] || llmsTextCache[llm.llmsTxtUrl];
+    if (!text) {
+      text = (await loadLlmsTextByName(llm.name)) || '';
+      if (text) {
+        llmsTextCache[llm.name] = text;
+        llmsTextCache[llm.llmsTxtUrl] = text;
+      }
     }
 
     concatenatedLlmsTxt += `
 <${llm.label}-docs>
-${llmsTextCache[llm.llmsTxtUrl]}
+${text || ''}
 </${llm.label}-docs>
 `;
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:file-issues": "scripts/test-issues.sh",
     "test:api-key": "node scripts/test-api-key.js",
     "test:credits": "node scripts/test-credits.js",
+    "fetch-llms-text": "node scripts/fetch-llms-text.js",
     "check": "pnpm format && pnpm typecheck && pnpm test"
   },
   "dependencies": {

--- a/scripts/fetch-llms-text.js
+++ b/scripts/fetch-llms-text.js
@@ -1,0 +1,75 @@
+// Fetch LLMS text assets defined in app/llms/*.json and write them to app/llms/{name}.txt
+// Usage: pnpm fetch-llms-text
+// Notes:
+// - Overwrites existing .txt files
+// - Exits with non-zero code on any error
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function readJsonFile(filePath) {
+  const raw = await fs.readFile(filePath, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse JSON: ${filePath} -> ${(err && err.message) || err}`);
+  }
+}
+
+async function fetchText(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} fetching ${url}`);
+  }
+  return await res.text();
+}
+
+async function main() {
+  const repoRoot = path.resolve(__dirname, '..');
+  const llmsDir = path.join(repoRoot, 'app', 'llms');
+
+  const entries = await fs.readdir(llmsDir, { withFileTypes: true });
+  const jsonFiles = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.json'))
+    .map((e) => path.join(llmsDir, e.name));
+
+  if (jsonFiles.length === 0) {
+    console.warn('No JSON files found in app/llms. Nothing to do.');
+    return;
+  }
+
+  const tasks = jsonFiles.map(async (jsonPath) => {
+    const cfg = await readJsonFile(jsonPath);
+    const name = cfg?.name;
+    const url = cfg?.llmsTxtUrl;
+
+    if (!name || typeof name !== 'string') {
+      throw new Error(`Missing or invalid 'name' in ${path.relative(repoRoot, jsonPath)}`);
+    }
+
+    if (!url || typeof url !== 'string') {
+      throw new Error(`Missing or invalid 'llmsTxtUrl' in ${path.relative(repoRoot, jsonPath)}`);
+    }
+
+    const text = await fetchText(url);
+    const outPath = path.join(llmsDir, `${name}.txt`);
+    await fs.writeFile(outPath, text, 'utf8');
+    return { name, outPath };
+  });
+
+  const results = await Promise.all(tasks);
+  for (const r of results) {
+    const rel = path.relative(repoRoot, r.outPath);
+    console.log(`Wrote ${rel}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('[fetch-llms-text] Failed:', err?.stack || err);
+  process.exitCode = 1;
+});

--- a/tests/prompt-builder.test.ts
+++ b/tests/prompt-builder.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+// Ensure we use the real implementation of ../app/prompts in this file only
+// Some tests and the global setup mock this module; undo that here before importing it.
+(vi as any).doUnmock?.('../app/prompts');
+vi.unmock('../app/prompts');
+vi.resetModules();
+
+// Will be assigned in beforeAll after we unmock and re-import the module
+let generateImportStatements: (llms: Array<any>) => string;
+let makeBaseSystemPrompt: (model: string, sessionDoc?: any) => Promise<string>;
+let preloadLlmsText: () => Promise<void>;
+
+// Load actual LLM configs and txt content from app/llms
+// Use eager glob so it's resolved at import time in Vitest/Vite environment
+const llmsJsonModules = import.meta.glob('../app/llms/*.json', { eager: true }) as Record<
+  string,
+  { default: any }
+>;
+
+// Deterministic order by filepath to avoid FS-dependent ordering
+const orderedLlms = Object.entries(llmsJsonModules)
+  .sort((a, b) => a[0].localeCompare(b[0]))
+  .map(([_, mod]) => mod.default);
+
+// Load the raw text files; key by filepath, value is file contents
+const llmsTxtModules = import.meta.glob('../app/llms/*.txt', {
+  eager: true,
+  as: 'raw',
+}) as Record<string, string>;
+
+function textForName(name: string): string {
+  const entry = Object.entries(llmsTxtModules).find(([p]) => p.endsWith(`${name}.txt`));
+  return entry ? (entry[1] as unknown as string) : '';
+}
+
+beforeAll(async () => {
+  const mod = await import('../app/prompts');
+  // Pull real exported functions from the actual module
+  generateImportStatements = (mod as any).generateImportStatements;
+  makeBaseSystemPrompt = mod.makeBaseSystemPrompt;
+  preloadLlmsText = mod.preloadLlmsText;
+});
+
+describe('prompt builder (real implementation)', () => {
+  it('generateImportStatements: deterministic, one line per JSON, no duplicates', () => {
+    expect(typeof generateImportStatements).toBe('function');
+
+    const importBlock = generateImportStatements(orderedLlms);
+    const lines = importBlock.trim().split('\n').filter(Boolean);
+
+    // One import per JSON config
+    expect(lines.length).toBe(orderedLlms.length);
+
+    // Deterministic sort: by importModule ascending
+    const modulesSorted = [...orderedLlms]
+      .filter((l) => l.importModule && l.importName)
+      .sort((a, b) => a.importModule.localeCompare(b.importModule));
+    const expectedOrder = modulesSorted.map((l) => l.importModule);
+    const actualOrder = lines.map((l) => {
+      const m = l.match(/from \"([^\"]+)\"$/);
+      return m ? m[1] : '';
+    });
+    expect(actualOrder).toEqual(expectedOrder);
+
+    // No duplicates even if we add a duplicate entry
+    const withDup = [...orderedLlms, orderedLlms[0]];
+    const importBlockWithDup = generateImportStatements(withDup);
+    const linesWithDup = importBlockWithDup.trim().split('\n').filter(Boolean);
+    expect(linesWithDup.length).toBe(orderedLlms.length);
+
+    // Each line is an ES import line
+    for (const line of lines) {
+      expect(line.startsWith('import { ')).toBe(true);
+      expect(line.includes(' } from "')).toBe(true);
+    }
+  });
+
+  it('makeBaseSystemPrompt: includes imports, llms docs (concatenated), default stylePrompt', async () => {
+    // Warm cache so docs are available via raw imports
+    await preloadLlmsText();
+
+    const prompt = await makeBaseSystemPrompt('test-model', {
+      stylePrompt: undefined,
+      userPrompt: undefined,
+    });
+
+    // Code fence and imports
+    const importBlock = generateImportStatements(orderedLlms);
+    expect(prompt).toContain('```js');
+    expect(prompt).toContain('import React, { ... } from "react"' + importBlock);
+
+    // Concatenated docs for each LLM in the same order
+    const expectedDocs = orderedLlms
+      .map((llm) => `\n<${llm.label}-docs>\n${textForName(llm.name) || ''}\n</${llm.label}-docs>\n`)
+      .join('');
+    expect(prompt).toContain(expectedDocs);
+
+    // Default style prompt appears when undefined
+    // Use a distinctive phrase from the default
+    expect(prompt).toContain('Memphis Alchemy');
+  });
+
+  it('makeBaseSystemPrompt: supports custom stylePrompt and userPrompt', async () => {
+    await preloadLlmsText();
+
+    const prompt = await makeBaseSystemPrompt('test-model', {
+      stylePrompt: 'custom',
+      userPrompt: 'hello',
+    });
+
+    const importBlock = generateImportStatements(orderedLlms);
+    expect(prompt).toContain('import React, { ... } from "react"' + importBlock);
+
+    // Custom stylePrompt line replaces default
+    expect(prompt).toContain("Don't use words from the style prompt in your copy: custom");
+    expect(prompt).not.toContain('Memphis Alchemy');
+
+    // User prompt appears verbatim
+    expect(prompt).toContain('hello');
+  });
+});


### PR DESCRIPTION
Replace hardcoded library names in system prompt template with data-driven approach:

- Add importModule and importName fields to llms/*.json files
- Replace switch statement with for loop in generateImportStatements()
- Update type definitions to include new import configuration fields
- Eliminate hardcoded library references like 'call-ai', 'use-fireproof', 'use-vibes'

This makes the system more maintainable by centralizing all library configuration in JSON files, removing the need to update TypeScript code when adding or modifying library imports.

🤖 Generated with [Claude Code](https://claude.ai/code)