### PR TITLE
Add route configuration for vibesdiy.net

### DIFF
--- a/hosting/pkg/wrangler.jsonc
+++ b/hosting/pkg/wrangler.jsonc
@@ -32,8 +32,8 @@
   "routes": [
     {
       "pattern": "*vibesdiy.net/*",
-      "zone_name": "vibesdiy.net"
-    }
+      "zone_name": "vibesdiy.net",
+    },
   ],
 
   /**


### PR DESCRIPTION
Introduce route configuration for vibesdiy.net and fix a syntax error by adding a missing comma.