### PR TITLE
fix(call-ai): use Headers API for X-VIBES-Token in image endpoints

### DIFF
--- a/call-ai/tests/integration/imagegen.integration.test.ts
+++ b/call-ai/tests/integration/imagegen.integration.test.ts
@@ -148,15 +148,20 @@ describe("Image Generation Integration Tests", () => {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     } as unknown as Storage;
-    Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
+    const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+    try {
+      Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
 
-    const result = await imageGen("prompt", { apiKey: "VIBES_DIY" });
-    expect(result).toBeDefined();
+      const result = await imageGen("prompt", { apiKey: "VIBES_DIY" });
+      expect(result).toBeDefined();
 
-    const fetchCall = globalFetch.mock.calls[0];
-    const headers = fetchCall[1]?.headers as Headers;
-    expect(headers).toBeInstanceOf(Headers);
-    expect(headers.get("X-VIBES-Token")).toBe(token);
+      const fetchCall = globalFetch.mock.calls[0];
+      const headers = fetchCall[1]?.headers as Headers;
+      expect(headers).toBeInstanceOf(Headers);
+      expect(headers.get("X-VIBES-Token")).toBe(token);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: originalLocalStorage, writable: true, configurable: true });
+    }
   });
 
   it("adds X-VIBES-Token when localStorage token is set (edit)", async () => {
@@ -175,16 +180,21 @@ describe("Image Generation Integration Tests", () => {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     } as unknown as Storage;
-    Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
+    const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+    try {
+      Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
 
-    const mockImageBlob = new Blob(["fake"], { type: "image/png" });
-    const files = [new File([mockImageBlob], "a.png", { type: "image/png" })];
-    const result = await imageGen("prompt", { apiKey: "VIBES_DIY", images: files });
-    expect(result).toBeDefined();
+      const mockImageBlob = new Blob(["fake"], { type: "image/png" });
+      const files = [new File([mockImageBlob], "a.png", { type: "image/png" })];
+      const result = await imageGen("prompt", { apiKey: "VIBES_DIY", images: files });
+      expect(result).toBeDefined();
 
-    const fetchCall = globalFetch.mock.calls[0];
-    const headers = fetchCall[1]?.headers as Headers;
-    expect(headers).toBeInstanceOf(Headers);
-    expect(headers.get("X-VIBES-Token")).toBe(token);
+      const fetchCall = globalFetch.mock.calls[0];
+      const headers = fetchCall[1]?.headers as Headers;
+      expect(headers).toBeInstanceOf(Headers);
+      expect(headers.get("X-VIBES-Token")).toBe(token);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: originalLocalStorage, writable: true, configurable: true });
+    }
   });
 });

--- a/call-ai/tests/integration/imagegen.test.ts
+++ b/call-ai/tests/integration/imagegen.test.ts
@@ -126,15 +126,20 @@ describe("imageGen function", () => {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     } as unknown as Storage;
-    Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
+    const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+    try {
+      Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
 
-    const prompt = "A simple prompt";
-    await imageGen(prompt, { apiKey: "VIBES_DIY", model: "gpt-image-1" });
+      const prompt = "A simple prompt";
+      await imageGen(prompt, { apiKey: "VIBES_DIY", model: "gpt-image-1" });
 
-    expect(fetch).toHaveBeenCalledTimes(1);
-    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-    const headers = fetchCall[1].headers as Headers;
-    expect(headers).toBeInstanceOf(Headers);
-    expect(headers.get("X-VIBES-Token")).toBe(mockToken);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const headers = fetchCall[1].headers as Headers;
+      expect(headers).toBeInstanceOf(Headers);
+      expect(headers.get("X-VIBES-Token")).toBe(mockToken);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: originalLocalStorage, writable: true, configurable: true });
+    }
   });
 });

--- a/call-ai/tests/unit/imagegen.test.ts
+++ b/call-ai/tests/unit/imagegen.test.ts
@@ -125,13 +125,18 @@ describe("imageGen function", () => {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     } as unknown as Storage;
-    Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
+    const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+    try {
+      Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
 
-    await imageGen("A prompt", { apiKey: "VIBES_DIY", model: "gpt-image-1" });
+      await imageGen("A prompt", { apiKey: "VIBES_DIY", model: "gpt-image-1" });
 
-    expect(fetch).toHaveBeenCalledTimes(1);
-    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
-    const headers = fetchCall[1].headers as Headers;
-    expect(headers.get("X-VIBES-Token")).toBe(mockToken);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const headers = fetchCall[1].headers as Headers;
+      expect(headers.get("X-VIBES-Token")).toBe(mockToken);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: originalLocalStorage, writable: true, configurable: true });
+    }
   });
 });

--- a/call-ai/tests/unit/imagegen.unit.test.ts
+++ b/call-ai/tests/unit/imagegen.unit.test.ts
@@ -153,18 +153,23 @@ describe("imageGen", () => {
       setItem: vi.fn(),
       removeItem: vi.fn(),
     } as unknown as Storage;
-    Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
+    const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+    try {
+      Object.defineProperty(globalThis, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
 
-    const mockImageBlob = new Blob(["fake image data"], { type: "image/png" });
-    const mockFiles = [new File([mockImageBlob], "image1.png", { type: "image/png" })];
+      const mockImageBlob = new Blob(["fake image data"], { type: "image/png" });
+      const mockFiles = [new File([mockImageBlob], "image1.png", { type: "image/png" })];
 
-    await imageGen("Edit me", { apiKey: "VIBES_DIY", images: mockFiles });
+      await imageGen("Edit me", { apiKey: "VIBES_DIY", images: mockFiles });
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    const fetchCall = globalFetch.mock.calls[0];
-    const headers = fetchCall[1]?.headers as Headers;
-    expect(headers).toBeInstanceOf(Headers);
-    expect(headers.get("X-VIBES-Token")).toBe(token);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const fetchCall = globalFetch.mock.calls[0];
+      const headers = fetchCall[1]?.headers as Headers;
+      expect(headers).toBeInstanceOf(Headers);
+      expect(headers.get("X-VIBES-Token")).toBe(token);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", { value: originalLocalStorage, writable: true, configurable: true });
+    }
   });
 
   it("should handle errors from the image generation API", async () => {


### PR DESCRIPTION
## Summary

Fixed X-VIBES-Token header implementation in image generation endpoints to use the native Headers API, following the same pattern as call-ai/pkg/api.ts.

## Changes

### call-ai/pkg/image.ts
- **Reverted** previous `Record<string, string>` approach
- **Implemented** Headers API pattern:
  - Uses `new Headers()` constructor with Authorization and Content-Type
  - Conditionally adds X-VIBES-Token via `headers.set()` method
  - Includes `!headers.has()` check before setting
- Applied to both `/api/openai-image/generate` and `/api/openai-image/edit` endpoints

### Test Files
Updated all image generation test files to expect Headers instances:
- `call-ai/tests/unit/imagegen.test.ts`
- `call-ai/tests/unit/imagegen.unit.test.ts`
- `call-ai/tests/integration/imagegen.test.ts`
- `call-ai/tests/integration/imagegen.integration.test.ts`

## Test Results

All tests passing:
- Image generation unit tests: ✓
- Image generation integration tests: ✓
- `pnpm check` (format + build + lint + test): ✓

## Related Commits

- Reverts: c3215f2d, a961f263
- Follows pattern from: call-ai/pkg/api.ts:477-488

Generated with [Claude Code](https://claude.com/claude-code)