### PR TITLE
Enable sandbox serving via cfServe + build:dist script

### DIFF
--- a/claude-browse-vibes/sandbox-debug.spec.js
+++ b/claude-browse-vibes/sandbox-debug.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from "@playwright/test";
+
+test("load sandbox and capture console errors", async ({ page }) => {
+  const errors = [];
+  const logs = [];
+  const failedRequests = [];
+  const allModuleResponses = [];
+
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      errors.push(msg.text());
+    } else {
+      logs.push(`[${msg.type()}] ${msg.text()}`);
+    }
+  });
+
+  page.on("pageerror", (err) => {
+    errors.push(`PAGE ERROR: ${err.message}`);
+  });
+
+  page.on("requestfailed", (req) => {
+    errors.push(`REQUEST_FAILED: ${req.url()} reason=${req.failure()?.errorText}`);
+  });
+
+  page.on("response", (response) => {
+    const url = response.url();
+    const ct = response.headers()["content-type"] || "";
+    if (response.status() >= 400) {
+      failedRequests.push(`${response.status()} ${ct} ${url}`);
+    }
+    if (url.endsWith(".js") || url.endsWith(".mjs") || url.includes("~~transformed~~") || url.includes("/dist/")) {
+      allModuleResponses.push(`${response.status()} ${ct} ${url}`);
+      if (ct.includes("text/html")) {
+        failedRequests.push(`MIME_MISMATCH ${response.status()} ${ct} ${url}`);
+      }
+    }
+  });
+
+  await page.goto("http://crop-hidden-blew--jchris.localhost:8888/", {
+    waitUntil: "networkidle",
+    timeout: 15000,
+  });
+
+  // Wait a bit for any async module loading
+  await page.waitForTimeout(3000);
+
+  console.log("=== CONSOLE LOGS ===");
+  for (const log of logs) {
+    console.log(log);
+  }
+
+  console.log("\n=== CONSOLE ERRORS ===");
+  if (errors.length === 0) {
+    console.log("No errors!");
+  } else {
+    for (const err of errors) {
+      console.log(err);
+    }
+  }
+
+  console.log("\n=== FAILED REQUESTS ===");
+  for (const req of failedRequests) {
+    console.log(req);
+  }
+
+  console.log("\n=== ALL JS/MODULE RESPONSES ===");
+  for (const r of allModuleResponses) {
+    console.log(r);
+  }
+
+  console.log("\n=== DOM STATE ===");
+  const bodyHTML = await page.evaluate(() => document.body.innerHTML.substring(0, 1000));
+  console.log(bodyHTML);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1111,253 +1111,6 @@ importers:
         specifier: 0.24.10
         version: 0.24.10(@pnpm/logger@5.2.0)(typescript@5.9.3)
 
