### PR TITLE
Add sub path deployment support via APP_BASENAME environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules
 .netlify/
 .react-router/
 .wrangler/
+
+# Ignore editor backup files
+**~

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,18 @@ packages:
   - "use-vibes/tests"
   - "vibes.diy/pkg"
   - "vibes.diy/tests"
+
+# Avoid needing to interactively run 'pnpm approve-build' step during quickstart
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - "@tailwindcss/oxide"
+  - "core-js"
+  - "es5-ext"
+  - "esbuild"
+  - "netlify"
+  - "netlify-cli"
+  - "playwright-chromium"
+  - "sharp"
+  - "unix-dgram"
+  - "unrs-resolver"
+  - "workerd"

--- a/use-vibes/tests/setup.ts
+++ b/use-vibes/tests/setup.ts
@@ -11,7 +11,7 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
 
 // Setup global mock for call-ai module
 vi.mock('call-ai', async () => {
-  return await import('./mocks/call-ai.mock.js');
+  return await import('./mocks/call-ai.mock.ts');
 });
 
 // Mock react-dom's createPortal to render children directly in the component

--- a/vibes.diy/pkg/app/config/env.ts
+++ b/vibes.diy/pkg/app/config/env.ts
@@ -42,6 +42,7 @@ export const POSTHOG_HOST = import.meta.env.VITE_POSTHOG_HOST || "";
 // Application Behavior
 export const IS_DEV_MODE = import.meta.env.DEV || false;
 export const APP_MODE = import.meta.env.MODE || "production"; // typically 'development', 'production', 'test'
+export const APP_BASENAME = import.meta.env.VITE_APP_BASENAME || "/";
 
 // Fireproof Connect & Auth
 export const CONNECT_URL =

--- a/vibes.diy/pkg/app/root.tsx
+++ b/vibes.diy/pkg/app/root.tsx
@@ -10,7 +10,12 @@ import {
 } from "react-router";
 
 import { PostHogProvider } from "posthog-js/react";
-import { POSTHOG_KEY, POSTHOG_HOST, IS_DEV_MODE } from "./config/env.js";
+import {
+  POSTHOG_KEY,
+  POSTHOG_HOST,
+  IS_DEV_MODE,
+  APP_BASENAME,
+} from "./config/env.js";
 import type { Route } from "./+types/root";
 import "./app.css";
 import ClientOnly from "./components/ClientOnly.js";
@@ -19,8 +24,8 @@ import { AuthProvider } from "./contexts/AuthContext.js";
 import { CookieConsentProvider } from "./contexts/CookieConsentContext.js";
 
 export const links: Route.LinksFunction = () => [
-  { rel: "icon", type: "image/svg+xml", href: "/favicon.svg" },
-  { rel: "alternate icon", href: "/favicon.ico" },
+  { rel: "icon", type: "image/svg+xml", href: `${APP_BASENAME}favicon.svg` },
+  { rel: "alternate icon", href: `${APP_BASENAME}favicon.ico` },
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
   {
     rel: "preconnect",

--- a/vibes.diy/pkg/react-router.config.ts
+++ b/vibes.diy/pkg/react-router.config.ts
@@ -4,4 +4,5 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: false,
+  basename: process.env.VITE_APP_BASENAME || "/",
 } satisfies Config;

--- a/vibes.diy/pkg/vite.config.ts
+++ b/vibes.diy/pkg/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
       //      cloudflare(),
       ...(!disableReactRouter ? [reactRouter()] : []),
     ],
+    base: process.env.VITE_APP_BASENAME || "/",
     build: {
       outDir: "build",
     },


### PR DESCRIPTION
This change allows deployment to non-root URLs, eg "localhost/vibes" or similar.

Fixes headless deployment (avoids interactive use of `pnpm approve-builds`) with `onlyBuiltDependencies` directive.

These both relate to development environment improvements for automated code QA and demo-generation features.