### PR TITLE
refactor: clean approach - pass RAG_DECISION_MODEL at call site

### DIFF
--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -152,7 +152,7 @@ async function sleepReject<T>(ms: number) {
 }
 
 export async function selectLlmsAndOptions(
-  _model: string,
+  model: string,
   userPrompt: string,
   history: HistoryMessage[],
   iopts: LlmSelectionOptions,
@@ -191,7 +191,7 @@ export async function selectLlmsAndOptions(
       ? opts.callAiEndpoint.toString().replace(/\/+$/, "")
       : undefined,
     apiKey: "sk-vibes-proxy-managed",
-    model: RAG_DECISION_MODEL,
+    model,
     schema: {
       name: "module_and_options_selection",
       properties: {
@@ -317,7 +317,7 @@ export async function makeBaseSystemPrompt(
       .filter((name) => llmsCatalogNames.has(name));
   } else {
     const decisions = await selectLlmsAndOptions(
-      model,
+      RAG_DECISION_MODEL,
       userPrompt,
       history,
       sessionDoc,


### PR DESCRIPTION
## Summary
- Clean refactor to pass `RAG_DECISION_MODEL` constant at call site instead of modifying function signature
- Maintains full backward compatibility without confusing unused parameters
- Much cleaner approach than marking parameters as unused

## Changes Made
- Keep `selectLlmsAndOptions` function signature completely unchanged
- Pass `RAG_DECISION_MODEL` instead of user's model at call site in `makeBaseSystemPrompt`
- Function uses the passed model parameter as intended (GPT-4o for RAG decisions)
- Zero breaking changes to public API

## Benefits
- Cleaner code without unused parameter markers
- Full backward compatibility maintained
- Clear separation of concerns: caller decides which model to use
- RAG decisions now consistently use GPT-4o for better performance and cost efficiency

🤖 Generated with [Claude Code](https://claude.ai/code)