### PR TITLE
feat(hosting): migrate legacy domains to vibes-hosting-v2

### DIFF
--- a/hosting/pkg/wrangler.jsonc
+++ b/hosting/pkg/wrangler.jsonc
@@ -34,6 +34,22 @@
       "pattern": "*vibesdiy.net/*",
       "zone_name": "vibesdiy.net",
     },
+    {
+      "pattern": "*vibecode.garden/*",
+      "zone_name": "vibecode.garden",
+    },
+    {
+      "pattern": "*vibesdiy.app/*",
+      "zone_name": "vibesdiy.app",
+    },
+    {
+      "pattern": "*vibesdiy.work/*",
+      "zone_name": "vibesdiy.work",
+    },
+    {
+      "pattern": "vibes-diy-api.com/*",
+      "zone_name": "vibes-diy-api.com",
+    },
   ],
 
   /**


### PR DESCRIPTION
## Migration Plan

Adds domain routes from ai-builder-hosting to vibes-hosting-v2:
- `*vibecode.garden/*`
- `*vibesdiy.app/*`
- `*vibesdiy.work/*`
- `*vibes-diy-api.com/*`

### Zero-Downtime Strategy
1. ✅ Add routes to new worker (this PR)
2. ⏸️ Both workers handle traffic (load balanced)
3. 🔍 Monitor & verify new worker works
4. ❌ Remove routes from old worker (manual/separate step)

### Queue Migration
Moving from `publish-events` → `publish-events-v2` (already configured)

### Testing Checklist
- [ ] CI passes (hosting:check)
- [ ] Manual test: https://vibecode.garden
- [ ] Manual test: https://vibesdiy.app
- [ ] Manual test: https://vibesdiy.work
- [ ] Manual test: https://vibes-diy-api.com
- [ ] Verify queue events flow to `publish-events-v2`
- [ ] Monitor Cloudflare logs for errors

### Rollback
If issues occur: Close PR or revert merge. Old worker still active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)