### PR TITLE
fix: restore call-ai credential management via window.CALLAI_API_KEY

### DIFF
--- a/call-ai/pkg/api.ts
+++ b/call-ai/pkg/api.ts
@@ -370,8 +370,8 @@ function prepareRequestParams(
   requestOptions: RequestInit;
   schemaStrategy: SchemaStrategy;
 } {
-  // The API key (Clerk session token) must be provided via options.apiKey
-  const apiKey = options.apiKey;
+  // Try multiple sources for the API key: explicit option, keyStore, or environment
+  const apiKey = options.apiKey || keyStore().current || callAiEnv.CALLAI_API_KEY;
   if (!apiKey) {
     throw new CallAIError({
       message: "API key is required",

--- a/use-vibes/base/mounting/mountVibeCode.ts
+++ b/use-vibes/base/mounting/mountVibeCode.ts
@@ -1,11 +1,12 @@
 import { mountVibesApp } from '../vibe-app-mount.js';
 
-// Declare Babel as a global loaded via CDN script tag
+// Declare Babel and CALLAI_API_KEY as globals loaded via CDN script tag or set at runtime
 declare global {
   interface Window {
     Babel: {
       transform: (code: string, options: { presets: string[] }) => { code: string | null };
     };
+    CALLAI_API_KEY?: string;
   }
 }
 
@@ -18,11 +19,17 @@ export async function mountVibeCode(
   titleId: string,
   installId: string,
   transformImports: (code: string) => string,
-  showVibesSwitch = true
+  showVibesSwitch = true,
+  apiKey?: string
 ): Promise<void> {
   let objectURL: string | undefined;
 
   try {
+    // Set window.CALLAI_API_KEY if apiKey is provided
+    // This allows call-ai to use the key via callAiEnv.CALLAI_API_KEY
+    if (apiKey && typeof window !== 'undefined') {
+      window.CALLAI_API_KEY = apiKey;
+    }
     // Step 1: Transform imports (rewrite unknown bare imports to esm.sh)
     const codeWithTransformedImports = transformImports(code);
 

--- a/use-vibes/base/mounting/mountVibeWithCleanup.ts
+++ b/use-vibes/base/mounting/mountVibeWithCleanup.ts
@@ -10,7 +10,8 @@ export async function mountVibeWithCleanup(
   titleId: string,
   installId: string,
   transformImports: (code: string) => string,
-  showVibesSwitch = true
+  showVibesSwitch = true,
+  apiKey?: string
 ): Promise<() => void> {
   return new Promise<() => void>((resolve) => {
     const resolveOnce = new ResolveOnce<void>();
@@ -65,16 +66,22 @@ export async function mountVibeWithCleanup(
     document.addEventListener('vibes-mount-error', handleMountError);
 
     // Mount the vibe
-    mountVibeCode(code, containerId, titleId, installId, transformImports, showVibesSwitch).catch(
-      (_err) => {
-        // Babel/transform errors - caught before module execution
-        resolveOnce.once(() => {
-          cleanup();
-          resolve(() => {
-            // No-op cleanup
-          });
+    mountVibeCode(
+      code,
+      containerId,
+      titleId,
+      installId,
+      transformImports,
+      showVibesSwitch,
+      apiKey
+    ).catch((_err) => {
+      // Babel/transform errors - caught before module execution
+      resolveOnce.once(() => {
+        cleanup();
+        resolve(() => {
+          // No-op cleanup
         });
-      }
-    );
+      });
+    });
   });
 }

--- a/vibes.diy/pkg/app/components/ResultPreview/InlinePreview.tsx
+++ b/vibes.diy/pkg/app/components/ResultPreview/InlinePreview.tsx
@@ -3,6 +3,7 @@ import { Lazy } from "@adviser/cement";
 import { ensureSuperThis } from "@fireproof/core-runtime";
 import { mountVibeWithCleanup } from "use-vibes";
 import { setupDevShims, transformImportsDev } from "../../utils/dev-shims.js";
+import { useAuth } from "@clerk/clerk-react";
 
 const sthis = Lazy(() => ensureSuperThis());
 
@@ -17,6 +18,7 @@ export function InlinePreview({
   sessionId,
   codeReady,
 }: InlinePreviewProps) {
+  const { getToken } = useAuth();
   const [containerId] = useState(
     () => `preview-container-${sthis().nextId().str}`,
   );
@@ -39,6 +41,9 @@ export function InlinePreview({
           unmountVibeRef.current = null;
         }
 
+        // Get Clerk token for API authentication
+        const clerkToken = await getToken();
+
         // Mount the vibe code and capture the unmount callback via event
         const unmount = await mountVibeWithCleanup(
           code,
@@ -47,6 +52,7 @@ export function InlinePreview({
           "preview", // Use "preview" as installId for result preview context
           transformImportsDev,
           false, // Hide vibes switch in result preview mode
+          clerkToken || undefined, // Pass Clerk token as apiKey
         );
 
         if (active) {

--- a/vibes.diy/pkg/app/routes/vibe-viewer.tsx
+++ b/vibes.diy/pkg/app/routes/vibe-viewer.tsx
@@ -31,6 +31,7 @@ function getHostnameFromUrl(url: string): string {
 }
 
 function VibeInstanceViewerContent() {
+  const { getToken } = useAuth();
   const { titleId, installId } = useParams<{
     titleId: string;
     installId: string;
@@ -90,6 +91,9 @@ function VibeInstanceViewerContent() {
 
         if (!active) return;
 
+        // Get Clerk token for API authentication
+        const clerkToken = await getToken();
+
         // Mount the vibe code and capture the unmount callback via event
         unmountVibe = await mountVibeWithCleanup(
           vibeCode,
@@ -97,6 +101,8 @@ function VibeInstanceViewerContent() {
           titleId,
           installId,
           transformImportsDev,
+          true, // showVibesSwitch
+          clerkToken || undefined, // Pass Clerk token as apiKey
         );
       } catch (err) {
         console.error("Error loading vibe:", err);


### PR DESCRIPTION
## Summary

Restores the working v0.17.5 credential flow that was broken when call-ai was refactored to require explicit `options.apiKey`. This fix uses the simple window global approach that works for both dev and published vibes.

## Problem

PR #624 attempted to fix credential management but failed due to a timing issue: it set `window.CALLAI_API_KEY` **after** React rendering began, but user vibe code needs the key **during** module loading (before React renders).

## Solution

This PR sets `window.CALLAI_API_KEY` at the correct point in the mounting lifecycle - **before** the user's vibe code is imported.

### Changes

**call-ai package:**
- Restore API key resolution chain: `options.apiKey || keyStore().current || callAiEnv.CALLAI_API_KEY`
- This matches the working v0.17.5 pattern with multiple fallback sources

**use-vibes package:**
- Add optional `apiKey` parameter to `mountVibeCode()` and `mountVibeWithCleanup()`
- Set `window.CALLAI_API_KEY` at the start of `mountVibeCode()`, before blob URL creation
- Declare `CALLAI_API_KEY` in Window interface for TypeScript

**vibes.diy app:**
- Get Clerk token via `useAuth().getToken()` in `InlinePreview` and `vibe-viewer`
- Pass token through mounting chain as `apiKey` parameter

## Credential Flow

1. Component gets Clerk JWT via `useAuth().getToken()`
2. Token passed to `mountVibeWithCleanup()` as `apiKey` parameter
3. `mountVibeCode()` sets `window.CALLAI_API_KEY = apiKey` **before module loading**
4. User's vibe code imports and may call `callAi()` at top level
5. `call-ai` checks resolution chain and finds `window.CALLAI_API_KEY`
6. Request sent with `Authorization: Bearer` header
7. Backend validates Clerk token and proxies to OpenRouter

## Why This Works vs PR #624

### Timing is Critical

**Mounting lifecycle:**
1. `mountVibeCode()` - transforms JSX
2. Creates blob URL
3. **Dynamic import** - user code executes (may call `callAi()`)
4. `mountVibesApp()` - React rendering begins

**PR #624 (failed):** Set window global at step 4 - too late, user code already failed  
**This PR (works):** Set window global at step 1 - available when user code runs at step 3

### Architectural Insight

User vibe code loaded via blob URL **cannot access React Context** from host app. It can only access:
- Window globals ✅
- Function parameters ✅  
- Environment variables ✅

React Context is not available across module boundaries, so window globals are the correct approach.

## Testing

- ✅ `pnpm build` - passes
- ✅ `pnpm lint` - passes
- ✅ TypeScript compilation - no errors

## Benefits

- **Minimal changes**: 5 files vs 8 files in PR #624
- **Clean separation**: Keeps `VibeMetadata` focused on ledger naming, doesn't mix in auth
- **Correct timing**: Sets credentials before user code loads
- **Backwards compatible**: Restores v0.17.5 fallback behavior
- **No backend changes**: Works with existing Clerk integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>