### PR TITLE
Remove CLERK_PUBLISHABLE_KEY from hosting workflows

### DIFF
--- a/.github/workflows/hosting-deploy.yaml
+++ b/.github/workflows/hosting-deploy.yaml
@@ -59,6 +59,5 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           CLERK_SECRET_KEY_TEST: ${{ secrets.CLERK_SECRET_KEY_TEST }}
-          CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}

--- a/.github/workflows/hosting-pr-preview.yaml
+++ b/.github/workflows/hosting-pr-preview.yaml
@@ -73,7 +73,6 @@ jobs:
           echo "${{ secrets.SERVER_OPENROUTER_API_KEY }}" | npx wrangler secret put SERVER_OPENROUTER_API_KEY --name ${{ steps.pr.outputs.worker_name }}
           echo "${{ secrets.OPENAI_API_KEY }}" | npx wrangler secret put OPENAI_API_KEY --name ${{ steps.pr.outputs.worker_name }}
           echo "${{ secrets.CLERK_SECRET_KEY }}" | npx wrangler secret put CLERK_SECRET_KEY --name ${{ steps.pr.outputs.worker_name }}
-          echo "${{ secrets.CLERK_PUBLISHABLE_KEY }}" | npx wrangler secret put CLERK_PUBLISHABLE_KEY --name ${{ steps.pr.outputs.worker_name }}
 
           # Clerk test key for PR previews
           if [ -n "${{ secrets.CLERK_SECRET_KEY_TEST }}" ]; then

--- a/hosting/actions/deploy/action.yaml
+++ b/hosting/actions/deploy/action.yaml
@@ -31,9 +31,6 @@ inputs:
   CLERK_SECRET_KEY_TEST:
     description: "Clerk test secret key for development/testing"
     required: false
-  CLERK_PUBLISHABLE_KEY:
-    description: "Clerk publishable key for frontend authentication"
-    required: true
   DISCORD_WEBHOOK_URL:
     description: "Discord webhook URL for notifications (optional)"
     required: false
@@ -98,7 +95,6 @@ runs:
 
         # Required Clerk keys
         echo "${{ inputs.CLERK_SECRET_KEY }}" | npx wrangler secret put CLERK_SECRET_KEY
-        echo "${{ inputs.CLERK_PUBLISHABLE_KEY }}" | npx wrangler secret put CLERK_PUBLISHABLE_KEY
 
         # Optional Clerk test key
         if [ -n "${{ inputs.CLERK_SECRET_KEY_TEST }}" ]; then


### PR DESCRIPTION
CLERK_PUBLISHABLE_KEY is a frontend-only configuration that is:
- Hardcoded in vibes.diy/pkg/app/config/env.ts with fallback logic
- Managed by Netlify for frontend deployments
- Never referenced in hosting worker code

Removed from:
- hosting-deploy.yaml workflow
- hosting-pr-preview.yaml workflow
- hosting/actions/deploy/action.yaml action inputs and upload step
- GitHub production environment secrets

This simplifies deployment configuration by removing an unused secret
from the hosting worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>