### PR TITLE
Remove login modal overlay, force sidebar login

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -15,7 +15,6 @@ import type { Route } from './+types/root';
 import './app.css';
 import ClientOnly from './components/ClientOnly';
 import CookieBanner from './components/CookieBanner';
-import { NeedsLoginModal } from './components/NeedsLoginModal';
 import { AuthProvider } from './contexts/AuthContext';
 import { CookieConsentProvider } from './contexts/CookieConsentContext';
 
@@ -111,7 +110,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
               {children}
               <ClientOnly>
                 <CookieBanner />
-                <NeedsLoginModal />
               </ClientOnly>
             </CookieConsentProvider>
             <ScrollRestoration data-testid="scroll-restoration" />


### PR DESCRIPTION
## Summary
Remove the automatic login modal overlay to improve UX by forcing users to use the existing login button in the sidebar instead of showing intrusive popups.

## Changes
- **Removed** `<NeedsLoginModal />` component from `app/root.tsx`
- **Removed** unused import for `NeedsLoginModal` to clean up code
- **Preserved** all existing auth detection logic and `setNeedsLogin()` calls

## Impact
- ✅ **No more modal overlays** when authentication is needed
- ✅ **Sidebar login still works** - users can login through the existing `LoginMenu` component
- ✅ **All auth logic preserved** - `setNeedsLogin()` calls continue to work (just don't trigger modal)
- ✅ **All tests pass** - no breaking changes to existing functionality

## UX Improvement
- **Before**: Intrusive modal popup appears automatically when auth needed
- **After**: Users must intentionally click the login button in sidebar
- **Benefit**: Less disruptive, more user-controlled login flow

## Technical Details
This is a minimal, non-breaking change:
- Only 2 lines of code removed
- All existing authentication infrastructure remains intact
- Easy to revert if needed by adding the component back
- Maintains backward compatibility

## Verification
- ✅ `pnpm check` passes (format, typecheck, tests)
- ✅ All 68 test files pass (386 tests)
- ✅ No TypeScript errors
- ✅ Application builds and runs correctly

The change enforces that login must happen through the dedicated sidebar button, providing a cleaner and less intrusive user experience.