### PR TITLE
feat: add pluggable AssetProvider with R2 support

### DIFF
--- a/vibes.diy/api/svc/cf-env.ts
+++ b/vibes.diy/api/svc/cf-env.ts
@@ -1,7 +1,9 @@
-import { D1Database } from "@cloudflare/workers-types";
+import type { D1Database } from "@cloudflare/workers-types";
+import type { R2BucketIf } from "./intern/asset-provider.js";
 
 export interface Env {
   DB: D1Database;
+  ASSETS_BUCKET?: R2BucketIf;
   ENVIRONMENT: string;
   VIBES_SVC_HOSTNAME_BASE: string;
   // Add more bindings here as needed

--- a/vibes.diy/api/svc/intern/asset-provider.ts
+++ b/vibes.diy/api/svc/intern/asset-provider.ts
@@ -1,0 +1,441 @@
+import { BuildURI, exception2Result, Option, Result, URI } from "@adviser/cement";
+import { inArray } from "drizzle-orm";
+import type { VibesSqlite } from "../create-handler.js";
+import { sqlAssets } from "../sql/vibes-diy-api-schema.js";
+
+export interface AssetPutItem {
+  cid: string;
+  data: Uint8Array;
+}
+
+export interface AssetPutResult {
+  url: string;
+}
+
+export type AssetGetContent = Uint8Array | ReadableStream<Uint8Array>;
+export type AssetGetResult = Result<Option<AssetGetContent>>;
+
+export type AssetPutItemResult = { ok: true; value: AssetPutResult } | { ok: false; error: Error };
+
+export interface SuccessfulAssetPutRow<TInput> {
+  input: TInput;
+  result: Extract<AssetPutItemResult, { ok: true }>;
+}
+
+export function collectSuccessfulAssetPutRows<TInput>(
+  inputs: readonly TInput[],
+  putResults: readonly AssetPutItemResult[],
+  getCid: (input: TInput) => string
+): Result<SuccessfulAssetPutRow<TInput>[], Error> {
+  if (putResults.length !== inputs.length) {
+    return Result.Err(new Error(`Asset provider returned ${putResults.length} results for ${inputs.length} items`));
+  }
+
+  const failures: string[] = [];
+  const rows: SuccessfulAssetPutRow<TInput>[] = [];
+  for (let index = 0; index < inputs.length; index++) {
+    const input = inputs[index];
+    const result = putResults[index];
+    if (input === undefined || result === undefined) {
+      return Result.Err(new Error(`internal error: missing put input/result at index=${index}`));
+    }
+    if (result.ok === false) {
+      failures.push(`${getCid(input)}(${result.error.message})`);
+      continue;
+    }
+    rows.push({ input, result });
+  }
+
+  if (failures.length > 0) {
+    return Result.Err(new Error(`Asset put failed for ${failures.length} item${failures.length > 1 ? "s" : ""}: ${failures.join(", ")}`));
+  }
+
+  return Result.Ok(rows);
+}
+
+export type AssetProviderFatalCode =
+  | "MISCONFIGURED_BACKENDS"
+  | "BACKEND_PUT_RESULT_COUNT_MISMATCH"
+  | "BACKEND_GET_RESULT_COUNT_MISMATCH";
+
+export interface AssetProviderFatalError extends Error {
+  readonly type: "asset-provider-fatal";
+  readonly code: AssetProviderFatalCode;
+}
+
+class AssetProviderFatal extends Error implements AssetProviderFatalError {
+  readonly type = "asset-provider-fatal";
+  readonly code: AssetProviderFatalCode;
+
+  constructor(message: string, code: AssetProviderFatalCode) {
+    super(message);
+    this.name = "AssetProviderFatal";
+    this.code = code;
+  }
+}
+
+function makeAssetProviderFatalError(message: string, code: AssetProviderFatalCode): AssetProviderFatalError {
+  return new AssetProviderFatal(message, code);
+}
+
+export interface AssetBackend {
+  readonly protocol: string;
+  puts(items: AssetPutItem[]): Promise<AssetPutItemResult[]>;
+  gets(urls: string[]): Promise<AssetGetResult[]>;
+  canGet(url: string): boolean;
+}
+
+export interface AssetSelector {
+  select(backends: AssetBackend[], item: AssetPutItem): AssetBackend;
+}
+
+export interface AssetProvider {
+  puts(items: AssetPutItem[]): Promise<Result<AssetPutItemResult[], AssetProviderFatalError>>;
+  gets(urls: string[]): Promise<Result<AssetGetResult[], AssetProviderFatalError>>;
+}
+
+export interface R2BucketIf {
+  put(key: string, value: Uint8Array): Promise<unknown>;
+  get(
+    key: string
+  ): Promise<{ body: ReadableStream<Uint8Array> | null; arrayBuffer(): Promise<ArrayBuffer> } | null>;
+}
+
+export function createAssetProvider(backends: AssetBackend[], selector: AssetSelector): AssetProvider {
+  return {
+    async puts(items) {
+      if (items.length === 0) return Result.Ok([]);
+      if (backends.length === 0) {
+        return Result.Err(makeAssetProviderFatalError("AssetProvider requires at least one backend", "MISCONFIGURED_BACKENDS"));
+      }
+
+      // Group items by backend while preserving original positional indexes.
+      const byBackend = new Map<AssetBackend, { index: number; item: AssetPutItem }[]>();
+      for (let index = 0; index < items.length; index++) {
+        const item = items[index];
+        const backend = selector.select(backends, item);
+        const current = byBackend.get(backend);
+        if (current !== undefined) {
+          current.push({ index, item });
+          continue;
+        }
+        byBackend.set(backend, [{ index, item }]);
+      }
+
+      const backendResults = await Promise.all(
+        Array.from(byBackend.entries()).map(async ([backend, batch]) => {
+          const results = await backend.puts(batch.map((entry) => entry.item));
+          if (results.length !== batch.length) {
+            return {
+              ok: false as const,
+              error: makeAssetProviderFatalError(
+                `Backend protocol=${backend.protocol} returned ${results.length} put results for ${batch.length} input items`,
+                "BACKEND_PUT_RESULT_COUNT_MISMATCH"
+              ),
+            };
+          }
+          return { ok: true as const, batch, results };
+        })
+      );
+      const out: AssetPutItemResult[] = new Array(items.length);
+      for (const backendResult of backendResults) {
+        if (backendResult.ok === false) {
+          return Result.Err(backendResult.error);
+        }
+        const { batch, results } = backendResult;
+        for (let index = 0; index < batch.length; index++) {
+          out[batch[index].index] = results[index];
+        }
+      }
+      return Result.Ok(out);
+    },
+
+    async gets(urls) {
+      if (urls.length === 0) return Result.Ok([]);
+      if (backends.length === 0) {
+        return Result.Err(makeAssetProviderFatalError("AssetProvider requires at least one backend", "MISCONFIGURED_BACKENDS"));
+      }
+
+      // Group URLs by backend while preserving original positional indexes.
+      const byBackend = new Map<AssetBackend, { index: number; url: string }[]>();
+      const out: AssetGetResult[] = urls.map(() => Result.Ok(Option.None()));
+      for (let index = 0; index < urls.length; index++) {
+        const url = urls[index];
+        const backend = backends.find((b) => b.canGet(url));
+        if (backend === undefined) {
+          out[index] = Result.Err(new Error(`No backend configured to handle asset URL: ${url}`));
+          continue;
+        }
+        const current = byBackend.get(backend);
+        if (current !== undefined) {
+          current.push({ index, url });
+          continue;
+        }
+        byBackend.set(backend, [{ index, url }]);
+      }
+
+      const backendResults = await Promise.all(
+        Array.from(byBackend.entries()).map(async ([backend, batch]) => {
+          const results = await backend.gets(batch.map((entry) => entry.url));
+          if (results.length !== batch.length) {
+            return {
+              ok: false as const,
+              error: makeAssetProviderFatalError(
+                `Backend protocol=${backend.protocol} returned ${results.length} get results for ${batch.length} input URLs`,
+                "BACKEND_GET_RESULT_COUNT_MISMATCH"
+              ),
+            };
+          }
+          return { ok: true as const, batch, results };
+        })
+      );
+      for (const backendResult of backendResults) {
+        if (backendResult.ok === false) {
+          return Result.Err(backendResult.error);
+        }
+        const { batch, results } = backendResult;
+        for (let index = 0; index < batch.length; index++) {
+          out[batch[index].index] = results[index];
+        }
+      }
+      return Result.Ok(out);
+    },
+  };
+}
+
+export function buildAssetUrl(protocol: string, cid: string): string {
+  return BuildURI.from(`${protocol}://`).setParam("cid", cid).toString();
+}
+
+export interface ParsedAssetUrl {
+  protocol: string;
+  cid: string | undefined;
+}
+
+export function parseAssetUrl(url: string): Option<ParsedAssetUrl> {
+  const result = exception2Result(() => {
+    const parsed = URI.from(url);
+    const protocol = parsed.protocol.replace(/:$/, "");
+
+    // Reject file: - indicates malformed URL (cement returns file: for URLs without ://)
+    if (protocol === "file") return null;
+
+    const cid = parsed.getParam("cid");
+    return { protocol, cid };
+  });
+
+  if (result.isErr()) {
+    return Option.None();
+  }
+
+  const value = result.Ok();
+  if (value === null) {
+    return Option.None();
+  }
+
+  return Option.Some(value);
+}
+
+export function createSqliteBackend(db: VibesSqlite): AssetBackend {
+  return {
+    protocol: "sql",
+    async puts(items) {
+      if (items.length === 0) return [];
+
+      const created = new Date().toISOString();
+      const r = await exception2Result(() =>
+        db
+          .insert(sqlAssets)
+          .values(items.map((item) => ({ assetId: item.cid, content: item.data, created })))
+          .onConflictDoNothing()
+          .run()
+      );
+
+      if (r.isErr()) {
+        // Batch failed - return error for all items
+        return items.map(() => ({ ok: false, error: r.Err() }));
+      }
+
+      // All succeeded
+      return items.map((item) => ({
+        ok: true,
+        value: { url: buildAssetUrl("sql", item.cid) },
+      }));
+    },
+
+    canGet(url) {
+      const parsed = parseAssetUrl(url);
+      return parsed.IsSome() && parsed.unwrap().protocol === "sql";
+    },
+
+    async gets(urls) {
+      if (urls.length === 0) return [];
+
+      // Parse all URLs to extract CIDs
+      const parsed = urls.map((url) => parseAssetUrl(url));
+      const cids = parsed
+        .map((p, idx) => (p.IsSome() ? { cid: p.unwrap().cid, index: idx } : null))
+        .filter((item): item is { cid: string | undefined; index: number } => item !== null)
+        .filter((item): item is { cid: string; index: number } => item.cid !== undefined);
+
+      if (cids.length === 0) {
+        return urls.map(() => Result.Ok(Option.None()));
+      }
+
+      // Single batch SELECT with WHERE IN
+      const r = await exception2Result(() =>
+        db
+          .select()
+          .from(sqlAssets)
+          .where(inArray(sqlAssets.assetId, cids.map((c) => c.cid)))
+          .all()
+      );
+
+      if (r.isErr()) {
+        return urls.map(() => Result.Err(r.Err()));
+      }
+
+      // Map back to original order
+      const assetMap = new Map(r.Ok().map((a) => [a.assetId, a]));
+      return parsed.map((p) => {
+        if (p.IsNone()) return Result.Ok(Option.None());
+        const parsedUrl = p.unwrap();
+        if (parsedUrl.cid === undefined) return Result.Ok(Option.None());
+        const asset = assetMap.get(parsedUrl.cid);
+        if (asset === undefined) return Result.Ok(Option.None());
+        if (!(asset.content instanceof ArrayBuffer)) {
+          return Result.Err(new Error(`Asset ${parsedUrl.cid} has invalid content type`));
+        }
+        return Result.Ok(Option.Some(new Uint8Array(asset.content)));
+      });
+    },
+  };
+}
+
+export function createR2Backend(bucket: R2BucketIf): AssetBackend {
+  return {
+    protocol: "r2",
+    async puts(items) {
+      if (items.length === 0) return [];
+
+      // R2 doesn't have batch API - use Promise.all for parallelism
+      return Promise.all(
+        items.map(async (item) => {
+          const r = await exception2Result(() => bucket.put(item.cid, item.data));
+          if (r.isErr()) {
+            return { ok: false, error: r.Err() };
+          }
+          return { ok: true, value: { url: buildAssetUrl("r2", item.cid) } };
+        })
+      );
+    },
+
+    canGet(url) {
+      const parsed = parseAssetUrl(url);
+      return parsed.IsSome() && parsed.unwrap().protocol === "r2";
+    },
+
+    async gets(urls) {
+      if (urls.length === 0) return [];
+
+      const parsed = urls.map((url) => parseAssetUrl(url));
+
+      // Parallel fetches
+      return Promise.all(
+        parsed.map(async (p) => {
+          if (p.IsNone()) return Result.Ok(Option.None());
+          const parsedUrl = p.unwrap();
+          if (parsedUrl.cid === undefined) return Result.Ok(Option.None());
+          const cid = parsedUrl.cid;
+
+          const r = await exception2Result(() => bucket.get(cid));
+          if (r.isErr()) {
+            return Result.Err(r.Err());
+          }
+
+          const obj = r.Ok();
+          if (obj === null || obj.body === null) return Result.Ok(Option.None());
+          return Result.Ok(Option.Some(obj.body));
+        })
+      );
+    },
+  };
+}
+
+export function createFirstSelector(): AssetSelector {
+  return {
+    select(backends) {
+      return backends[0];
+    },
+  };
+}
+
+export function createSizeSelector(threshold: number, allBackends: AssetBackend[]): AssetSelector {
+  const largeBackend = allBackends.find((b) => b.protocol === "r2") ?? allBackends[0];
+  const smallBackend = allBackends.find((b) => b.protocol === "sql") ?? allBackends[0];
+  return {
+    select(_backends, item) {
+      return item.data.byteLength > threshold ? largeBackend : smallBackend;
+    },
+  };
+}
+
+export function parseAsSetup(
+  asSetup: string,
+  bindings: { db: VibesSqlite; r2Bucket?: R2BucketIf }
+): Result<{ backends: AssetBackend[]; selector: AssetSelector }, Error> {
+  const backends: AssetBackend[] = [];
+  let sizeThreshold: number | undefined;
+  for (const entry of asSetup.split(",").map((s) => s.trim()).filter(Boolean)) {
+    const uriResult = exception2Result(() => URI.from(entry));
+    if (uriResult.isErr()) {
+      return Result.Err(new Error(`Invalid AS_SETUP entry "${entry}": ${uriResult.Err().message}`));
+    }
+    const uri = uriResult.Ok();
+    switch (uri.protocol) {
+      case "sqlite:":
+        backends.push(createSqliteBackend(bindings.db));
+        break;
+      case "r2:":
+        if (bindings.r2Bucket === undefined) {
+          return Result.Err(new Error("AS_SETUP references r2: but no R2 bucket binding provided"));
+        }
+        backends.push(createR2Backend(bindings.r2Bucket));
+        {
+          const t = uri.getParam("threshold");
+          if (t != null) {
+            const n = Number(t);
+            if (Number.isFinite(n) === false || Number.isInteger(n) === false || n < 0) {
+              return Result.Err(new Error(`Invalid r2 threshold (expected non-negative integer bytes): ${t}`));
+            }
+            sizeThreshold = n;
+          }
+        }
+        break;
+      default:
+        return Result.Err(new Error(`Unknown AS_SETUP backend protocol: ${uri.protocol}. Supported: sqlite:, r2:`));
+    }
+  }
+  if (backends.length === 0) {
+    return Result.Err(new Error("AS_SETUP produced no backends"));
+  }
+  const selector = sizeThreshold != null ? createSizeSelector(sizeThreshold, backends) : createFirstSelector();
+  return Result.Ok({ backends, selector });
+}
+
+export function createAssetProviderFromEnv(
+  db: VibesSqlite,
+  env: Record<string, string>,
+  r2Bucket?: R2BucketIf
+): Result<AssetProvider, Error> {
+  const asSetup = env.AS_SETUP;
+  if (asSetup) {
+    const result = parseAsSetup(asSetup, { db, r2Bucket });
+    if (result.isErr()) {
+      return Result.Err(result.Err());
+    }
+    const { backends, selector } = result.Ok();
+    return Result.Ok(createAssetProvider(backends, selector));
+  }
+  return Result.Ok(createAssetProvider([createSqliteBackend(db)], createFirstSelector()));
+}

--- a/vibes.diy/api/svc/intern/ensure-storage.ts
+++ b/vibes.diy/api/svc/intern/ensure-storage.ts
@@ -26,37 +26,3 @@ export async function calcCid({ sthis }: { sthis: SuperThis }, content: CoerceBi
     },
   };
 }