-  vibes.diy/failback-homepage:
-    dependencies:
-      '@adviser/cement':
-        specifier: ^0.5.21
-        version: 0.5.21(typescript@5.9.3)
-      '@clerk/clerk-js':
-        specifier: ^5.121.1
-        version: 5.122.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.13)(bs58@5.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.13)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.4))(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@clerk/clerk-react':
-        specifier: ^5.60.0
-        version: 5.60.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@cloudflare/workers-types':
-        specifier: ^4.20260128.0
-        version: 4.20260128.0
-      '@fireproof/core':
-        specifier: 0.24.10
-        version: 0.24.10(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@fireproof/core-keybag':
-        specifier: 0.24.10
-        version: 0.24.10(typescript@5.9.3)
-      '@fireproof/core-protocols-dashboard':
-        specifier: 0.24.10
-        version: 0.24.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@fireproof/core-runtime':
-        specifier: 0.24.10
-        version: 0.24.10(typescript@5.9.3)
-      '@fireproof/core-types-base':
-        specifier: 0.24.10
-        version: 0.24.10(typescript@5.9.3)
-      '@fireproof/core-types-protocols-cloud':
-        specifier: 0.24.10
-        version: 0.24.10(typescript@5.9.3)
-      '@fireproof/use-fireproof':
-        specifier: 0.24.10
-        version: 0.24.10(@adviser/cement@0.5.21(typescript@5.9.3))(bufferutil@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@monaco-editor/react':
-        specifier: ^4.7.0
-        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-slot':
-        specifier: ^1.2.4
-        version: 1.2.4(@types/react@19.2.13)(react@19.2.4)
-      '@react-router/node':
-        specifier: ^7.12.0
-        version: 7.12.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
-      '@react-router/serve':
-        specifier: ^7.13.0
-        version: 7.13.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
-      '@shikijs/monaco':
-        specifier: ^3.22.0
-        version: 3.22.0
-      '@tailwindcss/typography':
-        specifier: ^0.5.19
-        version: 0.5.19(tailwindcss@4.1.18)
-      '@vibes.diy/prompts':
-        specifier: workspace:*
-        version: link:../../prompts/pkg
-      '@vibes.diy/use-vibes-base':
-        specifier: workspace:*
-        version: link:../../use-vibes/base
-      '@vibes.diy/use-vibes-types':
-        specifier: workspace:*
-        version: link:../../use-vibes/types
-      animejs:
-        specifier: ^4.3.5
-        version: 4.3.5
-      call-ai:
-        specifier: workspace:*
-        version: link:../../call-ai/pkg
-      class-variance-authority:
-        specifier: ^0.7.1
-        version: 0.7.1
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
-      esbuild:
-        specifier: ^0.27.1
-        version: 0.27.2
-      esbuild-wasm:
-        specifier: ^0.27.2
-        version: 0.27.2
-      isbot:
-        specifier: ^5.1.34
-        version: 5.1.34
-      jose:
-        specifier: ^6.1.1
-        version: 6.1.3
-      mime:
-        specifier: ^4.1.0
-        version: 4.1.0
-      monaco-editor:
-        specifier: ^0.55.1
-        version: 0.55.1
-      multiformats:
-        specifier: ^13.4.1
-        version: 13.4.2
-      posthog-js:
-        specifier: ^1.341.0
-        version: 1.341.0
-      react:
-        specifier: 19.2.4
-        version: 19.2.4
-      react-cookie-consent:
-        specifier: ^10.0.1
-        version: 10.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-dom:
-        specifier: 19.2.4
-        version: 19.2.4(react@19.2.4)
-      react-hot-toast:
-        specifier: ^2.6.0
-        version: 2.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-markdown:
-        specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.13)(react@19.2.4)
-      react-router:
-        specifier: ^7.13.0
-        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-router-dom:
-        specifier: ^7.12.0
-        version: 7.12.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      tailwind-merge:
-        specifier: ^3.4.0
-        version: 3.4.0
-      three:
-        specifier: ^0.182.0
-        version: 0.182.0
-      use-vibes:
-        specifier: workspace:*
-        version: link:../../use-vibes/pkg
-      zod:
-        specifier: ^4.1.13
-        version: 4.3.6
-    devDependencies:
-      '@babel/parser':
-        specifier: ^7.29.0
-        version: 7.29.0
-      '@babel/traverse':
-        specifier: ^7.28.6
-        version: 7.28.6
-      '@babel/types':
-        specifier: ^7.28.6
-        version: 7.28.6
-      '@chromatic-com/storybook':
-        specifier: ^5.0.0
-        version: 5.0.0(storybook@10.2.6(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))
-      '@cloudflare/vite-plugin':
-        specifier: ^1.23.0
-        version: 1.23.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(workerd@1.20260205.0)(wrangler@4.63.0(@cloudflare/workers-types@4.20260128.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@fireproof/core-cli':
-        specifier: 0.24.10
-        version: 0.24.10(@pnpm/logger@5.2.0)(typescript@5.9.3)
-      '@pnpm/lockfile-file':
-        specifier: ^9.1.3
-        version: 9.1.3(@pnpm/logger@5.2.0)
-      '@react-router/dev':
-        specifier: ^7.13.0
-        version: 7.13.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3))(@types/node@25.2.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(wrangler@4.63.0(@cloudflare/workers-types@4.20260128.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(yaml@2.8.2)
-      '@react-router/fs-routes':
-        specifier: ^7.13.0
-        version: 7.13.0(@react-router/dev@7.13.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3))(@types/node@25.2.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(wrangler@4.63.0(@cloudflare/workers-types@4.20260128.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(yaml@2.8.2))(typescript@5.9.3)
-      '@storybook/addon-a11y':
-        specifier: ^10.1.7
-        version: 10.1.11(storybook@10.2.6(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))
-      '@storybook/addon-docs':
-        specifier: ^10.2.6
-        version: 10.2.6(@types/react@19.2.13)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.2.6(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@storybook/addon-onboarding':
-        specifier: ^10.2.6
-        version: 10.2.6(storybook@10.2.6(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))
-      '@storybook/react':
-        specifier: ^10.0.8
-        version: 10.1.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.6(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))(typescript@5.9.3)
-      '@storybook/react-vite':
-        specifier: ^10.2.6
-        version: 10.2.6(esbuild@0.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.55.1)(storybook@10.2.6(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10))(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@tailwindcss/vite':
-        specifier: ^4.1.2
-        version: 4.1.18(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@types/babel__standalone':
-        specifier: ^7.1.9
-        version: 7.1.9
-      '@types/babel__traverse':
-        specifier: ^7.28.0
-        version: 7.28.0
-      '@types/mime-types':
-        specifier: ^3.0.1
-        version: 3.0.1
-      '@types/react':
-        specifier: ~19.2.13
-        version: 19.2.13
-      '@types/react-dom':
-        specifier: ~19.2.2
-        version: 19.2.3(@types/react@19.2.13)
-      '@types/three':
-        specifier: ^0.182.0
-        version: 0.182.0
-      cmd-ts:
-        specifier: ^0.14.3
-        version: 0.14.3
-      concurrently:
-        specifier: ^9.1.2
-        version: 9.2.1
-      cross-env:
-        specifier: ^10.0.0
-        version: 10.1.0
-      deno:
-        specifier: ^2.6.8
-        version: 2.6.8
-      find-up:
-        specifier: ^8.0.0
-        version: 8.0.0
-      mime-types:
-        specifier: ^3.0.2
-        version: 3.0.2
-      prettier:
-        specifier: ^3.8.1
-        version: 3.8.1
-      serve:
-        specifier: ^14.2.5
-        version: 14.2.5
-      shiki:
-        specifier: ^3.22.0
-        version: 3.22.0
-      storybook:
-        specifier: ^10.2.6
-        version: 10.2.6(@testing-library/dom@10.4.1)(bufferutil@4.1.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@5.0.10)
-      tailwindcss:
-        specifier: ^4.1.17
-        version: 4.1.18
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-tsconfig-paths:
-        specifier: ^6.0.5
-        version: 6.0.5(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      yaml:
-        specifier: ^2.8.2
-        version: 2.8.2
-      zx:
-        specifier: ^8.8.5
-        version: 8.8.5
-
   vibes.diy/pkg:
     dependencies:
       '@adviser/cement':
@@ -2190,39 +1943,6 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
-
-  '@deno/darwin-arm64@2.6.8':
-    resolution: {integrity: sha512-Q3STbV/+nr+xhL/bD4Av+yg5XNGuhTdTay4b0q0wU5GLlcwMsNXQ1mjrfT9CKdG/VuF30a8wE/u/sIq7bZsViQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@deno/darwin-x64@2.6.8':
-    resolution: {integrity: sha512-buz9Ncv/hQYUwcHIrv0g7fIKZWoO1OOfInVB9XK35hteOuknzOaN+X0uFI/idOyae6HqVKG31S2Wk5N99mSJ1g==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@deno/linux-arm64-glibc@2.6.8':
-    resolution: {integrity: sha512-U/jmXKFnbD0VnCuqISf8lbYp9RxRVO8vgSPdLHaUU4+VFCPx2nO3NPGJO1cZvHobTAsE0CzCH+21AyA/7S1V9g==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@deno/linux-x64-glibc@2.6.8':
-    resolution: {integrity: sha512-oY6qIbyrEHt+rzk7oHJ8KZgJ3mOQ1econRWcXlm/wOXORVDn7l9rEoY0vlOf4Qvv22tPTD5Jn1bxm6WBZBXmog==}
-    cpu: [x64]
-    os: [linux]
-
-  '@deno/win32-arm64@2.6.8':
-    resolution: {integrity: sha512-Zt5/R64VSuDyWsVBLTYH7BpxtdVwxUGyL2AMteSm45a+i1zaEbpwzJ0/lZM/TrBXIohu5+CRm/NKUPrGkkZAAA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@deno/win32-x64@2.6.8':
-    resolution: {integrity: sha512-gHI1K9vmCT+gtJlYnCLl1pBdqOwBoQs2E2e6MGtL0ncrU7VqOiZ3jD3f2QZnnsfZEhj/khSIjkVlTMIUSZtIcg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@dimforge/rapier3d-compat@0.12.0':
-    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -4106,16 +3826,6 @@ packages:
       typescript:
         optional: true
 
-  '@react-router/fs-routes@7.13.0':
-    resolution: {integrity: sha512-S7rilodzsn+8oKHk3VHo+M3gKB2znHZoUJEu1wD6ZTtb1sj+vkV/36M+bfbqXnbpXKs4+z3J4CWj53lpzEDiWA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@react-router/dev': ^7.13.0
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@react-router/node@7.12.0':
     resolution: {integrity: sha512-o/t10Cse4LK8kFefqJ8JjC6Ng6YuKD2I87S2AiJs17YAYtXU5W731ZqB73AWyCDd2G14R0dSuqXiASRNK/xLjg==}
     engines: {node: '>=20.0.0'}
@@ -4758,9 +4468,6 @@ packages:
     resolution: {integrity: sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@tweenjs/tween.js@23.1.3':
-    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
-
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -4848,9 +4555,6 @@ packages:
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
-  '@types/mime-types@3.0.1':
-    resolution: {integrity: sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==}
-
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -4895,12 +4599,6 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
-  '@types/stats.js@0.17.4':
-    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
-
-  '@types/three@0.182.0':
-    resolution: {integrity: sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==}
-
   '@types/tmp@0.2.6':
     resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
 
@@ -4915,9 +4613,6 @@ packages:
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
-
-  '@types/webxr@0.5.24':
-    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/ws@7.4.7':
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
@@ -5231,9 +4926,6 @@ packages:
     resolution: {integrity: sha512-MVbFWF6q8L22k8CGp7GHkfNeZc56nPQmERHq5PUC0haUrkai0QNmhD7HkHpNY7Kjg+ws1yeN7pg2bfGj4NyExw==}
     hasBin: true
 
-  '@webgpu/types@0.1.68':
-    resolution: {integrity: sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==}
-
   '@zeit/schemas@2.36.0':
     resolution: {integrity: sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==}
 
@@ -5318,9 +5010,6 @@ packages:
 
   alien-signals@2.0.6:
     resolution: {integrity: sha512-P3TxJSe31bUHBiblg59oU1PpaWPtmxF9GhJ/cB7OkgJ0qN/ifFSKUI25/v8ZhsT+lIG6ac8DpTOplXxORX6F3Q==}
-
-  animejs@4.3.5:
-    resolution: {integrity: sha512-yuQo/r97TCE+DDu3dTRKjyhBKSEGBcZorWeRW7WCE7EkAQpBoNd2E82dAAD/MDdrbREv7qsw/u7MAqiUX544WQ==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -6150,10 +5839,6 @@ packages:
     resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
     engines: {node: '>=10'}
 
-  deno@2.6.8:
-    resolution: {integrity: sha512-eJ+D9eu4YUtfec3F4nFRK06TKrGH+S8BasyqKIi2vKD11fI5kmgjYu08B4eheyQrfHj5hjGvB/dCdkfsAlsLzA==}
-    hasBin: true
-
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -6430,11 +6115,6 @@ packages:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
       esbuild: '>=0.12 <1'
-
-  esbuild-wasm@0.27.2:
-    resolution: {integrity: sha512-eUTnl8eh+v8UZIZh4MrMOKDAc8Lm7+NqP3pyuTORGFY1s/o9WoiJgKnwXy+te2J3hX7iRbFSHEyig7GsPeeJyw==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -7907,9 +7587,6 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  meshoptimizer@0.22.0:
-    resolution: {integrity: sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==}
-
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
@@ -8058,10 +7735,6 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -9506,9 +9179,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  three@0.182.0:
-    resolution: {integrity: sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==}
-
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
@@ -10942,26 +10612,6 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
-
-  '@deno/darwin-arm64@2.6.8':
-    optional: true
-
-  '@deno/darwin-x64@2.6.8':
-    optional: true
-
-  '@deno/linux-arm64-glibc@2.6.8':
-    optional: true
-
-  '@deno/linux-x64-glibc@2.6.8':
-    optional: true
-
-  '@deno/win32-arm64@2.6.8':
-    optional: true
-
-  '@deno/win32-x64@2.6.8':
-    optional: true
-
-  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -13212,13 +12862,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@react-router/fs-routes@7.13.0(@react-router/dev@7.13.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3))(@types/node@25.2.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(wrangler@4.63.0(@cloudflare/workers-types@4.20260128.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(yaml@2.8.2))(typescript@5.9.3)':
-    dependencies:
-      '@react-router/dev': 7.13.0(@react-router/serve@7.13.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3))(@types/node@25.2.1)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(wrangler@4.63.0(@cloudflare/workers-types@4.20260128.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10))(yaml@2.8.2)
-      minimatch: 9.0.5
-    optionalDependencies:
-      typescript: 5.9.3
-
   '@react-router/node@7.12.0(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)':
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
@@ -13944,8 +13587,6 @@ snapshots:
       '@tufjs/canonical-json': 2.0.0
       minimatch: 10.1.1
 
-  '@tweenjs/tween.js@23.1.3': {}
-
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -13997,7 +13638,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 25.2.1
 
   '@types/debug@4.1.12':
     dependencies:
@@ -14056,8 +13697,6 @@ snapshots:
 
   '@types/mdx@2.0.13': {}
 
-  '@types/mime-types@3.0.1': {}
-
   '@types/ms@2.1.0': {}
 
   '@types/node@12.20.55': {}
@@ -14104,18 +13743,6 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
-  '@types/stats.js@0.17.4': {}
-
-  '@types/three@0.182.0':
-    dependencies:
-      '@dimforge/rapier3d-compat': 0.12.0
-      '@tweenjs/tween.js': 23.1.3
-      '@types/stats.js': 0.17.4
-      '@types/webxr': 0.5.24
-      '@webgpu/types': 0.1.68
-      fflate: 0.8.2
-      meshoptimizer: 0.22.0
-
   '@types/tmp@0.2.6': {}
 
   '@types/trusted-types@2.0.7':
@@ -14127,11 +13754,9 @@ snapshots:
 
   '@types/uuid@8.3.4': {}
 
-  '@types/webxr@0.5.24': {}
-
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 12.20.55
+      '@types/node': 25.2.1
 
   '@types/ws@8.18.1':
     dependencies:
@@ -14548,8 +14173,6 @@ snapshots:
       multiformats: 13.4.2
       sade: 1.8.1
 
-  '@webgpu/types@0.1.68': {}
-
   '@zeit/schemas@2.36.0': {}
 
   '@zkochan/js-yaml@0.0.7':
@@ -14622,8 +14245,6 @@ snapshots:
       uri-js: 4.4.1
 
   alien-signals@2.0.6: {}
-
-  animejs@4.3.5: {}
 
   anser@1.4.10: {}
 
@@ -15536,15 +15157,6 @@ snapshots:
 
   delay@5.0.0: {}
 
-  deno@2.6.8:
-    optionalDependencies:
-      '@deno/darwin-arm64': 2.6.8
-      '@deno/darwin-x64': 2.6.8
-      '@deno/linux-arm64-glibc': 2.6.8
-      '@deno/linux-x64-glibc': 2.6.8
-      '@deno/win32-arm64': 2.6.8
-      '@deno/win32-x64': 2.6.8
-
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -15790,8 +15402,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  esbuild-wasm@0.27.2: {}
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -17727,8 +17337,6 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  meshoptimizer@0.22.0: {}
-
   methods@1.1.2: {}
 
   metro-babel-transformer@0.83.3:
@@ -18057,10 +17665,6 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -19771,8 +19375,6 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-
-  three@0.182.0: {}
 
   throat@5.0.0: {}
 

--- a/vibes.diy/api/svc/intern/import-map.ts
+++ b/vibes.diy/api/svc/intern/import-map.ts
@@ -206,8 +206,13 @@ export async function svcImportMap(
     "use-vibes": "/dist/use-vibes/pkg/index.js",
     "use-fireproof": "/dist/use-vibes/pkg/index.js",
 
+    "@vibes.diy/api-pkg": "/dist/api-pkg/index.js",
+    "@vibes.diy/api-types": "/dist/api-types/index.js",
+    "@vibes.diy/call-ai-v2": "/dist/call-ai-v2/index.js",
     "@vibes.diy/prompts": "/dist/prompts/pkg/index.js",
     "@vibes.diy/use-vibes-base": "/dist/use-vibes/base/index.js",
+    arktype: "https://esm.sh/arktype",
+    mime: "https://esm.sh/mime",
 
     "@fireproof/core-base": "FP",
     "@fireproof/core-blockstore": "FP",

--- a/vibes.diy/api/svc/intern/render-vibes.tsx
+++ b/vibes.diy/api/svc/intern/render-vibes.tsx
@@ -33,7 +33,7 @@ export async function renderVibes(
       if (item.mimeType === "application/javascript") {
         acc.push({
           // import relative to support prod and dev switching
-          importStmt: `import * as V${idx} from ${JSON.stringify(item.fileName.replace(/^\//, ""))};`,
+          importStmt: `import * as V${idx} from ${JSON.stringify(item.fileName.replace(/^\//, "./"))};`,
           var: `V${idx}`,
         });
       }
@@ -71,7 +71,7 @@ export async function renderVibes(
     mountJS: [
       `import { mountVibe } from '@vibes.diy/api-pkg';`,
       ...imports.map((i) => i.importStmt),
-      `mountVibe(${JSON.stringify(imports.map((i) => i.var))}, ${JSON.stringify(env)});`,
+      `mountVibe([${imports.map((i) => `${i.var}.default`).join(", ")}], ${JSON.stringify({ bindings: { appSlug: fs.appSlug, userSlug: fs.userSlug, fsId: fs.fsId }, env })});`,
     ].join("\n"),
   };
   const res = await exception2Result(() =>

--- a/vibes.diy/pkg/drizzle.d1-local-backend.config.ts
+++ b/vibes.diy/pkg/drizzle.d1-local-backend.config.ts
@@ -7,7 +7,9 @@ function getLocalD1DB(): string {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   $.sync`wrangler --config ./wrangler.toml d1 execute dev-vibes-diy-v2 --local --command="select 1"`;
   const basePath = path.resolve(".wrangler");
-  const dbFile = fs.readdirSync(basePath, { encoding: "utf-8", recursive: true }).find((f) => f.endsWith(".sqlite"));
+  const dbFile = fs
+    .readdirSync(basePath, { encoding: "utf-8", recursive: true })
+    .find((f) => f.endsWith(".sqlite") && f.includes("d1/"));
 
   if (!dbFile) {
     throw new Error(`.sqlite file not found in ${basePath}`);

--- a/vibes.diy/pkg/package.json
+++ b/vibes.diy/pkg/package.json
@@ -17,6 +17,7 @@
     "build:prod": "CLOUDFLARE_ENV=prod react-router build",
     "deploy:dev": "CLOUDFLARE_ENV=dev react-router build && wrangler deploy",
     "deploy:prod": "CLOUDFLARE_ENV=prod react-router build && wrangler deploy",
+    "build:dist": "bash scripts/build-dist.sh",
     "format:write": "prettier --write ."
   },
   "dependencies": {

--- a/vibes.diy/pkg/scripts/build-dist.sh
+++ b/vibes.diy/pkg/scripts/build-dist.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Builds workspace packages into public/dist/ for browser import map resolution.
+# Run from vibes.diy/pkg/ via: pnpm build:dist
+
+DIST=public/dist
+rm -rf "$DIST"
+mkdir -p "$DIST"
+
+TSGO_FLAGS="--ignoreConfig --target es2022 --module nodenext --moduleResolution nodenext --jsx react --rewriteRelativeImportExtensions --skipLibCheck --declaration false"
+
+pnpm exec tsgo $TSGO_FLAGS --outDir "$DIST/api-pkg"      --rootDir ../api/pkg       ../api/pkg/index.ts
+pnpm exec tsgo $TSGO_FLAGS --outDir "$DIST/api-types"     --rootDir ../api/types     ../api/types/index.ts
+pnpm exec tsgo $TSGO_FLAGS --outDir "$DIST/call-ai-v2"    --rootDir ../../call-ai/v2 ../../call-ai/v2/index.ts
+pnpm exec tsgo $TSGO_FLAGS --outDir "$DIST/prompts/pkg"   --rootDir ../../prompts/pkg ../../prompts/pkg/index.ts
+pnpm exec tsgo $TSGO_FLAGS --outDir "$DIST/use-vibes/base" --rootDir ../../use-vibes/base ../../use-vibes/base/index.ts
+pnpm exec tsgo $TSGO_FLAGS --outDir "$DIST/use-vibes/pkg"  --rootDir ../../use-vibes/pkg  ../../use-vibes/pkg/index.ts
+
+# Fix .jsx → .js in imports (tsgo converts .tsx → .jsx instead of .js)
+find "$DIST" -name "*.js" -exec sed -i '' 's/\.jsx"/\.js"/g; s/\.jsx'"'"'/\.js'"'"'/g' {} +
+
+echo "Built dist packages to $DIST"

--- a/vibes.diy/pkg/slack/serve/importmap.tsx
+++ b/vibes.diy/pkg/slack/serve/importmap.tsx
@@ -129,8 +129,13 @@ export function ImportMap(prop?: Partial<VibesDiyServCtx>) {
     "use-vibes": "/dist/use-vibes/pkg/index.js",
     "use-fireproof": "/dist/use-vibes/pkg/index.js",
 
+    "@vibes.diy/api-pkg": "/dist/api-pkg/index.js",
+    "@vibes.diy/api-types": "/dist/api-types/index.js",
+    "@vibes.diy/call-ai-v2": "/dist/call-ai-v2/index.js",
     "@vibes.diy/prompts": "/dist/prompts/pkg/index.js",
     "@vibes.diy/use-vibes-base": "/dist/use-vibes/base/index.js",
+    arktype: "https://esm.sh/arktype",
+    mime: "https://esm.sh/mime",
 
     "@fireproof/core-base": "FP",
     "@fireproof/core-blockstore": "FP",

--- a/vibes.diy/pkg/workers/app.ts
+++ b/vibes.diy/pkg/workers/app.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, ExportedHandler, Request as CFRequest, Response as CFResponse } from "@cloudflare/workers-types";
+import { ExecutionContext, ExportedHandler, Request as CFRequest, Response as CFResponse, CacheStorage } from "@cloudflare/workers-types";
 import { createRequestHandler } from "react-router";
 
 // @ts-expect-error - virtual module provided by React Router
@@ -6,13 +6,12 @@ import * as serverBuild from "virtual:react-router/server-build";
 import { Env } from "./env.js";
 
 export { ChatSessions } from "./chat-sessions.js";
-// import { cfServe } from "@vibes.diy/api-svc";
-// import { CfCacheIf } from "@vibes.diy/api-svc/api.js";
+import { cfServe, CFInject } from "@vibes.diy/api-svc/cf-serve.js";
+import { CfCacheIf } from "@vibes.diy/api-svc/api.js";
+import { WSSendProvider } from "@vibes.diy/api-svc/svc-ws-send-provider.js";
 
-// declare const caches: CacheStorage;
+declare const caches: CacheStorage & { default: CfCacheIf };
 const requestHandler = createRequestHandler(serverBuild, import.meta.env.MODE);
-
-// declare const WebSocketPair: typeof WebSocketPairType;
 
 export default {
   async fetch(request: CFRequest, env: Env, ctx: ExecutionContext): Promise<CFResponse> {
@@ -20,14 +19,18 @@ export default {
     if (url.pathname === "/api" || url.pathname.startsWith("/api/")) {
       const id = env.CHAT_SESSIONS.idFromName("global");
       const obj = env.CHAT_SESSIONS.get(id);
-      return obj.fetch(request); // Dummy fetch to ensure DO is initialized
+      return obj.fetch(request);
     }
-    if (url.hostname.endsWith(env.VIBES_SVC_HOSTNAME_BASE)) {
-      // const cctx = ctx as unknown as ExecutionContext & { cache: CfCacheIf };
-      // cctx.cache = caches.default as unknown as CfCacheIf;
-      // console.log("Doing cfServe for", url.href);
-      // return cfServe(request, env, cctx);
-      throw new Error("cfServe path disabled in app worker");
+    if (url.hostname.endsWith(env.VIBES_SVC_HOSTNAME_BASE) && !url.pathname.startsWith("/dist/") && !url.pathname.startsWith("/serve/")) {
+      const cctx = {
+        ...ctx,
+        cache: caches.default,
+        connections: new Set<WSSendProvider>(),
+        webSocketPair: () => {
+          throw new Error("WebSocket not supported in app worker");
+        },
+      } as unknown as ExecutionContext & CFInject;
+      return cfServe(request, env, cctx);
     }
 
     // Delegate to React Router for SSR


### PR DESCRIPTION
## Summary
- Enables cfServe in app worker for sandbox subdomain requests, with `/dist/` and `/serve/` passthrough to vite
- Adds browser import map entries for `@vibes.diy/api-pkg` and supporting packages
- Adds `pnpm build:dist` script to transpile 6 workspace packages into `public/dist/` for local dev (tsgo + jsx fix)
- Fixes drizzle config to target D1 sqlite files
- Fixes render-vibes.tsx relative path resolution for `~~transformed~~` imports

## Test plan
- [ ] `pnpm build:dist` from `vibes.diy/pkg/` builds all 6 packages to `public/dist/`
- [ ] `pnpm dev` serves sandbox URLs (e.g. `appSlug--userSlug.localhost:8888/`)
- [ ] No console errors on sandbox app load
- [ ] Existing routes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)