### PR TITLE
Fixing hidden menu not calculating new hight when childrens change

### DIFF
--- a/use-vibes/base/components/HiddenMenuWrapper/HiddenMenuWrapper.tsx
+++ b/use-vibes/base/components/HiddenMenuWrapper/HiddenMenuWrapper.tsx
@@ -215,8 +215,18 @@ export function HiddenMenuWrapper({
   useEffect(() => {
     const menuEl = menuRef.current;
     if (!menuEl) return;
-    // Use microtask to let layout settle, then measure
-    queueMicrotask?.(() => {
+    // Defer measurement to allow layout to settle, with a portable fallback
+    const defer = (cb: () => void) => {
+      if (typeof queueMicrotask === 'function') {
+        queueMicrotask(cb);
+      } else if (typeof requestAnimationFrame !== 'undefined') {
+        requestAnimationFrame(cb);
+      } else {
+        setTimeout(cb, 0);
+      }
+    };
+
+    defer(() => {
       const next = menuEl.offsetHeight;
       setMenuHeight((prev) => (prev !== next ? next : prev));
     });


### PR DESCRIPTION
when the children's change and the menu content became smaller the hidden menu use to keep it size making white line between the top of the menu and the children's 