### PR TITLE
Remove Clerk key swapping middleware to fix concurrency issue

### DIFF
--- a/hosting/pkg/src/index.ts
+++ b/hosting/pkg/src/index.ts
@@ -50,31 +50,6 @@ const openapi = fromHono(app, {
   docs_url: "/docs",
 });
 
-// Clerk key selection based on client origin
-openapi.use("/api/*", async (c, next) => {
-  const referer = c.req.header("Referer") || c.req.header("Origin") || "";
-  const refererUrl = referer ? new URL(referer) : null;
-  const clientHostname = refererUrl?.hostname || "vibes.diy";
-
-  // Use LIVE key ONLY for vibes.diy, test key for everything else
-  const isProductionClient = clientHostname === "vibes.diy";
-
-  console.log("🔐 Clerk key selection:", {
-    clientHostname,
-    isProductionClient,
-    hasTestKey: !!c.env.CLERK_SECRET_KEY_TEST,
-  });
-
-  if (!isProductionClient && c.env.CLERK_SECRET_KEY_TEST) {
-    c.env.CLERK_SECRET_KEY = c.env.CLERK_SECRET_KEY_TEST;
-    console.log("✅ Using TEST Clerk secret key");
-  } else {
-    console.log("✅ Using LIVE Clerk secret key");
-  }
-
-  await next();
-});
-
 // Add Clerk authentication middleware
 openapi.use("/api/*", clerkMiddleware());
 


### PR DESCRIPTION
The middleware was mutating c.env.CLERK_SECRET_KEY which persists
across requests in the same worker instance, causing parallel or
subsequent requests to potentially use the wrong key.

Now using production CLERK_SECRET_KEY only for all requests.
The test key logic can be re-implemented later using a request-scoped
approach that doesn't mutate shared environment state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>