### PR TITLE
Fix navigation to use React Router

### DIFF
--- a/vibes.diy/pkg/app/components/CookieBanner.tsx
+++ b/vibes.diy/pkg/app/components/CookieBanner.tsx
@@ -92,15 +92,20 @@ export default function CookieBanner() {
     }
   }, [hasConsent, gtmId]);
 
-  // Track cookie banner shown (only once per session to avoid double-counting on remounts)
+  // Track cookie banner shown (only once per session when actually rendered)
   useEffect(() => {
+    // Only track if banner will actually render
+    if (!XCookieConsent || !messageHasBeenSent) {
+      return;
+    }
+
     if (typeof sessionStorage !== "undefined") {
       if (!sessionStorage.getItem("cookie_banner_shown")) {
         trackEvent("cookie_banner_shown");
         sessionStorage.setItem("cookie_banner_shown", "true");
       }
     }
-  }, []);
+  }, [XCookieConsent, messageHasBeenSent]);
 
   // Don't render anything if any of these conditions are met:
   // 1. CookieConsent is not loaded

--- a/vibes.diy/pkg/app/routes/home.tsx
+++ b/vibes.diy/pkg/app/routes/home.tsx
@@ -71,7 +71,8 @@ export default function SessionWrapper() {
   // Handle prompt query parameter forwarding for root page
   useEffect(() => {
     // Only handle forwarding when on root page (no sessionId) and there's a prompt query
-    if (!urlSessionId && search) {
+    // Guard against duplicate navigations by checking local sessionId state
+    if (!urlSessionId && !sessionId && search) {
       const searchParams = new URLSearchParams(search);
       const promptParam = searchParams.get("prompt");
 


### PR DESCRIPTION
Switch to React Router for page navigation to prevent hook count mismatch errors. This change improves the handling of navigation within the application.