### PR TITLE
Preserve UTM parameters in URL for analytics tracking

### DIFF
--- a/vibes.diy/pkg/app/components/CookieBanner.tsx
+++ b/vibes.diy/pkg/app/components/CookieBanner.tsx
@@ -4,7 +4,7 @@ import { useLocation } from "react-router";
 import { VibesDiyEnv } from "../config/env.js";
 import { useCookieConsent } from "../contexts/CookieConsentContext.js";
 import { pageview, trackEvent } from "../utils/analytics.js";
-import { initGTM, persistUtmParams } from "../utils/gtm.js";
+import { initGTM } from "../utils/gtm.js";
 import { CookieConsent, getCookieConsentValue } from "react-cookie-consent";
 
 // We'll use any type for dynamic imports to avoid TypeScript errors with the cookie consent component
@@ -41,11 +41,6 @@ export default function CookieBanner() {
     });
   }, []);
 
-  // Persist UTM params as early as possible (storage only)
-  useEffect(() => {
-    persistUtmParams();
-  }, []);
-
   // Check for existing cookie consent
   useEffect(() => {
     if (getXCookieConsentValue) {
@@ -63,7 +58,7 @@ export default function CookieBanner() {
     }
   }, [location, hasConsent]);
 
-  // Initialize GTM and clean UTM params if consent is given
+  // Initialize GTM if consent is given
   const gtmId = VibesDiyEnv.GTM_CONTAINER_ID();
   useEffect(() => {
     if (gtmId && hasConsent && typeof document !== "undefined") {
@@ -72,23 +67,6 @@ export default function CookieBanner() {
 
       // Inject GTM (centralized here only)
       initGTM(gtmId);
-
-      if (window.history && window.history.replaceState) {
-        const url = new URL(window.location.href);
-        [
-          "utm_source",
-          "utm_medium",
-          "utm_campaign",
-          "utm_term",
-          "utm_content",
-          "fpref",
-        ].forEach((k) => url.searchParams.delete(k));
-        const searchStr = url.searchParams.toString();
-        const newUrl = `${url.pathname}${searchStr ? `?${searchStr}` : ""}${
-          url.hash || ""
-        }`;
-        window.history.replaceState({}, document.title, newUrl);
-      }
     }
   }, [hasConsent, gtmId]);
 

--- a/vibes.diy/pkg/app/utils/gtm.ts
+++ b/vibes.diy/pkg/app/utils/gtm.ts
@@ -32,27 +32,3 @@ export function gtmPush(obj: Record<string, unknown>) {
   w.dataLayer = w.dataLayer || [];
   w.dataLayer.push(obj);
 }
-
-/**
- * Persist UTM parameters to localStorage for GTM/HubSpot usage.
- * Call as early as possible (can be before consent) — storage only.
- */
-export function persistUtmParams() {
-  if (typeof window === "undefined") return;
-  try {
-    const url = new URL(window.location.href);
-    const keys = [
-      "utm_source",
-      "utm_medium",
-      "utm_campaign",
-      "utm_term",
-      "utm_content",
-    ];
-    for (const k of keys) {
-      const v = url.searchParams.get(k);
-      if (v) localStorage.setItem(k, v);
-    }
-  } catch {
-    // ignore
-  }
-}

--- a/vibes.diy/tests/app/CookieBanner-hook-ordering.test.tsx
+++ b/vibes.diy/tests/app/CookieBanner-hook-ordering.test.tsx
@@ -37,7 +37,6 @@ vi.mock("~/vibes.diy/app/utils/analytics", () => ({
 
 vi.mock("~/vibes.diy/app/utils/gtm", () => ({
   initGTM: vi.fn(),
-  persistUtmParams: vi.fn(),
 }));
 
 vi.mock("~/vibes.diy/app/config/env", () => ({


### PR DESCRIPTION
## Summary

- Remove client-side URL parameter stripping that was cleaning utm_source, utm_medium, utm_campaign, utm_term, utm_content, and fpref from the browser URL
- Remove unused persistUtmParams() function and localStorage persistence logic
- UTM parameters now remain visible in the URL for better analytics tracking

## Test plan

- [ ] Visit https://vibes.diy/?utm_source=johntest&utm_medium=cpc&utm_campaign=testingbaby&utm_id=johntesting
- [ ] Accept cookie consent
- [ ] Verify all UTM parameters remain in the URL (no longer stripped to just utm_id)
- [ ] Verify GTM and analytics still function correctly with parameters in URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)