### PR TITLE
Add chat bubble styling to BrutalistCard

### DIFF
--- a/use-vibes/base/components/BrutalistCard/BrutalistCard.styles.ts
+++ b/use-vibes/base/components/BrutalistCard/BrutalistCard.styles.ts
@@ -71,15 +71,30 @@ function getBoxShadow(size: BrutalistCardSize, variant: BrutalistCardVariant): s
 }
 
 /**
+ * Get border radius based on message type
+ */
+function getBorderRadius(messageType?: 'user' | 'ai'): string {
+  switch (messageType) {
+    case 'user':
+      return '12px 12px 0 12px'; // Bottom-right not rounded
+    case 'ai':
+      return '12px 12px 12px 0'; // Bottom-left not rounded
+    default:
+      return '12px'; // All corners rounded
+  }
+}
+
+/**
  * Get the brutalist card style
  */
 export function getBrutalistCardStyle(
   variant: BrutalistCardVariant = 'default',
-  size: BrutalistCardSize = 'md'
+  size: BrutalistCardSize = 'md',
+  messageType?: 'user' | 'ai'
 ): CSSProperties {
   return {
     // background, color, and border are now controlled by CSS classes for dark mode support
-    borderRadius: '12px',
+    borderRadius: getBorderRadius(messageType),
     padding: getPadding(size),
     fontSize: getFontSize(size),
     fontWeight: 500,

--- a/use-vibes/base/components/BrutalistCard/BrutalistCard.tsx
+++ b/use-vibes/base/components/BrutalistCard/BrutalistCard.tsx
@@ -9,6 +9,8 @@ export interface BrutalistCardProps extends React.HTMLAttributes<HTMLDivElement>
   variant?: BrutalistCardVariant;
   /** Size affecting padding, font size, and shadow size */
   size?: BrutalistCardSize;
+  /** Message type for chat bubble corner rounding */
+  messageType?: 'user' | 'ai';
 }
 
 /**
@@ -34,6 +36,7 @@ export const BrutalistCard = React.forwardRef<HTMLDivElement, BrutalistCardProps
       children,
       variant = 'default',
       size = 'md',
+      messageType,
       style,
       className,
       ...divProps
@@ -56,7 +59,7 @@ export const BrutalistCard = React.forwardRef<HTMLDivElement, BrutalistCardProps
     }, []);
 
     const cardStyle = {
-      ...getBrutalistCardStyle(variant, size),
+      ...getBrutalistCardStyle(variant, size, messageType),
       background: isDark ? '#1a1a1a' : '#fff',
       color: isDark ? '#fff' : '#1a1a1a',
       border: isDark ? '3px solid #555' : '3px solid #1a1a1a',

--- a/vibes.diy/pkg/app/components/Message.tsx
+++ b/vibes.diy/pkg/app/components/Message.tsx
@@ -110,7 +110,7 @@ const AIMessage = memo(
 const UserMessage = memo(({ message }: { message: ChatMessageDocument }) => {
   return (
     <div className="mb-4 flex flex-row justify-end px-4">
-      <BrutalistCard size="md" className="max-w-[85%]">
+      <BrutalistCard size="md" messageType="user" className="max-w-[85%]">
         <div className="prose prose-sm dark:prose-invert prose-ul:pl-5 prose-ul:list-disc prose-ol:pl-5 prose-ol:list-decimal prose-li:my-0 max-w-none">
           <ReactMarkdown>{message.text}</ReactMarkdown>
         </div>

--- a/vibes.diy/pkg/app/components/StructuredMessage.tsx
+++ b/vibes.diy/pkg/app/components/StructuredMessage.tsx
@@ -236,6 +236,7 @@ const StructuredMessage = ({
                 <BrutalistCard
                   key={`markdown-${index}`}
                   size="sm"
+                  messageType="ai"
                   className="my-4"
                 >
                   <div className="prose prose-sm dark:prose-invert prose-ul:pl-5 prose-ul:list-disc prose-ol:pl-5 prose-ol:list-decimal prose-li:my-0 max-w-none">


### PR DESCRIPTION
## Summary

- Add `messageType` prop to BrutalistCard component for chat bubble corner styling
- User messages get rounded corners except bottom-right
- AI messages get rounded corners except bottom-left  
- Default messages maintain all corners rounded
- Apply new styling to Message and StructuredMessage components

## Test plan

- [ ] Verify user messages display with appropriate corner rounding (bottom-right sharp)
- [ ] Verify AI messages display with appropriate corner rounding (bottom-left sharp)
- [ ] Check that the styling works correctly in both light and dark modes
- [ ] Ensure existing BrutalistCard usage without messageType still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)