-
-export function ensureStorage(
-  db: VibesSqlite
-): (...items: { cid: string; data: Uint8Array }[]) => Promise<Result<StorageResult[]>> {
-  return async (...items: { cid: string; data: Uint8Array }[]): Promise<Result<StorageResult[]>> => {
-    const now = new Date();
-    const created = now.toISOString();
-    const res = await exception2Result(() =>
-      db
-        .insert(sqlAssets)
-        .values(
-          items.map((item) => ({
-            assetId: item.cid,
-            content: item.data,
-            created,
-          }))
-        )
-        .onConflictDoNothing()
-        .run()
-    );
-    if (res.isErr()) {
-      return Result.Err(res);
-    }
-    return Result.Ok(
-      items.map((item) => ({
-        cid: item.cid,
-        getURL: `sql://Assets/${item.cid}`,
-        mode: "existing",
-        created: now,
-        size: item.data.byteLength,
-      }))
-    );
-  };
-}

--- a/vibes.diy/api/svc/sql/vibes-diy-api-schema.ts
+++ b/vibes.diy/api/svc/sql/vibes-diy-api-schema.ts
@@ -3,7 +3,7 @@ import { int, sqliteTable, text, blob, primaryKey, uniqueIndex, index } from "dr
 
 // could be put on R2
 export const sqlAssets = sqliteTable("Assets", {
-  assetId: text().primaryKey(), // sql://Assets.assetId (CID of content)
+  assetId: text().primaryKey(), // CID of content, served as sql://?cid={assetId}
   content: blob().notNull(), // actual code content
   created: text().notNull(),
 });

