### PR TITLE
Make Create page the new home page, move old home to /chat

### DIFF
--- a/prompts/pkg/llms/callai.txt
+++ b/prompts/pkg/llms/callai.txt
@@ -2,26 +2,6 @@
 
 The `callAI` helper function provides an easy way to make AI requests to OpenAI-compatible model providers.
 
-## Installation
-
-```bash
-npm install call-ai
-```
-
-## API Key
-
-You can set the API key in the `window` object:
-
-```javascript
-window.CALLAI_API_KEY = "your-api-key";
-```
-
-Or pass it directly to the `callAI` function:
-
-```javascript
-const response = await callAI("Write a haiku", { apiKey: "your-api-key" });
-```
-
 ## Basic Usage
 
 By default the function returns a Promise that resolves to the complete response:
@@ -135,22 +115,6 @@ try {
    - Avoid deeply nested object hierarchies (more than 2 levels deep)
    - Keep array items simple (strings or flat objects)
 
-3. **Model-specific considerations**:
-   - **OpenAI models**: Best overall schema adherence and handle complex nesting well
-   - **Claude models**: Great for simple schemas, occasional JSON formatting issues with complex structures
-   - **Gemini models**: Good general performance, handles array properties well
-   - **Llama/Mistral/Deepseek**: Strong with flat schemas, but often ignore nesting structure and provide their own organization
-
-4. **For mission-critical applications** requiring schema adherence, use OpenAI models or implement fallback mechanisms.
-
-### Models for Structured Outputs
-
-- OpenAI models: Best overall schema adherence and handle complex nesting well
-- Claude models: Great for simple schemas, occasional JSON formatting issues with complex structures
-- Gemini models: Good general performance, handles array properties well
-- Llama/Mistral/Deepseek: Strong with flat schemas, but often ignore nesting structure and provide their own organization
-
-
 ## Specifying a Model
 
 By default, the function uses `openrouter/auto` (automatic model selection). You can specify a different model:
@@ -215,61 +179,6 @@ const nextResponse = await callAI(messages);
 console.log(nextResponse);
 ```
 
-## Using with OpenAI API
-
-You can use callAI with OpenAI's API directly by providing the appropriate endpoint and API key:
-
-```javascript
-import { callAI } from 'call-ai';
-
-// Use with OpenAI's API
-const response = await callAI(
-  "Explain the theory of relativity", 
-  {
-    model: "gpt-4",
-    apiKey: "sk-...", // Your OpenAI API key
-    endpoint: "https://api.openai.com/v1/chat/completions"
-  }
-);
-
-console.log(response);
-
-// Or with streaming
-const generator = callAI(
-  "Explain the theory of relativity", 
-  {
-    model: "gpt-4",
-    apiKey: "sk-...", // Your OpenAI API key
-    endpoint: "https://api.openai.com/v1/chat/completions",
-    stream: true
-  }
-);
-
-for await (const chunk of generator) {
-  console.log(chunk);
-}
-```
-
-## Custom Endpoints
-
-You can specify a custom endpoint for any OpenAI-compatible API:
-
-```javascript
-import { callAI } from 'call-ai';
-
-// Use with any OpenAI-compatible API
-const response = await callAI(
-  "Generate ideas for a mobile app",
-  {
-    model: "your-model-name",
-    apiKey: "your-api-key",
-    endpoint: "https://your-custom-endpoint.com/v1/chat/completions"
-  }
-);
-
-console.log(response);
-```
-
 ## Recommended Models
 
 | Model | Best For | Speed vs Quality |
@@ -281,18 +190,6 @@ console.log(response);
 | `anthropic/claude-3-opus` | Complex reasoning | Slower, highest quality |
 | `mistralai/mistral-large` | Open weights alternative | Good balance |
 
-## Automatic Retry Mechanism
-
-Call-AI has a built-in fallback mechanism that automatically retries with `openrouter/auto` if the requested model is invalid or unavailable. This ensures your application remains functional even when specific models experience issues.
-
-If you need to disable this behavior (for example, in test environments), you can use the `skipRetry` option:
-
-```javascript
-const response = await callAI("Your prompt", {
-  model: "your-model-name",
-  skipRetry: true  // Disable automatic fallback
-});
-```
 
 ## Items with lists
 

--- a/prompts/pkg/llms/d3.md
+++ b/prompts/pkg/llms/d3.md
@@ -626,21 +626,21 @@ d3.json("data.json").then(createChart);
 
 ## Quick Chart Types
 
-### Bar Chart: `d3.scaleBand()` + `rect` elements
+Bar Chart: `d3.scaleBand()` + `rect` elements
 
-### Line Chart: `d3.line()` + `path` element
+Line Chart: `d3.line()` + `path` element
 
-### Scatter Plot: `circle` elements with `cx`, `cy` from scales
+Scatter Plot: `circle` elements with `cx`, `cy` from scales
 
-### Pie Chart: `d3.pie()` + `d3.arc()` + `path` elements
+Pie Chart: `d3.pie()` + `d3.arc()` + `path` elements
 
-### Network: `d3.forceSimulation()` + `line` + `circle` elements
+Network: `d3.forceSimulation()` + `line` + `circle` elements
 
-### Map: `d3.geoPath()` + GeoJSON data
+Map: `d3.geoPath()` + GeoJSON data
 
-### Treemap: `d3.treemap()` + hierarchical data
+Treemap: `d3.treemap()` + hierarchical data
 
-### Heatmap: `rect` grid + `d3.scaleSequential()` colors
+Heatmap: `rect` grid + `d3.scaleSequential()` colors
 
 ## Framework Integration
 
@@ -666,13 +666,6 @@ return <svg ref={svgRef}></svg>;
 - Debounce resize events for responsive charts
 - Use `d3.csv()`, `d3.json()` for async data loading
 - Leverage D3's built-in interpolators for smooth animations
-
-## Resources for Inspiration
-
-- [Observable D3 Gallery](https://observablehq.com/@d3/gallery)
-- [Bl.ocks.org](https://bl.ocks.org) - Community examples
-- [D3 Graph Gallery](https://d3-graph-gallery.com) - Chart type tutorials
-- [Mike Bostock's Blocks](https://bl.ocks.org/mbostock) - Creator's examples
 
 ---
 

--- a/prompts/pkg/llms/fireproof.txt
+++ b/prompts/pkg/llms/fireproof.txt
@@ -15,20 +15,11 @@ Fireproof enforces cryptographic causal consistency and ledger integrity using h
 
 The `use-fireproof` package provides both the core API and React hooks.
 
-```bash
-npm install use-fireproof
-```
-Works with ⚡️ ESM.sh:
-
 ```js
 import { useFireproof } from "https://esm.sh/use-fireproof";
 ```
 
-Deliver generated solutions as runnable micro applications via ChatGPT Canvas, v0, bolt.new, or Claude Artifacts. Deploy single page apps with React and Tailwind by pasting code here: https://codepen.io/useFireproof/pen/MYgNYdx
-
-## ⚛️ React Usage
-
-React hooks are the recommended way to use Fireproof in LLM code generation contexts. Here's how to use them:
+React hooks are the recommended way to use Fireproof in LLM code generation contexts.
 
 #### Create or Load a Database
 
@@ -40,23 +31,21 @@ import { useFireproof } from "use-fireproof";
 const { database, useLiveQuery, useDocument } = useFireproof("my-ledger");
 ```
 
-Fireproof databases are Merkle CRDTs, giving them the ledger-like causal consistency of git or a blockchain, but with the ability to merge and sync web data in real-time. Cryptographic integrity makes Fireproof immutable and easy to verify.
-
 #### Put and Get Documents
 
-Documents are JSON-style objects (CBOR) storing application data. Each has an `_id`, which can be auto-generated or set explicitly. Auto-generation is recommended to ensure uniqueness and avoid conflicts. If multiple replicas update the same database, Fireproof merges them via CRDTs, deterministically choosing the winner for each `_id`.
+Each document an `_id`, which can be auto-generated or set explicitly. Auto-generation is recommended to ensure uniqueness and avoid conflicts. If multiple replicas update the same database, Fireproof merges them via CRDTs, deterministically choosing the winner for each `_id`.
 
-It is best to have more granular documents, e.g. one document per user action, so saving a form or clicking a button should typically create or update a single document, or just a few documents. Avoid patterns that require a single document to grow without bound.
+Use granular documents, e.g. one document per user action, so saving a form or clicking a button should typically create or update a single document, or just a few documents. Avoid patterns that require a single document to grow without bound.
 
 Fireproof is a local database, no loading states required, just empty data states.
 
 ### Basic Example
 
-This example shows Fireproof's concise defaults. Here we only store user data, but get useful sorting without much code.
+This example shows Fireproof's `_id` allowse easy sorting with `useLiveQuery`.
 
 ```js
 const App = () => {
-  const { useDocument } = useFireproof("my-ledger");
+  const { useDocument, useLiveQuery } = useFireproof("my-ledger");
 
   const { doc, merge, submit } = useDocument({ text: "" });
 
@@ -98,7 +87,7 @@ const { doc, merge, submit, save, reset } = useDocument({ _id: "user-profile:abc
 ```
 
 The `useDocument` hook provides several methods:
-- `merge(updates)`: Update the document with new fields
+- `merge(updates)`: Update the document with new fields, without saving. Use this instead of keeping a `useState` for document data.
 - `submit(e)`: Handles form submission by preventing default, saving, and resetting
 - `save()`: Save the current document state
 - `reset()`: Reset to initial state
@@ -108,16 +97,11 @@ For form-based creation flows, use `submit`:
 <form onSubmit={submit}>
 ```
 
-Note: In some sandboxed environments (e.g., embedded canvases), the form submit event may be blocked. Use a button click handler instead:
-```js
-<button onClick={submit}>Save and Reset Fields</button>
-```
-
 When you call submit, the document is reset, so if you didn't provide an `_id` then you can use the form to create a stream of new documents as in the basic example above.
 
-### Query Data with React
+### Query Data
 
-Data is queried by sorted indexes defined by the application. Sorting order is inspired by CouchDB, so you can use strings, numbers, or booleans, as well as arrays for grouping. Use numbers when possible for sorting continuous data.
+Data is queried by sorted indexes defined by the application. Sort by strings, numbers, or booleans, as well as arrays for grouping. Use numbers when possible for sorting continuous data.
 
 You can use the `_id` field for temporal sorting so you dont have to write code to get simple recent document lists, as in the basic example above.
 
@@ -139,13 +123,34 @@ const { docs } = useLiveQuery("agentRating", {
 });
 ```
 
+#### Counter Pattern
+
+Documents can be updated by multiple clients, and synced later. To create an event counter, don't increment a number on a single doc, instead write a small document per counted event, and query them with an index. Example:
+
+
+```js
+const App = () => {
+  const { useLiveQuery, database } = useFireproof("my-ledger");
+
+  const { docs } = useLiveQuery('counter', { key : 'my-event-name'});
+  const counterValue = docs.length
+
+  function countEvent() {
+    database.put({
+      counter : 'my-event-name'
+    })
+  }
+
+  // Call countEvent() to count each event, and render counterValue in the UI.
+
+}
+```
+
+This pattern ensures the count is accurate even during sync.
+
 ### Custom Indexes
 
-For more complex query, you can write a custom index function. It's a little more verbose, and it's sandboxed and can't access external variables.
-
-#### Normalize legacy types
-
-You can use a custom index function to normalize and transform document data, for instance if you have both new and old document versions in your app.
+Use a custom index function to normalize and transform document data, for instance if you have both new and old document versions in your app.
 
 ```js
 const { docs } = useLiveQuery(
@@ -165,7 +170,10 @@ When you want to group rows easily, you can use an array index key. This is grea
 
 ```js
 const queryResult = useLiveQuery(
-  (doc) => [doc.date.getFullYear(), doc.date.getMonth(), doc.date.getDate()],
+  (doc) => { 
+    const date = new Date(doc);
+    return [date.getFullYear(), date.getMonth(), date.getDate()]
+  },
   { prefix: [2024, 11] }
 );
 ```
@@ -219,7 +227,7 @@ function App() {
 
 ## Architecture: Where's My Data?
 
-Fireproof is local-first, so it's always fast and your data is stored in the browser, so you can build apps without a cloud. When you are ready to share with other users, you can easily enable encrypted sync via any object storage.
+Data is stored in the browser, and is automatically synced with all invited users.
 
 ## Using Fireproof in JavaScript
 
@@ -259,7 +267,7 @@ database.subscribe((changes) => {
 
 ### Working with Files
 
-Fireproof has built-in support for file attachments. Files are encrypted by default and synced on-demand. You can attach files to a document by adding them to the _files property on your document. For example:
+Attach files to a document by adding them to the _files property. For example:
 
 ```html
 <input accept="image/*" title="save to Fireproof" type="file" id="files" multiple>
@@ -324,7 +332,6 @@ function handleSubmit(e) {
 Code listing for todo tracker App.jsx:
 ```js
 import React from "react";
-import ReactDOM from "react-dom/client";
 import { useFireproof } from "use-fireproof";
 
 export default function App() {
@@ -439,13 +446,5 @@ export default function App() {
   );
 }
 ```
-
-## See Also
-
-See the lite docs at https://use-fireproof.com/llms-mini.txt and the basics at https://use-fireproof.com/llms.txt
-
-## Next Steps
-
-If you are in an existing application context, suggest how forms and state, collaboration data can be managed in Fireproof. If this is a new app, use the examples above and start with a running App.js if you can.
 
 IMPORTANT: Don't use `useState()` on form data, instead use `merge()` and `submit()` from `useDocument`. Only use `useState` for ephemeral UI state (active tabs, open/closed panels, cursor positions). Keep your data model in Fireproof.

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -391,7 +391,6 @@ You are an AI assistant tasked with creating React components. You should create
 - Keep your component file as short as possible for fast updates
 - Keep the database name stable as you edit the code
 - The system can send you crash reports, fix them by simplifying the affected code
-- If you get missing block errors, change the database name to a new name
 - List data items on the main page of your app so users don't have to hunt for them
 - If you save data, make sure it is browseable in the app, eg lists should be clickable for more details
 ${instructionalLine}${demoDataLines}
@@ -410,7 +409,7 @@ ${
     : ""
 }IMPORTANT: You are working in one JavaScript file, use tailwind classes for styling. Remember to use brackets like bg-[#242424] for custom colors.
 
-Provide a title and brief explanation followed by the component code. The component should demonstrate proper Fireproof integration with real-time updates and proper data persistence. Follow it with a short description of the app's purpose and instructions how to use it (with occasional bold or italic for emphasis). Then suggest some additional features that could be added to the app.
+Provide a title and brief explanation followed by the component code. The component should demonstrate proper Fireproof integration with real-time updates and proper data persistence. Follow it with a brief description of the app's purpose and instructions how to use it (with occasional bold or italic for emphasis). Then suggest some additional features that could be added to the app.
 
 Begin the component with the import statements. Use react and the following libraries:
 


### PR DESCRIPTION
## Summary
- Make `/create` route the new root index (`/`)
- Move old home page to `/chat` route
- Update "Learn" link to point to `/chat` instead of `/`
- Keep session routes namespaced under `/create/:sessionId`

## Changes
- **routes.ts**: Changed index route from `home.tsx` to `create.tsx`, added `/chat` route for old home page
- **create.tsx**: Updated "Learn" link href from `/` to `/chat`
- **create-route.test.tsx**: Updated test expectation for Learn link href

## Routing Structure After Changes
- `/` → Create page (new landing page)
- `/chat` → Home/Learn page (original root content)
- `/create/:sessionId` → Create sessions (unchanged)
- `/chat/:sessionId/*` → Chat sessions (unchanged)
- All other routes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)