### PR TITLE
Replace goal tracker suggestion with random app

### DIFF
--- a/vibes.diy/pkg/app/components/NewSessionView.tsx
+++ b/vibes.diy/pkg/app/components/NewSessionView.tsx
@@ -101,7 +101,7 @@ export default function NewSessionView({
                 style={{ flex: "1" }}
                 onClick={() => handleSelectSuggestion(progressTrackerPrompt)}
               >
-                Progress Tracker
+                Random App
               </VibesButton>
               <VibesButton
                 variant="yellow"

--- a/vibes.diy/pkg/app/data/quick-suggestions-data.ts
+++ b/vibes.diy/pkg/app/data/quick-suggestions-data.ts
@@ -104,8 +104,8 @@ export const quickSuggestions: Suggestion[] = [
     text: "Create a party planning app with guest list, RSVP tracking, and budget calculator.",
   },
   {
-    label: "Progress Tracker",
-    text: "Build a goal tracker with progress bars, streak counters, and milestone celebrations.",
+    label: "Random App",
+    text: "Create a random app idea and build it automatically.",
   },
   {
     label: "Jam Session",
@@ -117,6 +117,6 @@ export const quickSuggestions: Suggestion[] = [
 export const partyPlannerPrompt =
   "Create a party planning app with guest list, RSVP tracking, and budget calculator.";
 export const progressTrackerPrompt =
-  "Build a goal tracker with progress bars, streak counters, and milestone celebrations.";
+  "Create a random app idea and build it automatically.";
 export const jamSessionPrompt =
   "Create a music collaboration tool with chord progressions and shared bpm and drum machine.";


### PR DESCRIPTION
## Summary
- update the quick suggestion prompt to build a random app instead of a goal tracker
- update the New Session shortcut button label to match the new random app prompt

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69290a73bc988323b2eea91a8ae3ee75)