--- a/vibes.diy/api/svc/types.ts
+++ b/vibes.diy/api/svc/types.ts
@@ -3,9 +3,10 @@ import { FPApiToken } from "@fireproof/core-types-protocols-dashboard";
 import { VibesSqlite } from "./create-handler.js";
 import { WSSendProvider } from "./svc-ws-send-provider.js";
 import { DeviceIdCAIf } from "@fireproof/core-types-device-id";
-import { Logger, Result } from "@adviser/cement";
+import { Logger } from "@adviser/cement";
 import { LLMRequest } from "@vibes.diy/call-ai-v2";
 import { LLMHeaders, VibesFPApiParameters } from "@vibes.diy/api-types";
+import type { AssetProvider } from "./intern/asset-provider.js";
 
 export interface StorageResult {
   cid: string;
@@ -33,7 +34,6 @@ export interface VibesApiSQLCtx {
   cache: CfCacheIf;
   fetchPkgVersion(pkg: string): Promise<string | undefined>;
   // waitUntil<T>(promise: Promise<T>): void;
-  ensureStorage(...items: { cid: string; data: Uint8Array }[]): Promise<Result<StorageResult[]>>;
-
+  assetProvider: AssetProvider;
   llmRequest(prompt: LLMRequest & { headers: LLMHeaders }): Promise<Response>;
 }

--- a/vibes.diy/api/tests/asset-provider.test.ts
+++ b/vibes.diy/api/tests/asset-provider.test.ts
@@ -1,0 +1,494 @@
+import { describe, expect, it } from "vitest";
+import {
+  AssetBackend,
+  AssetGetResult,
+  AssetPutItem,
+  AssetPutItemResult,
+  AssetProvider,
+  buildAssetUrl,
+  createAssetProvider,
+  createFirstSelector,
+  createSizeSelector,
+  parseAsSetup,
+  parseAssetUrl,
+} from "@vibes.diy/api-svc/intern/asset-provider.js";
+import { isReadableStreamContent } from "@vibes.diy/api-svc/intern/render-vibes.js";
+import type { VibesSqlite } from "@vibes.diy/api-svc/create-handler.js";
+import { Option, Result, stream2array, uint8array2stream } from "@adviser/cement";
+
+async function contentToUint8(content: Uint8Array | ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  if (isReadableStreamContent(content)) {
+    const chunks = await stream2array(content);
+    const total = chunks.reduce((n, c) => n + c.length, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+      out.set(c, offset);
+      offset += c.length;
+    }
+    return out;
+  }
+  return content;
+}
+
+async function expectOkPuts(ap: AssetProvider, items: AssetPutItem[]): Promise<AssetPutItemResult[]> {
+  const result = await ap.puts(items);
+  expect(result.isOk()).toBe(true);
+  return result.Ok();
+}
+
+async function expectOkGets(ap: AssetProvider, urls: string[]): Promise<AssetGetResult[]> {
+  const result = await ap.gets(urls);
+  expect(result.isOk()).toBe(true);
+  return result.Ok();
+}
+
+function createMemoryBackend(protocol: "sql" | "r2"): AssetBackend {
+  const store = new Map<string, Uint8Array>();
+  return {
+    protocol,
+    async puts(items: AssetPutItem[]): Promise<AssetPutItemResult[]> {
+      return items.map((item) => {
+        store.set(item.cid, item.data);
+        return { ok: true, value: { url: buildAssetUrl(protocol, item.cid) } };
+      });
+    },
+    canGet(url: string): boolean {
+      const parsed = parseAssetUrl(url);
+      return parsed.IsSome() && parsed.unwrap().protocol === protocol;
+    },
+    async gets(urls: string[]): Promise<AssetGetResult[]> {
+      return urls.map((url) => {
+        const parsed = parseAssetUrl(url);
+        const cid = parsed.IsSome() ? parsed.unwrap().cid : undefined;
+        if (cid === undefined) return Result.Ok(Option.None());
+        const found = store.get(cid);
+        if (found === undefined) return Result.Ok(Option.None());
+        if (protocol === "r2") {
+          return Result.Ok(Option.Some(uint8array2stream(found)));
+        }
+        return Result.Ok(Option.Some(found));
+      });
+    },
+  };
+}
+
+function createErrorBackend(protocol: string): AssetBackend {
+  return {
+    protocol,
+    async puts(items: AssetPutItem[]): Promise<AssetPutItemResult[]> {
+      return items.map(() => ({
+        ok: false,
+        error: new Error(`${protocol} put failed`),
+      }));
+    },
+    canGet(url: string): boolean {
+      const parsed = parseAssetUrl(url);
+      return parsed.IsSome() && parsed.unwrap().protocol === protocol;
+    },
+    async gets(urls: string[]): Promise<AssetGetResult[]> {
+      return urls.map(() => Result.Err(new Error(`${protocol} get failed`)));
+    },
+  };
+}
+
+describe("asset URL parsing", () => {
+  it("buildAssetUrl produces canonical format with ://", () => {
+    const sqlUrl = buildAssetUrl("sql", "zTestCid");
+    expect(sqlUrl).toMatch(/^sql:\/\//);
+    expect(sqlUrl).toContain("cid=zTestCid");
+
+    const r2Url = buildAssetUrl("r2", "zTestCid");
+    expect(r2Url).toMatch(/^r2:\/\//);
+    expect(r2Url).toContain("cid=zTestCid");
+  });
+
+  it("buildAssetUrl round-trips through parseAssetUrl", () => {
+    for (const protocol of ["sql", "r2"] as const) {
+      const url = buildAssetUrl(protocol, "zTestCid123");
+      const parsed = parseAssetUrl(url);
+      expect(parsed.IsSome()).toBe(true);
+      expect(parsed.unwrap().protocol).toBe(protocol);
+      expect(parsed.unwrap().cid).toBe("zTestCid123");
+    }
+  });
+
+  it("parseAssetUrl rejects URLs without ://", () => {
+    expect(parseAssetUrl("sql:?cid=zFoo").IsNone()).toBe(true);
+    expect(parseAssetUrl("r2:?cid=zBar").IsNone()).toBe(true);
+  });
+
+  it("parseAssetUrl accepts URLs with ://", () => {
+    const sql = parseAssetUrl("sql://?cid=zFoo");
+    expect(sql.IsSome()).toBe(true);
+    expect(sql.unwrap().protocol).toBe("sql");
+    const r2 = parseAssetUrl("r2://?cid=zBar");
+    expect(r2.IsSome()).toBe(true);
+    expect(r2.unwrap().protocol).toBe("r2");
+  });
+});
+
+describe("AssetProvider", () => {
+  it("puts and gets with multiple backends via selector", async () => {
+    const sqlBackend = createMemoryBackend("sql");
+    const r2Backend = createMemoryBackend("r2");
+    const selector = createSizeSelector(1024, [sqlBackend, r2Backend]);
+    const ap = createAssetProvider([sqlBackend, r2Backend], selector);
+
+    const small = { cid: "zSmall", data: new Uint8Array(100) };
+    const large = { cid: "zLarge", data: new Uint8Array(2000) };
+
+    const puts = await expectOkPuts(ap, [small, large]);
+    expect(puts[0]?.ok).toBe(true);
+    expect(puts[1]?.ok).toBe(true);
+    if (puts[0]?.ok) expect(puts[0].value.url).toMatch(/^sql:/);
+    if (puts[1]?.ok) expect(puts[1].value.url).toMatch(/^r2:/);
+
+    const urls = puts.map((p) => (p.ok ? p.value.url : ""));
+    const gets = await expectOkGets(ap, urls);
+    expect(gets[0].isOk()).toBe(true);
+    expect(gets[0].Ok().IsSome()).toBe(true);
+    expect(gets[1].isOk()).toBe(true);
+    expect(gets[1].Ok().IsSome()).toBe(true);
+    expect(await contentToUint8(gets[0].Ok().unwrap())).toEqual(small.data);
+    expect(await contentToUint8(gets[1].Ok().unwrap())).toEqual(large.data);
+  });
+
+  it("puts preserves order with interleaved backends", async () => {
+    const sqlBackend = createMemoryBackend("sql");
+    const r2Backend = createMemoryBackend("r2");
+    const selector = createSizeSelector(1024, [sqlBackend, r2Backend]);
+    const ap = createAssetProvider([sqlBackend, r2Backend], selector);
+
+    const items = [
+      { cid: "zSmall1", data: new Uint8Array(100) },
+      { cid: "zLarge1", data: new Uint8Array(2000) },
+      { cid: "zSmall2", data: new Uint8Array(200) },
+      { cid: "zLarge2", data: new Uint8Array(3000) },
+      { cid: "zSmall3", data: new Uint8Array(300) },
+    ];
+
+    const puts = await expectOkPuts(ap, items);
+    expect(puts).toHaveLength(5);
+    expect(puts[0]?.ok).toBe(true);
+    expect(puts[1]?.ok).toBe(true);
+    expect(puts[2]?.ok).toBe(true);
+    expect(puts[3]?.ok).toBe(true);
+    expect(puts[4]?.ok).toBe(true);
+  });
+
+  it("gets returns None per-item without aborting batch", async () => {
+    const sqlBackend = createMemoryBackend("sql");
+    const ap = createAssetProvider([sqlBackend], createFirstSelector());
+    const gets = await expectOkGets(ap, [buildAssetUrl("sql", "nonexistent"), buildAssetUrl("sql", "alsoMissing")]);
+    expect(gets).toHaveLength(2);
+    expect(gets[0].isOk()).toBe(true);
+    expect(gets[0].Ok().IsNone()).toBe(true);
+    expect(gets[1].isOk()).toBe(true);
+    expect(gets[1].Ok().IsNone()).toBe(true);
+  });
+
+  it("parseAsSetup creates backends from env string", () => {
+    const mockDb = {} as VibesSqlite;
+    const mockBucket = {
+      put: async () => undefined,
+      get: async () => null,
+    };
+    const result = parseAsSetup("sqlite://local,r2://bucket?threshold=4096", { db: mockDb, r2Bucket: mockBucket });
+    expect(result.isOk()).toBe(true);
+    const { backends } = result.Ok();
+    expect(backends).toHaveLength(2);
+    expect(backends[0]?.protocol).toBe("sql");
+    expect(backends[1]?.protocol).toBe("r2");
+  });
+
+  it("parseAsSetup returns error on empty", () => {
+    const mockDb = {} as VibesSqlite;
+    const result = parseAsSetup("", { db: mockDb });
+    expect(result.isErr()).toBe(true);
+    expect(result.Err().message).toContain("AS_SETUP produced no backends");
+  });
+
+  it("parseAsSetup returns error on unsupported protocol", () => {
+    const mockDb = {} as VibesSqlite;
+    const result = parseAsSetup("s3://bucket", { db: mockDb });
+    expect(result.isErr()).toBe(true);
+    expect(result.Err().message).toContain("Unknown AS_SETUP backend protocol");
+  });
+
+  it("parseAsSetup returns error on invalid r2 threshold", () => {
+    const mockDb = {} as VibesSqlite;
+    const mockBucket = {
+      put: async () => undefined,
+      get: async () => null,
+    };
+    const r1 = parseAsSetup("sqlite://local,r2://bucket?threshold=abc", { db: mockDb, r2Bucket: mockBucket });
+    expect(r1.isErr()).toBe(true);
+    expect(r1.Err().message).toContain("Invalid r2 threshold");
+
+    const r2 = parseAsSetup("sqlite://local,r2://bucket?threshold=-1", { db: mockDb, r2Bucket: mockBucket });
+    expect(r2.isErr()).toBe(true);
+    expect(r2.Err().message).toContain("Invalid r2 threshold");
+
+    const r3 = parseAsSetup("sqlite://local,r2://bucket?threshold=1.5", { db: mockDb, r2Bucket: mockBucket });
+    expect(r3.isErr()).toBe(true);
+    expect(r3.Err().message).toContain("Invalid r2 threshold");
+  });
+
+  it("puts results match argument positions", async () => {
+    const backend = createMemoryBackend("sql");
+    const ap = createAssetProvider([backend], createFirstSelector());
+    const items = [
+      { cid: "zFirst", data: new Uint8Array([1]) },
+      { cid: "zSecond", data: new Uint8Array([2]) },
+      { cid: "zThird", data: new Uint8Array([3]) },
+    ];
+    const puts = await expectOkPuts(ap, items);
+    expect(puts).toHaveLength(3);
+    for (let i = 0; i < items.length; i++) {
+      const r = puts[i];
+      expect(r?.ok).toBe(true);
+      if (r?.ok) {
+        const parsed = parseAssetUrl(r.value.url);
+        expect(parsed.IsSome()).toBe(true);
+        expect(parsed.unwrap().cid).toBe(items[i].cid);
+      }
+    }
+  });
+
+  it("gets results match argument positions", async () => {
+    const backend = createMemoryBackend("sql");
+    const ap = createAssetProvider([backend], createFirstSelector());
+    const items = [
+      { cid: "zA", data: new Uint8Array([10]) },
+      { cid: "zB", data: new Uint8Array([20]) },
+    ];
+    await expectOkPuts(ap, items);
+    const gets = await expectOkGets(ap, [buildAssetUrl("sql", "zB"), buildAssetUrl("sql", "zA")]);
+    expect(gets).toHaveLength(2);
+    expect(await contentToUint8(gets[0].Ok().unwrap())).toEqual(new Uint8Array([20]));
+    expect(await contentToUint8(gets[1].Ok().unwrap())).toEqual(new Uint8Array([10]));
+  });
+
+  it("error-only backend returns errors for all puts", async () => {
+    const backend = createErrorBackend("fail");
+    const ap = createAssetProvider([backend], createFirstSelector());
+    const puts = await expectOkPuts(ap, [
+      { cid: "z1", data: new Uint8Array(10) },
+      { cid: "z2", data: new Uint8Array(20) },
+    ]);
+    expect(puts).toHaveLength(2);
+    for (const r of puts) {
+      expect(r.ok).toBe(false);
+      if (r.ok === false) expect(r.error.message).toMatch(/fail put failed/);
+    }
+  });
+
+  it("error-only backend returns Err for all gets", async () => {
+    const backend = createErrorBackend("fail");
+    const ap = createAssetProvider([backend], createFirstSelector());
+    const gets = await expectOkGets(ap, [buildAssetUrl("fail", "z1"), buildAssetUrl("fail", "z2")]);
+    expect(gets).toHaveLength(2);
+    for (const r of gets) {
+      expect(r.isErr()).toBe(true);
+      expect(r.Err().message).toMatch(/fail get failed/);
+    }
+  });
+
+  it("mixed results: some puts succeed, some fail", async () => {
+    const good = createMemoryBackend("sql");
+    const bad = createErrorBackend("r2");
+    const selector = createSizeSelector(100, [good, bad]);
+    const ap = createAssetProvider([good, bad], selector);
+
+    const puts = await expectOkPuts(ap, [
+      { cid: "zSmall", data: new Uint8Array(50) },
+      { cid: "zBig", data: new Uint8Array(200) },
+    ]);
+    expect(puts).toHaveLength(2);
+    expect(puts[0]?.ok).toBe(true);
+    expect(puts[1]?.ok).toBe(false);
+    if (puts[0]?.ok) expect(puts[0].value.url).toContain("zSmall");
+    if (puts[1] && !puts[1].ok) expect(puts[1].error.message).toContain("r2 put failed");
+  });
+
+  it("gets with no matching backend returns per-item error", async () => {
+    const backend = createMemoryBackend("sql");
+    const ap = createAssetProvider([backend], createFirstSelector());
+    const result = await ap.gets([buildAssetUrl("unknown", "z1")]);
+    expect(result.isOk()).toBe(true);
+    const gets = result.Ok();
+    expect(gets).toHaveLength(1);
+    expect(gets[0].isErr()).toBe(true);
+    expect(gets[0].Err().message).toContain("No backend configured to handle asset URL");
+    expect(gets[0].Err().message).toContain("unknown://");
+  });
+
+  it("error results preserve positional puts and Err gets", async () => {
+    const backend = createErrorBackend("err");
+    const ap = createAssetProvider([backend], createFirstSelector());
+
+    const puts = await expectOkPuts(ap, [{ cid: "zMyCid", data: new Uint8Array(1) }]);
+    expect(puts[0]?.ok).toBe(false);
+
+    const gets = await expectOkGets(ap, [buildAssetUrl("err", "zMyCid")]);
+    expect(gets[0].isErr()).toBe(true);
+  });
+
+  it("puts preserves positional results for duplicate cids (no dedupe)", async () => {
+    const backend: AssetBackend = {
+      protocol: "track",
+      async puts(items) {
+        return items.map((item) => ({
+          ok: true,
+          value: { url: `track://${item.cid}-${item.data[0]}` },
+        }));
+      },
+      canGet() {
+        return false;
+      },
+      async gets() {
+        return [];
+      },
+    };
+    const ap = createAssetProvider([backend], createFirstSelector());
+    const puts = await expectOkPuts(ap, [
+      { cid: "zDup", data: new Uint8Array([1]) },
+      { cid: "zOther", data: new Uint8Array([9]) },
+      { cid: "zDup", data: new Uint8Array([2]) },
+    ]);
+
+    expect(puts).toHaveLength(3);
+    expect(puts[0]?.ok).toBe(true);
+    expect(puts[1]?.ok).toBe(true);
+    expect(puts[2]?.ok).toBe(true);
+    if (puts[0]?.ok) {
+      expect(puts[0].value.url).toBe("track://zDup-1");
+    }
+    if (puts[2]?.ok) {
+      expect(puts[2].value.url).toBe("track://zDup-2");
+    }
+  });
+
+  it("gets preserves order with duplicate URLs", async () => {
+    const backend = createMemoryBackend("sql");
+    const ap = createAssetProvider([backend], createFirstSelector());
+
+    await expectOkPuts(ap, [
+      { cid: "zDup", data: new Uint8Array([42]) },
+      { cid: "zOther", data: new Uint8Array([99]) },
+    ]);
+
+    const dupUrl = buildAssetUrl("sql", "zDup");
+    const otherUrl = buildAssetUrl("sql", "zOther");
+    const gets = await expectOkGets(ap, [dupUrl, otherUrl, dupUrl]);
+
+    expect(gets).toHaveLength(3);
+    expect(gets[0].isOk()).toBe(true);
+    expect(gets[1].isOk()).toBe(true);
+    expect(gets[2].isOk()).toBe(true);
+    expect(gets[0].Ok().IsSome()).toBe(true);
+    expect(gets[2].Ok().IsSome()).toBe(true);
+
+    const data0 = await contentToUint8(gets[0].Ok().unwrap());
+    expect(data0).toEqual(new Uint8Array([42]));
+  });
+
+  it("gets duplicate streamed URLs provide independent consumable streams", async () => {
+    const backend = createMemoryBackend("r2");
+    const ap = createAssetProvider([backend], createFirstSelector());
+    const expected = new Uint8Array([7, 8, 9]);
+    await expectOkPuts(ap, [{ cid: "zDupStream", data: expected }]);
+
+    const dupUrl = buildAssetUrl("r2", "zDupStream");
+    const gets = await expectOkGets(ap, [dupUrl, dupUrl]);
+
+    expect(gets).toHaveLength(2);
+    expect(gets[0].isOk()).toBe(true);
+    expect(gets[1].isOk()).toBe(true);
+    expect(gets[0].Ok().IsSome()).toBe(true);
+    expect(gets[1].Ok().IsSome()).toBe(true);
+
+    const content0 = gets[0].Ok().unwrap();
+    const content1 = gets[1].Ok().unwrap();
+    expect(isReadableStreamContent(content0)).toBe(true);
+    expect(isReadableStreamContent(content1)).toBe(true);
+    expect(content0).not.toBe(content1);
+
+    const [data0, data1] = await Promise.all([contentToUint8(content0), contentToUint8(content1)]);
+    expect(data0).toEqual(expected);
+    expect(data1).toEqual(expected);
+  });
+
+  it("puts returns fatal error on backend count mismatch", async () => {
+    const badBackend: AssetBackend = {
+      protocol: "bad",
+      async puts(items) {
+        return items.slice(0, -1).map((item) => ({
+          ok: true,
+          value: { url: buildAssetUrl("bad", item.cid) },
+        }));
+      },
+      canGet() {
+        return false;
+      },
+      async gets() {
+        return [];
+      },
+    };
+
+    const ap = createAssetProvider([badBackend], createFirstSelector());
+    const result = await ap.puts([
+      { cid: "z1", data: new Uint8Array(10) },
+      { cid: "z2", data: new Uint8Array(20) },
+    ]);
+
+    expect(result.isErr()).toBe(true);
+    const error = result.Err();
+    expect(error.type).toBe("asset-provider-fatal");
+    expect(error.code).toBe("BACKEND_PUT_RESULT_COUNT_MISMATCH");
+    expect(error.message).toContain("returned 1 put results for 2 input items");
+  });
+
+  it("gets returns fatal error on backend count mismatch", async () => {
+    const badBackend: AssetBackend = {
+      protocol: "bad",
+      async puts() {
+        return [];
+      },
+      canGet(url) {
+        return url.startsWith("bad://");
+      },
+      async gets(urls) {
+        return urls.slice(0, -1).map(() => Result.Ok(Option.None()));
+      },
+    };
+
+    const ap = createAssetProvider([badBackend], createFirstSelector());
+    const result = await ap.gets([buildAssetUrl("bad", "z1"), buildAssetUrl("bad", "z2")]);
+
+    expect(result.isErr()).toBe(true);
+    const error = result.Err();
+    expect(error.type).toBe("asset-provider-fatal");
+    expect(error.code).toBe("BACKEND_GET_RESULT_COUNT_MISMATCH");
+    expect(error.message).toContain("returned 1 get results for 2 input URLs");
+  });
+
+  it("gets preserves batch and returns per-item errors for unknown URLs", async () => {
+    const sqlBackend = createMemoryBackend("sql");
+    const ap = createAssetProvider([sqlBackend], createFirstSelector());
+
+    // Try to get URLs with invalid/unsupported protocols
+    const result = await ap.gets(["http://example.com/foo", "https://example.com/bar", buildAssetUrl("r2", "validCid")]);
+
+    expect(result.isOk()).toBe(true);
+    const gets = result.Ok();
+    expect(gets).toHaveLength(3);
+    expect(gets[0].isErr()).toBe(true);
+    expect(gets[1].isErr()).toBe(true);
+    expect(gets[2].isErr()).toBe(true);
+    expect(gets[0].Err().message).toContain("http://example.com/foo");
+    expect(gets[1].Err().message).toContain("https://example.com/bar");
+    expect(gets[2].Err().message).toContain("r2://");
+  });
+});

--- a/vibes.diy/api/tests/render-vibes-stream.test.ts
+++ b/vibes.diy/api/tests/render-vibes-stream.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { uint8array2stream } from "@adviser/cement";
+import { bufferContent } from "../svc/intern/render-vibes.js";
+
+describe("render-vibes bufferContent", () => {
+  const testData = new Uint8Array([1, 2, 3, 4, 5]);
+
+  it("should handle ReadableStream by buffering", async () => {
+    const stream = uint8array2stream(testData);
+    const result = await bufferContent(stream);
+    expect(result).toEqual(testData);
+  });
+
+  it("should handle Uint8Array directly", async () => {
+    const result = await bufferContent(testData);
+    expect(result).toEqual(testData);
+  });
+
+  it("should buffer multi-chunk streams correctly", async () => {
+    // Create a stream with multiple chunks
+    const chunk1 = new Uint8Array([1, 2, 3]);
+    const chunk2 = new Uint8Array([4, 5]);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(chunk1);
+        controller.enqueue(chunk2);
+        controller.close();
+      }
+    });
+
+    const result = await bufferContent(stream);
+    expect(result).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+  });
+});

