### PR TITLE
Fix .env template source location in QuickStart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create beautiful, interactive mini apps with zero setup. Your creations are auto
 2. Or set up your own:
    - Clone the repository
    - Install with `pnpm i`
-   - Copy `env-template.txt` to `.env`
+   - Copy `.env.example` to `.env`
    - Add your AI account key from [OpenRouter](https://openrouter.ai/settings/keys)
    - Run `pnpm dev`
 


### PR DESCRIPTION
Title says it all.

This is a very small fix to the README.md file, mainly just testing contribution workflows.