--- a/vibes.diy/pkg/workers/boundary.ts
+++ b/vibes.diy/pkg/workers/boundary.ts
@@ -1,0 +1,64 @@
+import { AppContext } from "@adviser/cement";
+import { CFInjectMutable, cfServeAppCtx } from "@vibes.diy/api-svc/cf-serve.js";
+import type { VibesApiSQLCtx } from "@vibes.diy/api-svc/types.js";
+import type { ExecutionContext, Request as CFRequest, Response as CFResponse } from "@cloudflare/workers-types";
+import { Env } from "./env.js";
+
+declare const Response: typeof CFResponse;
+
+interface WorkerBoundaryContext {
+  appCtx: AppContext;
+  vibesCtx: VibesApiSQLCtx;
+}
+
+export function workerInternalErrorResponse(error: Error): CFResponse {
+  return new Response(
+    JSON.stringify({
+      type: "vibes.diy.error",
+      message: `Internal Server Error: ${error.message}`,
+    }),
+    {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+}
+
+function isCfResponse(response: Response | CFResponse): response is CFResponse {
+  return "getAll" in response.headers;
+}
+
+// Prefer pass-through for worker-native responses; only fallback-convert for non-worker responses.
+export async function cloneWebResponseAsCfResponse(webResponse: Response | CFResponse): Promise<CFResponse> {
+  if (isCfResponse(webResponse)) {
+    return webResponse;
+  }
+  const body = webResponse.body === null ? null : await webResponse.arrayBuffer();
+  return new Response(body, {
+    status: webResponse.status,
+    statusText: webResponse.statusText,
+    headers: [...webResponse.headers],
+  });
+}
+
+export async function withWorkerBoundaryContext<T extends CFResponse>({
+  request,
+  env,
+  cctx,
+  onContext,
+  onError,
+}: {
+  request: CFRequest;
+  env: Env;
+  cctx: ExecutionContext & CFInjectMutable;
+  onContext(ctx: WorkerBoundaryContext): Promise<T>;
+  onError(error: Error): T | Promise<T>;
+}): Promise<T> {
+  const rCfCtx = await cfServeAppCtx(request, env, cctx);
+  if (rCfCtx.isErr()) {
+    return onError(rCfCtx.Err());
+  }
+  const cfCtx = rCfCtx.Ok();
+  cctx.appCtx = cfCtx.appCtx;
+  return onContext(cfCtx);
+}


### PR DESCRIPTION
## Summary

Replaces monolithic `ensureStorage` with `AssetProvider` abstraction supporting multiple storage backends (SQLite, R2) configured via `AS_SETUP` env var.

## Key Changes

- **AssetProvider interface** with pluggable backends (SQLite, R2)
- **Per-item error semantics** - `puts/gets` return `(Ok|Error)[]` so one failure doesn't block others
- **Streaming get()** - Returns `ReadableStream` directly from R2, no buffering
- **Size-based routing** - Assets above threshold go to R2, below to SQLite
- **Result/Option types** - Clean error handling with cement primitives
- **URL helpers** - `buildAssetUrl/parseAssetUrl` for `sql:?cid={cid}` format
- **16 unit tests** - Memory backend, error-only backend, streaming, per-item errors

## Configuration

Defaults to SQLite-only (backwards compatible). Opt-in R2 via:
```bash
AS_SETUP=sqlite://local,r2://bucket?threshold=4096
```

## Files Changed

**Core (2 files):**
- `asset-provider.ts` (225 lines) - Implementation
- `asset-provider.test.ts` (280 lines) - Unit tests

**Wiring (4 files):**
- `create-handler.ts`, `cf-env.ts`, `cf-serve.ts`, `api.ts`

**Callers (3 files):**
- `write-apps.ts`, `ensure-app-slug-item.ts`, `serv-entry-point.ts`

**Cleanup (3 files):**
- `ensure-storage.ts`, `api.test.ts`, `vibes-diy-api-schema.ts`

## Test Plan

- [x] `pnpm test asset-provider` — 16/16 pass
- [ ] `pnpm check` — TypeScript compiles
- [ ] Deploy without `AS_SETUP` (default: SQLite-only) — backwards compatible
- [ ] Deploy with `AS_SETUP=sqlite://local,r2://bucket?threshold=4096` — opt-in R2 routing

## Stats

12 files changed, 631 insertions(+), 118 deletions(-)