### PR TITLE
call-ai v2: schema support, Anthropic direct, CLI --text mode

### DIFF
--- a/call-ai/v2/README.md
+++ b/call-ai/v2/README.md
@@ -257,7 +257,7 @@ Integration plans (not part of this package):
 
 - vibes.diy chat using advanced API
 - Auth for vibes iframe runtime
-- Generated vibes legacy callAI wrapper
+- Generated vibes structured callAI wrapper
 
 ## TODO
 

--- a/call-ai/v2/build-request.test.ts
+++ b/call-ai/v2/build-request.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { buildRequestBody, getHeaders } from "./build-request.js";
+import type { RequestBody } from "./build-request.js";
+import sandwichSchema from "./fixtures/sandwich-schema.json" with { type: "json" };
+
+describe("buildRequestBody", () => {
+  it("without schema: no response_format, no system message", () => {
+    const body: RequestBody = buildRequestBody({ model: "openai/gpt-4o-mini", prompt: "Hello" });
+    expect(body.model).toBe("openai/gpt-4o-mini");
+    expect(body.stream).toBe(true);
+    expect(body.response_format).toBeUndefined();
+    expect(body.messages).toEqual([{ role: "user", content: "Hello" }]);
+  });
+
+  it("with schema: adds response_format and system message", () => {
+    const body: RequestBody = buildRequestBody({
+      model: "openai/gpt-4o-mini",
+      prompt: "Describe a sandwich",
+      schema: sandwichSchema,
+    });
+    expect(body.response_format).toEqual({
+      type: "json_schema",
+      json_schema: {
+        name: "sandwich",
+        strict: true,
+        schema: {
+          type: "object",
+          properties: sandwichSchema.properties,
+          required: ["name", "layers"],
+          additionalProperties: false,
+        },
+      },
+    });
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].role).toBe("system");
+    expect(body.messages[1]).toEqual({ role: "user", content: "Describe a sandwich" });
+  });
+
+  it("schema without name defaults to result", () => {
+    const body: RequestBody = buildRequestBody({
+      model: "gpt-4o-mini",
+      prompt: "test",
+      schema: { properties: { x: { type: "string" } } },
+    });
+    expect(body.response_format?.json_schema.name).toBe("result");
+  });
+
+  it("schema without required defaults to all property keys", () => {
+    const body: RequestBody = buildRequestBody({
+      model: "gpt-4o-mini",
+      prompt: "test",
+      schema: { properties: { a: { type: "string" }, b: { type: "number" } } },
+    });
+    expect(body.response_format?.json_schema.schema.required).toEqual(["a", "b"]);
+  });
+
+  it("with schema + apiStyle anthropic: uses tools/tool_choice", () => {
+    const body = buildRequestBody({
+      model: "claude-sonnet-4-6",
+      prompt: "Describe a sandwich",
+      schema: sandwichSchema,
+      apiStyle: "anthropic",
+    });
+    expect(body.response_format).toBeUndefined();
+    expect(body.tools).toEqual([{
+      name: "sandwich",
+      description: "Return structured JSON",
+      input_schema: {
+        type: "object",
+        properties: sandwichSchema.properties,
+        required: ["name", "layers"],
+        additionalProperties: false,
+      },
+    }]);
+    expect(body.tool_choice).toEqual({ type: "tool", name: "sandwich" });
+    expect(body.max_tokens).toBe(1024);
+    expect(body.messages).toEqual([{ role: "user", content: "Describe a sandwich" }]);
+  });
+
+  it("auto-detects anthropic style from api.anthropic.com URL", () => {
+    const body = buildRequestBody({
+      model: "claude-sonnet-4-6",
+      prompt: "Describe a sandwich",
+      schema: sandwichSchema,
+      url: "https://api.anthropic.com/v1/messages",
+    });
+    expect(body.response_format).toBeUndefined();
+    expect(body.tools).toBeDefined();
+    expect(body.tool_choice).toEqual({ type: "tool", name: "sandwich" });
+  });
+
+  it("anthropic URL without schema still uses anthropic message shape", () => {
+    const body = buildRequestBody({
+      model: "claude-sonnet-4-6",
+      prompt: "Describe a sandwich",
+      url: "https://api.anthropic.com/v1/messages",
+    });
+    expect(body.response_format).toBeUndefined();
+    expect(body.tools).toBeUndefined();
+    expect(body.messages).toEqual([{ role: "user", content: "Describe a sandwich" }]);
+    expect(body.max_tokens).toBe(1024);
+  });
+
+  it("non-anthropic URL defaults to openai style", () => {
+    const body = buildRequestBody({
+      model: "openai/gpt-4o-mini",
+      prompt: "Describe a sandwich",
+      schema: sandwichSchema,
+      url: "https://openrouter.ai/api/v1/chat/completions",
+    });
+    expect(body.response_format).toBeDefined();
+    expect(body.tools).toBeUndefined();
+  });
+
+  it("nested objects get required/additionalProperties automatically", () => {
+    const body = buildRequestBody({
+      model: "gpt-4o-mini",
+      prompt: "test",
+      schema: {
+        properties: {
+          name: { type: "string" },
+          address: {
+            type: "object",
+            properties: {
+              street: { type: "string" },
+              city: { type: "string" },
+              location: {
+                type: "object",
+                properties: {
+                  lat: { type: "number" },
+                  lng: { type: "number" },
+                },
+              },
+            },
+          },
+          tags: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+                score: { type: "number" },
+              },
+            },
+          },
+        },
+      },
+    });
+    const schema = body.response_format!.json_schema.schema;
+    expect(schema.required).toEqual(["name", "address", "tags"]);
+    expect(schema.additionalProperties).toBe(false);
+
+    const address = schema.properties.address as {
+      required: string[];
+      additionalProperties: boolean;
+      properties: Record<string, unknown>;
+    };
+    expect(address.required).toEqual(["street", "city", "location"]);
+    expect(address.additionalProperties).toBe(false);
+
+    const location = address.properties.location as { required: string[]; additionalProperties: boolean };
+    expect(location.required).toEqual(["lat", "lng"]);
+    expect(location.additionalProperties).toBe(false);
+
+    const tags = schema.properties.tags as { items: { required: string[]; additionalProperties: boolean } };
+    expect(tags.items.required).toEqual(["label", "score"]);
+    expect(tags.items.additionalProperties).toBe(false);
+  });
+
+  it("nested objects get required/additionalProperties for anthropic style too", () => {
+    const body = buildRequestBody({
+      model: "claude-sonnet-4-6",
+      prompt: "test",
+      apiStyle: "anthropic",
+      schema: {
+        properties: {
+          name: { type: "string" },
+          meta: {
+            type: "object",
+            properties: {
+              color: { type: "string" },
+            },
+          },
+        },
+      },
+    });
+
+    const tool = body.tools![0];
+    const meta = tool.input_schema.properties.meta as { required: string[]; additionalProperties: boolean };
+    expect(meta.required).toEqual(["color"]);
+    expect(meta.additionalProperties).toBe(false);
+  });
+
+  it("anthropic headers include x-api-key and anthropic-version", () => {
+    const headers = getHeaders("anthropic", "sk-ant-test");
+    expect(headers["x-api-key"]).toBe("sk-ant-test");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("openai headers use Bearer authorization", () => {
+    const headers = getHeaders("openai", "sk-test");
+    expect(headers["Authorization"]).toBe("Bearer sk-test");
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  it("explicit apiStyle overrides URL auto-detection", () => {
+    const body = buildRequestBody({
+      model: "claude-sonnet-4-6",
+      prompt: "Describe a sandwich",
+      schema: sandwichSchema,
+      url: "https://api.anthropic.com/v1/messages",
+      apiStyle: "openai",
+    });
+    expect(body.response_format).toBeDefined();
+    expect(body.tools).toBeUndefined();
+  });
+});

--- a/call-ai/v2/build-request.ts
+++ b/call-ai/v2/build-request.ts
@@ -1,0 +1,209 @@
+import { URI } from "@adviser/cement";
+
+export interface SchemaInput {
+  readonly name?: string;
+  readonly properties: Record<string, unknown>;
+  readonly required?: readonly string[];
+  readonly additionalProperties?: boolean;
+}
+
+interface ChatMessage {
+  readonly role: string;
+  readonly content: string | readonly { readonly type: string; readonly text: string }[];
+}
+
+interface ResponseFormat {
+  readonly type: "json_schema";
+  readonly json_schema: {
+    readonly name: string;
+    readonly strict: true;
+    readonly schema: {
+      readonly type: "object";
+      readonly properties: Record<string, unknown>;
+      readonly required: readonly string[];
+      readonly additionalProperties: boolean;
+    };
+  };
+}
+
+interface AnthropicTool {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: {
+    readonly type: "object";
+    readonly properties: Record<string, unknown>;
+    readonly required: readonly string[];
+    readonly additionalProperties: boolean;
+  };
+}
+
+interface AnthropicToolChoice {
+  readonly type: "tool";
+  readonly name: string;
+}
+
+export interface RequestBody {
+  readonly model: string;
+  readonly messages: readonly ChatMessage[];
+  readonly stream: true;
+  readonly response_format?: ResponseFormat;
+  readonly tools?: readonly AnthropicTool[];
+  readonly tool_choice?: AnthropicToolChoice;
+  readonly max_tokens?: number;
+}
+
+export interface BuildRequestParams {
+  readonly model: string;
+  readonly prompt: string;
+  readonly schema?: SchemaInput;
+  readonly apiStyle?: ApiStyle;
+  readonly url?: string;
+}
+
+export type ApiStyle = "openai" | "anthropic";
+
+export function getHeaders(apiStyle: ApiStyle, apiKey: string): Record<string, string> {
+  if (apiStyle === "anthropic") {
+    return {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    };
+  }
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export function resolveApiStyle(url?: string, apiStyle?: ApiStyle): ApiStyle {
+  if (apiStyle !== undefined) {
+    return apiStyle;
+  }
+
+  if (url !== undefined && URI.from(url).hostname === "api.anthropic.com") {
+    return "anthropic";
+  }
+  return "openai";
+}
+
+interface NormalizedSchema {
+  readonly name: string;
+  readonly schema: {
+    readonly type: "object";
+    readonly properties: Record<string, unknown>;
+    readonly required: readonly string[];
+    readonly additionalProperties: boolean;
+  };
+}
+
+function processProperties(properties: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const prop = value as Record<string, unknown>;
+      if (prop.type === "object" && prop.properties) {
+        const nested = prop.properties as Record<string, unknown>;
+        result[key] = {
+          ...prop,
+          properties: processProperties(nested),
+          required: prop.required ?? Object.keys(nested),
+          additionalProperties: prop.additionalProperties ?? false,
+        };
+      } else if (prop.type === "array" && prop.items && typeof prop.items === "object") {
+        const items = prop.items as Record<string, unknown>;
+        if (items.type === "object" && items.properties) {
+          const nested = items.properties as Record<string, unknown>;
+          result[key] = {
+            ...prop,
+            items: {
+              ...items,
+              properties: processProperties(nested),
+              required: items.required ?? Object.keys(nested),
+              additionalProperties: items.additionalProperties ?? false,
+            },
+          };
+        } else {
+          result[key] = value;
+        }
+      } else {
+        result[key] = value;
+      }
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function normalizeSchema(schema: SchemaInput): NormalizedSchema {
+  return {
+    name: schema.name !== undefined ? schema.name : "result",
+    schema: {
+      type: "object",
+      properties: processProperties(schema.properties),
+      required: schema.required !== undefined ? [...schema.required] : Object.keys(schema.properties),
+      additionalProperties: schema.additionalProperties !== undefined ? schema.additionalProperties : false,
+    },
+  };
+}
+
+export function buildRequestBody({ model, prompt, schema, apiStyle, url }: BuildRequestParams): RequestBody {
+  const style = resolveApiStyle(url, apiStyle);
+
+  if (style === "anthropic") {
+    const anthropicBody: RequestBody = {
+      model,
+      messages: [{ role: "user", content: prompt }],
+      stream: true,
+      max_tokens: 1024,
+    };
+
+    if (schema === undefined) {
+      return anthropicBody;
+    }
+
+    const normalized = normalizeSchema(schema);
+    return {
+      ...anthropicBody,
+      tools: [{
+        name: normalized.name,
+        description: "Return structured JSON",
+        input_schema: normalized.schema,
+      }],
+      tool_choice: { type: "tool", name: normalized.name },
+    };
+  }
+
+  if (schema === undefined) {
+    return {
+      model,
+      messages: [{ role: "user", content: prompt }],
+      stream: true,
+    };
+  }
+
+  const normalized = normalizeSchema(schema);
+  const systemMessages: readonly ChatMessage[] = [
+    {
+      role: "system",
+      content: [{ type: "text", text: `Return a JSON object conforming to this schema: ${JSON.stringify(schema)}` }],
+    },
+  ];
+
+  const messages: readonly ChatMessage[] = [
+    ...systemMessages,
+    { role: "user", content: prompt },
+  ];
+
+  const responseFormat: ResponseFormat = {
+    type: "json_schema",
+    json_schema: {
+      name: normalized.name,
+      strict: true,
+      schema: normalized.schema,
+    },
+  };
+
+  return { model, messages, stream: true, response_format: responseFormat };
+}

--- a/call-ai/v2/cli.node.test.ts
+++ b/call-ai/v2/cli.node.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const cliDir = dirname(fileURLToPath(import.meta.url));
+
+describe("cli --dry-run", () => {
+  it("prints request body without requiring API key", () => {
+    const env = { ...process.env };
+    delete env.OPENROUTER_API_KEY;
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "cli.ts", "--prompt", "Describe a sandwich", "--dry-run", "--api-key", ""],
+      {
+        cwd: cliDir,
+        env,
+        encoding: "utf-8",
+      }
+    );
+
+    expect(result.status).toBe(0);
+    const body = JSON.parse(result.stdout);
+    expect(body).toEqual({
+      model: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: "Describe a sandwich" }],
+      stream: true,
+    });
+  });
+
+  it("uses anthropic body shape for anthropic URL even without schema", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "cli.ts",
+        "--prompt",
+        "Describe a sandwich",
+        "--dry-run",
+        "--url",
+        "https://api.anthropic.com/v1/messages",
+      ],
+      {
+        cwd: cliDir,
+        encoding: "utf-8",
+      }
+    );
+
+    expect(result.status).toBe(0);
+    const body = JSON.parse(result.stdout);
+    expect(body.messages).toEqual([{ role: "user", content: "Describe a sandwich" }]);
+    expect(body.max_tokens).toBe(1024);
+    expect(body.response_format).toBeUndefined();
+    expect(body.tools).toBeUndefined();
+  });
+});
+
+describe("cli --text --src", () => {
+  it("outputs accumulated text from a fixture file", () => {
+    const fixture = join(cliDir, "fixtures", "openrouter-gpt-json-schema.llm.txt");
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "cli.ts", "--text", "--src", fixture],
+      {
+        cwd: cliDir,
+        encoding: "utf-8",
+      }
+    );
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout.trim());
+    expect(parsed).toHaveProperty("name");
+    expect(parsed).toHaveProperty("layers");
+    expect(typeof parsed.name).toBe("string");
+    expect(Array.isArray(parsed.layers)).toBe(true);
+  });
+});

--- a/call-ai/v2/cli.ts
+++ b/call-ai/v2/cli.ts
@@ -1,6 +1,7 @@
 import { command, run, string, option, flag } from "cmd-ts";
 import { dotenv, path } from "zx";
 import { promises as fs } from "node:fs";
+import { buildRequestBody, getHeaders, resolveApiStyle, SchemaInput } from "./build-request.js";
 import {
   createStatsCollector,
   createLineStream,
@@ -141,6 +142,27 @@ const app = command({
       description: "Directory to save decoded images (enables image saving)",
       defaultValue: () => "",
     }),
+    schema: option({
+      type: string,
+      long: "schema",
+      description: "JSON file with schema for structured output (adds response_format: json_schema)",
+      defaultValue: () => "",
+    }),
+    apiStyle: option({
+      type: string,
+      long: "api-style",
+      description: "API style: openai (default, auto-detected) or anthropic",
+      defaultValue: () => "",
+    }),
+    text: flag({
+      long: "text",
+      short: "t",
+      description: "Output just the accumulated text content (no JSON wrapper)",
+    }),
+    dryRun: flag({
+      long: "dry-run",
+      description: "Print the request body as JSON and exit (don't call API)",
+    }),
   },
   handler: async ({
     prompt,
@@ -160,7 +182,18 @@ const app = command({
     statsInterval,
     image,
     imageDir,
+    schema: schemaPath,
+    apiStyle: apiStyleArg,
+    text,
+    dryRun,
   }) => {
+    // Load schema if provided
+    let schemaObj: SchemaInput | undefined;
+    if (schemaPath) {
+      const schemaJson = await fs.readFile(schemaPath, "utf-8");
+      schemaObj = JSON.parse(schemaJson);
+    }
+
     let body: ReadableStream<Uint8Array>;
 
     if (src) {
@@ -177,28 +210,28 @@ const app = command({
         },
       });
     } else {
-      if (!apiKey) {
-        console.error("Error: API key required. Use --api-key or set OPENROUTER_API_KEY in .env");
-        process.exit(1);
-      }
-
       if (!prompt) {
         console.error("Error: Prompt required. Use --prompt or --src");
         process.exit(1);
       }
 
+      const style = resolveApiStyle(url, apiStyleArg === "openai" || apiStyleArg === "anthropic" ? apiStyleArg : undefined);
+      const requestBody = buildRequestBody({ model, prompt, schema: schemaObj, apiStyle: style, url });
+
+      if (dryRun) {
+        console.log(JSON.stringify(requestBody, null, 2));
+        process.exit(0);
+      }
+
+      if (!apiKey) {
+        console.error("Error: API key required. Use --api-key or set OPENROUTER_API_KEY in .env");
+        process.exit(1);
+      }
+
       const response = await fetch(url, {
         method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model,
-          messages: [{ role: "user", content: prompt }],
-          logprobs: true,
-          stream: true,
-        }),
+        headers: getHeaders(style, apiKey),
+        body: JSON.stringify(requestBody),
       });
 
       if (!response.ok) {
@@ -216,7 +249,7 @@ const app = command({
     }
     const sthis = ensureSuperThis();
 
-    if (all || line || data || sse || delta || full || block || stats || image || imageDir) {
+    if (all || line || data || sse || delta || full || block || stats || image || imageDir || text) {
       const streamId = sthis.nextId().str;
       const intervalMs = parseInt(statsInterval, 10) || 1000;
       const pipeline = body
@@ -231,6 +264,7 @@ const app = command({
 
       const reader = pipeline.getReader();
 
+      let textNeedsNewline = false;
       const sectionState = {
         sectionId: "",
         mode: "" as "toplevel" | "code" | "",
@@ -292,6 +326,12 @@ const app = command({
           }
         }
 
+        if (text && isToplevelLine(value)) {
+          if (textNeedsNewline) process.stdout.write("\n");
+          process.stdout.write(value.line);
+          textNeedsNewline = true;
+        }
+
         if (image && isBlockImage(value)) {
           const response = await fetch(value.url);
           const blob = await response.blob();
@@ -325,6 +365,7 @@ const app = command({
           console.log(JSON.stringify(value));
         }
       }
+      if (text && textNeedsNewline) process.stdout.write("\n");
     } else {
       const reader = body.getReader();
       const decoder = new TextDecoder();

--- a/call-ai/v2/fixtures/README.md
+++ b/call-ai/v2/fixtures/README.md
@@ -1,0 +1,46 @@
+# SSE Fixtures
+
+Captured raw SSE responses for testing the v2 streaming pipeline.
+
+## Providers
+
+| Fixture | Provider | Schema method | Format |
+|---------|----------|---------------|--------|
+| `openrouter-gpt-json-schema.llm.txt` | OpenRouter → GPT-4o-mini | `response_format: json_schema` | OpenRouter SSE |
+| `openrouter-claude-json-schema.llm.txt` | OpenRouter → Claude Sonnet | `response_format: json_schema` | OpenRouter SSE |
+| `openai-json-schema.llm.txt` | OpenAI direct | `response_format: json_schema` | OpenAI SSE |
+| `anthropic-json-schema.llm.txt` | Anthropic direct | `tool_use` + `tool_choice` | Anthropic SSE (`input_json_delta`) |
+
+All fixtures return a sandwich JSON: `{ "name": "...", "layers": ["..."] }`
+
+## Regenerating fixtures
+
+```bash
+cd call-ai/v2
+bash fixtures/capture.sh
+```
+
+Requires `.env` with: `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`
+
+## CLI with schema
+
+The v2 CLI supports `--schema` for structured output:
+
+```bash
+# Dry run (prints request body, no API call)
+pnpm cli --prompt "Describe a sandwich" --schema fixtures/sandwich-schema.json --dry-run
+
+# Live capture (raw SSE to stdout)
+pnpm cli --prompt "Describe a sandwich" --schema fixtures/sandwich-schema.json
+```
+
+## Notes
+
+- Anthropic's native API doesn't support `response_format` — uses `tool_use` with `tool_choice` instead, producing `input_json_delta` events
+- In production, all models go through OpenRouter which provides a unified `response_format: json_schema` interface
+- The Anthropic fixture proves the pipeline handles `input_json_delta` for potential future direct-API support
+
+## Files
+
+- `sandwich-schema.json` — shared schema used by all captures
+- `capture.sh` — shell script to re-capture all fixtures via CLI

--- a/call-ai/v2/fixtures/anthropic-json-schema.llm.txt
+++ b/call-ai/v2/fixtures/anthropic-json-schema.llm.txt
@@ -1,0 +1,156 @@
+event: message_start
+data: {"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_019epw3hKjNVGCbsefduPEWG","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":682,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard","inference_geo":"global"}} }
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01VQDdVe8HppbJ3BwmzeVgCh","name":"sandwich","input":{},"caller":{"type":"direct"}}          }
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}          }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"nam"}           }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\": \"Classic"}        }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" Club San"}              }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"dwich\""} }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":", \""}             }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"layers\": [\"T"}       }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"op "}        }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"slice of t"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"oasted white"}     }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" bread\",\"M"} }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ayo"}         }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nnaise\","}           }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Crispy "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"bacon strip"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\",\""}         }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Sliced "}     }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"turkey breas"}            }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"t\",\"Chedda"}             }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r cheese\",\"F"}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"resh lett"}     }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uce l"} }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"eaves\","} }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Tomato slic"}             }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"es\",\"Middle"}              }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" slice o"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"f "}            }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"toas"}       }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ted white br"}             }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ead\",\"Mu"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stard\""}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",\"Ham slices"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\",\"Swiss che"}        }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ese"}      }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\",\""}           }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Cucumb"}              }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"er slices\",\""}     }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Red onion "}           }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rings"}              }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\",\"Bott"}    }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"om s"}        }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"li"}            }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ce of"}     }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":" toasted w"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hite br"}  }
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ead\"]}"}       }
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0      }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":682,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":145}  }
+
+event: message_stop
+data: {"type":"message_stop"              }
+

--- a/call-ai/v2/fixtures/capture.sh
+++ b/call-ai/v2/fixtures/capture.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Capture SSE fixtures from all 4 provider combinations.
+#
+# Usage: cd call-ai/v2 && bash fixtures/capture.sh
+#
+# Requires .env with: OPENROUTER_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Load .env
+set -a
+source .env
+set +a
+
+DIR=fixtures
+SCHEMA=fixtures/sandwich-schema.json
+PROMPT="Describe a sandwich"
+
+echo "Capturing OpenRouter GPT..." >&2
+pnpm --silent cli \
+  --prompt "$PROMPT" \
+  --schema "$SCHEMA" \
+  --model openai/gpt-4o-mini \
+  --api-key "$OPENROUTER_API_KEY" \
+  --url https://openrouter.ai/api/v1/chat/completions \
+  > "$DIR/openrouter-gpt-json-schema.llm.txt"
+echo "  → $(wc -l < "$DIR/openrouter-gpt-json-schema.llm.txt") lines" >&2
+
+echo "Capturing OpenRouter Claude..." >&2
+pnpm --silent cli \
+  --prompt "$PROMPT" \
+  --schema "$SCHEMA" \
+  --model anthropic/claude-sonnet-4-6 \
+  --api-key "$OPENROUTER_API_KEY" \
+  --url https://openrouter.ai/api/v1/chat/completions \
+  > "$DIR/openrouter-claude-json-schema.llm.txt"
+echo "  → $(wc -l < "$DIR/openrouter-claude-json-schema.llm.txt") lines" >&2
+
+echo "Capturing OpenAI Direct..." >&2
+pnpm --silent cli \
+  --prompt "$PROMPT" \
+  --schema "$SCHEMA" \
+  --model gpt-4o-mini \
+  --api-key "$OPENAI_API_KEY" \
+  --url https://api.openai.com/v1/chat/completions \
+  > "$DIR/openai-json-schema.llm.txt"
+echo "  → $(wc -l < "$DIR/openai-json-schema.llm.txt") lines" >&2
+
+echo "Capturing Anthropic Direct (tool_use)..." >&2
+pnpm --silent cli \
+  --prompt "$PROMPT" \
+  --schema "$SCHEMA" \
+  --model claude-sonnet-4-6 \
+  --api-key "$ANTHROPIC_API_KEY" \
+  --url https://api.anthropic.com/v1/messages \
+  > "$DIR/anthropic-json-schema.llm.txt"
+echo "  → $(wc -l < "$DIR/anthropic-json-schema.llm.txt") lines" >&2
+
+echo "Done." >&2

--- a/call-ai/v2/fixtures/openai-json-schema.llm.txt
+++ b/call-ai/v2/fixtures/openai-json-schema.llm.txt
@@ -1,0 +1,58 @@
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"WDYbdJ"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Uge9c"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"name"},"logprobs":null,"finish_reason":null}],"obfuscation":"UL3J"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"vTM"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"Classic"},"logprobs":null,"finish_reason":null}],"obfuscation":"1"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":" BL"},"logprobs":null,"finish_reason":null}],"obfuscation":"tMy1K"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"T"},"logprobs":null,"finish_reason":null}],"obfuscation":"yJFYuXS"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"sHB"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"layers"},"logprobs":null,"finish_reason":null}],"obfuscation":"hx"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\":[\""},"logprobs":null,"finish_reason":null}],"obfuscation":"hS"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"bread"},"logprobs":null,"finish_reason":null}],"obfuscation":"5ze"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"wcZ"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"b"},"logprobs":null,"finish_reason":null}],"obfuscation":"rKFTeNW"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"acon"},"logprobs":null,"finish_reason":null}],"obfuscation":"EaHw"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"UEb"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"lett"},"logprobs":null,"finish_reason":null}],"obfuscation":"6lLW"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"uce"},"logprobs":null,"finish_reason":null}],"obfuscation":"FwSyx"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"rxb"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"tom"},"logprobs":null,"finish_reason":null}],"obfuscation":"PhvOy"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"ato"},"logprobs":null,"finish_reason":null}],"obfuscation":"RVfIS"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"dAx"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"may"},"logprobs":null,"finish_reason":null}],"obfuscation":"rWObp"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"onnaise"},"logprobs":null,"finish_reason":null}],"obfuscation":"B"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"AlD"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"bread"},"logprobs":null,"finish_reason":null}],"obfuscation":"no0"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"\"]"},"logprobs":null,"finish_reason":null}],"obfuscation":"4iJEB"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"ksCJG0Q"}
+
+data: {"id":"chatcmpl-DFOmPADG2Pv0zy4NQiMQuokJrduGA","object":"chat.completion.chunk","created":1772562545,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_b2175cdf48","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"sj"}
+
+data: [DONE]
+

--- a/call-ai/v2/fixtures/openrouter-claude-json-schema.llm.txt
+++ b/call-ai/v2/fixtures/openrouter-claude-json-schema.llm.txt
@@ -1,0 +1,62 @@
+: OPENROUTER PROCESSING
+
+: OPENROUTER PROCESSING
+
+: OPENROUTER PROCESSING
+
+: OPENROUTER PROCESSING
+
+: OPENROUTER PROCESSING
+
+: OPENROUTER PROCESSING
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"{\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"name\":\"Classic","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" Club","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" Sandwich\",\"layers\":[\"top","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" bread","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" slice","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" (","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"to","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"asted)","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"\",\"may","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"onnaise\",\"lettuce\",\"tomato","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" sl","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"ices\",\"cri","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"spy bacon","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"\",\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"sl","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"iced turkey","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"\",\"c","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"heddar cheese\",\"may","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"onnaise\",\"bottom","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":" bread slice (toasted)\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"]}","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"stop","native_finish_reason":"stop"}]}
+
+data: {"id":"gen-1772562538-PJUiT9THCipyICFtGoZw","object":"chat.completion.chunk","created":1772562538,"model":"anthropic/claude-4.6-sonnet-20260217","provider":"Amazon Bedrock","choices":[],"usage":{"prompt_tokens":242,"completion_tokens":59,"total_tokens":301,"cost":0.00159489,"is_byok":false,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0,"audio_tokens":0,"video_tokens":0},"cost_details":{"upstream_inference_cost":0.001611,"upstream_inference_prompt_cost":0.000726,"upstream_inference_completions_cost":0.000885},"completion_tokens_details":{"reasoning_tokens":0,"image_tokens":0,"audio_tokens":0}}}
+
+data: [DONE]
+

--- a/call-ai/v2/fixtures/openrouter-gpt-json-schema.llm.txt
+++ b/call-ai/v2/fixtures/openrouter-gpt-json-schema.llm.txt
@@ -1,0 +1,66 @@
+: OPENROUTER PROCESSING
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"{\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"name","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\":\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"Club","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":" Sandwich","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\",\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"layers","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\":[\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"s","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"liced","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":" turkey","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\",\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"b","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"acon","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\",\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"lett","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"uce","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\",\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"tom","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"ato","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\",\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"may","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"onnaise","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\",\"","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"whole","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":" wheat","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":" bread","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"\"]","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"}","role":"assistant"},"finish_reason":null,"native_finish_reason":null}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[{"index":0,"delta":{"content":"","role":"assistant"},"finish_reason":"stop","native_finish_reason":"stop"}]}
+
+data: {"id":"gen-1772562535-5M38GkTNegixMbaztvYZ","object":"chat.completion.chunk","created":1772562535,"model":"openai/gpt-4o-mini","provider":"OpenAI","system_fingerprint":"fp_6b8d2fb52e","choices":[],"usage":{"prompt_tokens":97,"completion_tokens":29,"total_tokens":126,"cost":0.0000316305,"is_byok":false,"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0,"audio_tokens":0,"video_tokens":0},"cost_details":{"upstream_inference_cost":0.00003195,"upstream_inference_prompt_cost":0.00001455,"upstream_inference_completions_cost":0.0000174},"completion_tokens_details":{"reasoning_tokens":0,"image_tokens":0,"audio_tokens":0}}}
+
+data: [DONE]
+

--- a/call-ai/v2/fixtures/sandwich-schema.json
+++ b/call-ai/v2/fixtures/sandwich-schema.json
@@ -1,0 +1,7 @@
+{
+  "name": "sandwich",
+  "properties": {
+    "name": { "type": "string" },
+    "layers": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/call-ai/v2/prompt-type.ts
+++ b/call-ai/v2/prompt-type.ts
@@ -18,6 +18,20 @@ export const ChatMessage = type({
 });
 export type ChatMessage = typeof ChatMessage.infer;
 
+// JSON schema for structured output via response_format
+export const JsonSchemaFormat = type({
+  name: "string",
+  "strict?": "boolean",
+  schema: "Record<string, unknown>",
+});
+export type JsonSchemaFormat = typeof JsonSchemaFormat.infer;
+
+export const ResponseFormat = type({
+  type: "'json_object' | 'json_schema'",
+  "json_schema?": JsonSchemaFormat,
+});
+export type ResponseFormat = typeof ResponseFormat.infer;
+
 // LLM request body (OpenRouter/OpenAI compatible)
 export const LLMRequest = type({
   "model?": "string",
@@ -31,6 +45,7 @@ export const LLMRequest = type({
   "frequency_penalty?": "number",
   "presence_penalty?": "number",
   "stop?": "string | string[]",
+  "response_format?": ResponseFormat,
 });
 
 export type LLMRequest = typeof LLMRequest.infer;

--- a/call-ai/v2/provider-fixtures.test.ts
+++ b/call-ai/v2/provider-fixtures.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { isBlockEnd, isDeltaLine, isSseEnd, isSseError } from "./index.js";
+import type { DeltaLineMsg, SseEndMsg } from "./index.js";
+import {
+  loadFixtureLines,
+  parseToplevelJson,
+  runDeltaPipeline,
+  runFullPipeline,
+  runSsePipeline,
+} from "./test-helper.js";
+
+const fixtureConfigs = [
+  { name: "OpenRouter GPT (json_schema)", file: "openrouter-gpt-json-schema.llm.txt" },
+  { name: "OpenRouter Claude (json_schema)", file: "openrouter-claude-json-schema.llm.txt" },
+  { name: "OpenAI Direct (json_schema)", file: "openai-json-schema.llm.txt" },
+  { name: "Anthropic Direct (tool_use)", file: "anthropic-json-schema.llm.txt" },
+] as const;
+
+const fixtures = new Map<string, string[]>();
+
+beforeAll(async () => {
+  await Promise.all(
+    fixtureConfigs.map(async ({ name, file }) => {
+      fixtures.set(name, await loadFixtureLines(file));
+    })
+  );
+});
+
+function getFixtureLines(name: string): string[] {
+  const lines = fixtures.get(name);
+  if (lines === undefined) {
+    throw new Error(`Fixture not found: ${name}`);
+  }
+  return lines;
+}
+
+function expectSandwichShape(value: unknown) {
+  expect(value).toHaveProperty("name");
+  expect(value).toHaveProperty("layers");
+  const parsed = value as { name: unknown; layers: unknown[] };
+  expect(typeof parsed.name).toBe("string");
+  expect(Array.isArray(parsed.layers)).toBe(true);
+  expect(parsed.layers.length).toBeGreaterThan(0);
+  for (const layer of parsed.layers) {
+    expect(typeof layer).toBe("string");
+  }
+}
+
+describe("captured provider fixtures", () => {
+  for (const { name } of fixtureConfigs) {
+    it(`${name}: sse-stream accepts chunks without errors`, async () => {
+      const res = await runSsePipeline(getFixtureLines(name));
+      const errors = res.filter((event) => isSseError(event));
+      const endEvents = res.filter((event): event is SseEndMsg => isSseEnd(event));
+
+      expect(errors).toHaveLength(0);
+      expect(endEvents).toHaveLength(1);
+      expect(endEvents[0].totalChunks).toBeGreaterThan(0);
+    });
+
+    it(`${name}: full pipeline emits one block and valid sandwich JSON`, async () => {
+      const res = await runFullPipeline(getFixtureLines(name));
+      const parsed = parseToplevelJson(res);
+      expectSandwichShape(parsed);
+
+      const blockEnds = res.filter((event) => isBlockEnd(event));
+      expect(blockEnds).toHaveLength(1);
+    });
+
+    it(`${name}: delta-stream reconstructs valid JSON`, async () => {
+      const res = await runDeltaPipeline(getFixtureLines(name));
+      const fullText = res
+        .filter((event): event is DeltaLineMsg => isDeltaLine(event))
+        .map((event) => event.content)
+        .join("");
+      expect(fullText).toContain('{"name"');
+      const parsed = JSON.parse(fullText);
+      expectSandwichShape(parsed);
+    });
+  }
+});

--- a/call-ai/v2/sse-stream.ts
+++ b/call-ai/v2/sse-stream.ts
@@ -45,6 +45,40 @@ export const SseChunk = type({
   "+": "delete",
 });
 
+// Direct OpenAI format: same shape but without provider and native_finish_reason
+const OpenAiDirectChunk = type({
+  id: "string",
+  model: "string",
+  object: "string",
+  created: "number",
+  choices: type({
+    index: "number",
+    delta: {
+      "role?": "string",
+      "content?": "string",
+      "reasoning?": "string|null",
+      "reasoning_details?": "unknown[]",
+      "+": "delete",
+    },
+    finish_reason: "string|null",
+    "logprobs?": "unknown",
+  }).array(),
+  "system_fingerprint?": "string",
+  "usage?": SseUsage,
+  "+": "delete",
+});
+
+function openaiDirectToSseChunk(validated: typeof OpenAiDirectChunk.infer): SseChunk {
+  return {
+    ...validated,
+    provider: "openai",
+    choices: validated.choices.map((c) => ({
+      ...c,
+      native_finish_reason: c.finish_reason,
+    })),
+  };
+}
+
 export type SseChunk = typeof SseChunk.infer;
 
 export const SseBeginMsg = type({
@@ -114,11 +148,130 @@ export const isSseMsg = (msg: unknown, streamId?: string): msg is SseStreamMsg =
 
 // Combined output type (passthrough + own events)
 
+// Anthropic SSE format detection and translation
+// Detects events like message_start, content_block_delta, message_delta
+// and translates them into OpenAI-shaped SseChunk objects
+
+interface AnthropicState {
+  id: string;
+  model: string;
+  created: number;
+}
+
+function isAnthropicEvent(json: unknown): json is Record<string, unknown> & { type: string } {
+  return typeof json === "object" && json !== null && "type" in json && typeof json.type === "string";
+}
+
+function obj(v: unknown): Record<string, unknown> | undefined {
+  if (typeof v !== "object" || v === null) return undefined;
+  return Object.fromEntries(Object.entries(v));
+}
+
+function str(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function num(v: unknown, fallback = 0): number {
+  return typeof v === "number" ? v : fallback;
+}
+
+function anthropicToSseChunk(
+  json: Record<string, unknown> & { type: string },
+  state: AnthropicState
+): SseChunk | "skip" | null {
+  const base = () => ({
+    id: state.id,
+    provider: "anthropic",
+    model: state.model,
+    object: "chat.completion.chunk",
+    created: state.created,
+  });
+
+  switch (json.type) {
+    case "message_start": {
+      const msg = obj(json.message);
+      if (msg === undefined) return null;
+      state.id = str(msg.id);
+      state.model = str(msg.model);
+      return {
+        ...base(),
+        choices: [
+          {
+            index: 0,
+            delta: { role: str(msg.role, "assistant"), content: "" },
+            finish_reason: null,
+            native_finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      };
+    }
+
+    case "content_block_delta": {
+      const delta = obj(json.delta);
+      if (delta === undefined) return "skip";
+      let content: string;
+      if (delta.type === "text_delta" && typeof delta.text === "string") {
+        content = delta.text;
+      } else if (delta.type === "input_json_delta" && typeof delta.partial_json === "string") {
+        content = delta.partial_json;
+      } else {
+        return "skip";
+      }
+      return {
+        ...base(),
+        choices: [
+          {
+            index: 0,
+            delta: { content },
+            finish_reason: null,
+            native_finish_reason: null,
+            logprobs: null,
+          },
+        ],
+      };
+    }
+
+    case "message_delta": {
+      const delta = obj(json.delta);
+      const usage = obj(json.usage);
+      const chunk: SseChunk = {
+        ...base(),
+        choices: [
+          {
+            index: 0,
+            delta: { content: "" },
+            finish_reason: delta ? str(delta.stop_reason, "stop") : "stop",
+            native_finish_reason: delta ? str(delta.stop_reason, "stop") : "stop",
+            logprobs: null,
+          },
+        ],
+      };
+      if (usage) {
+        const inp = num(usage.input_tokens);
+        const out = num(usage.output_tokens);
+        chunk.usage = { prompt_tokens: inp, completion_tokens: out, total_tokens: inp + out };
+      }
+      return chunk;
+    }
+
+    case "content_block_start":
+    case "content_block_stop":
+    case "ping":
+    case "message_stop":
+      return "skip";
+
+    default:
+      return null;
+  }
+}
+
 export function createSseStream(filterStreamId: string): TransformStream<DataStreamMsg, SseStreamMsg> {
   let chunkNr = 0;
   let errorNr = 0;
   const usages: SseUsage[] = [];
   let streamId = "";
+  const anthropicState: AnthropicState = { id: "", model: "", created: Math.floor(Date.now() / 1000) };
 
   return new TransformStream<DataStreamMsg, SseStreamMsg>({
     transform: passthrough((msg, controller) => {
@@ -146,28 +299,69 @@ export function createSseStream(filterStreamId: string): TransformStream<DataStr
           timestamp: new Date(),
         });
       } else if (isDataLine(msg, filterStreamId)) {
+        // Try OpenRouter format first (has provider + native_finish_reason)
         const result = SseChunk(msg.json);
-        if (result instanceof type.errors) {
-          errorNr++;
+        if (!("summary" in result)) {
+          chunkNr++;
+          if (result.usage) {
+            usages.push(result.usage);
+          }
           controller.enqueue({
-            type: "sse.error",
+            type: "sse.line",
             streamId,
-            error: result.summary,
-            json: msg.json,
-            errorNr,
+            chunk: result,
+            chunkNr,
             timestamp: new Date(),
           });
           return;
         }
-        chunkNr++;
-        if (result.usage) {
-          usages.push(result.usage);
+
+        // Try direct OpenAI format (no provider/native_finish_reason)
+        const directResult = OpenAiDirectChunk(msg.json);
+        if (!("summary" in directResult)) {
+          const chunk = openaiDirectToSseChunk(directResult);
+          chunkNr++;
+          if (chunk.usage) {
+            usages.push(chunk.usage);
+          }
+          controller.enqueue({
+            type: "sse.line",
+            streamId,
+            chunk,
+            chunkNr,
+            timestamp: new Date(),
+          });
+          return;
         }
+
+        // Try Anthropic format
+        if (isAnthropicEvent(msg.json)) {
+          const translated = anthropicToSseChunk(msg.json, anthropicState);
+          if (translated === "skip") return;
+          if (translated !== null) {
+            chunkNr++;
+            if (translated.usage) {
+              usages.push(translated.usage);
+            }
+            controller.enqueue({
+              type: "sse.line",
+              streamId,
+              chunk: translated,
+              chunkNr,
+              timestamp: new Date(),
+            });
+            return;
+          }
+        }
+
+        // Neither format matched
+        errorNr++;
         controller.enqueue({
-          type: "sse.line",
+          type: "sse.error",
           streamId,
-          chunk: result,
-          chunkNr,
+          error: result.summary,
+          json: msg.json,
+          errorNr,
           timestamp: new Date(),
         });
       } else if (isDataEnd(msg, filterStreamId)) {

--- a/call-ai/v2/test-helper.ts
+++ b/call-ai/v2/test-helper.ts
@@ -1,0 +1,73 @@
+import { array2stream, loadAsset, stream2array } from "@adviser/cement";
+import {
+  createDataStream,
+  createDeltaStream,
+  createLineStream,
+  createSectionsStream,
+  createSseStream,
+  createStatsCollector,
+  isToplevelLine,
+} from "./index.js";
+
+async function resolveContent(content: string): Promise<string> {
+  const match = content.match(/^export default "([^"]+)"/);
+  if (match && match[1]) {
+    const response = await fetch(match[1]);
+    return response.text();
+  }
+  return content;
+}
+
+export async function loadFixtureLines(filename: string): Promise<string[]> {
+  const result = await loadAsset(`fixtures/${filename}`, {
+    basePath: () => import.meta.url,
+    fallBackUrl: import.meta.url,
+  });
+  const content = await resolveContent(result.Ok());
+  return content.split("\n");
+}
+
+function streamFromLines(lines: readonly string[]) {
+  return array2stream(lines.map((line) => `${line}\n`));
+}
+
+function createPipeline(lines: readonly string[]) {
+  let id = 1;
+  const streamId = `test-${id++}`;
+  return {
+    streamId,
+    nextId: () => `test-${id++}`,
+    base: streamFromLines(lines)
+      .pipeThrough(createStatsCollector(streamId, 5000))
+      .pipeThrough(createLineStream(streamId))
+      .pipeThrough(createDataStream(streamId))
+      .pipeThrough(createSseStream(streamId)),
+  };
+}
+
+export function runSsePipeline(lines: readonly string[]) {
+  const { base } = createPipeline(lines);
+  return stream2array(base);
+}
+
+export function runDeltaPipeline(lines: readonly string[]) {
+  const { streamId, nextId, base } = createPipeline(lines);
+  return stream2array(base.pipeThrough(createDeltaStream(streamId, nextId)));
+}
+
+export function runFullPipeline(lines: readonly string[]) {
+  const { streamId, nextId, base } = createPipeline(lines);
+  return stream2array(
+    base
+      .pipeThrough(createDeltaStream(streamId, nextId))
+      .pipeThrough(createSectionsStream(streamId, nextId))
+  );
+}
+
+export function parseToplevelJson(events: readonly unknown[]) {
+  const text = events
+    .filter((event) => isToplevelLine(event))
+    .map((event) => event.line)
+    .join("\n");
+  return JSON.parse(text);
+}

--- a/call-ai/v2/vitest.browser.config.ts
+++ b/call-ai/v2/vitest.browser.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     name: "browser",
     include: ["**/*.test.ts"],
+    exclude: ["**/*.node.test.ts"],
     browser: {
       enabled: true,
       headless: true,

--- a/vibes.diy/vibe/srv-sandbox/README.md
+++ b/vibes.diy/vibe/srv-sandbox/README.md
@@ -1,0 +1,35 @@
+# `@vibes.diy/vibe-srv-sandbox`
+
+Bridge layer between runtime postMessage events and `vibes.diy` API calls.
+
+## `vibe.req.callAI` flow
+
+The callAI path is implemented in `call-ai-flow.ts` and is intentionally **structured-only**:
+
+1. Open application chat via `openChat`.
+2. Send prompt with:
+   - schema system message
+   - `response_format: { type: "json_object" }`
+3. Collect response text from `block.toplevel.line` events only.
+4. Return `vibe.res.callAI`:
+   - `{ status: "ok", promptId, result }`
+   - or `{ status: "error", message }`
+
+Notes:
+
+- There is no JSON code-block fallback mode in this flow.
+- Missing section events or empty toplevel content return an error response.
+
+## Tests
+
+Run package-local tests:
+
+```bash
+pnpm --dir vibes.diy/vibe/srv-sandbox test
+```
+
+Or from root project selection:
+
+```bash
+pnpm exec vitest run --config vitest.config.ts --project vibe-srv-sandbox
+```

--- a/vibes.diy/vibe/srv-sandbox/call-ai-flow.ts
+++ b/vibes.diy/vibe/srv-sandbox/call-ai-flow.ts
@@ -1,0 +1,171 @@
+import { processStream } from "@adviser/cement";
+import {
+  ChatMessage,
+  isToplevelLine,
+  type LLMRequest,
+  type ResponseFormat,
+} from "@vibes.diy/call-ai-v2";
+import type { ReqCallAI, ResErrorCallAI, ResOkCallAI } from "@vibes.diy/vibe-types";
+
+interface ResultLike<T = unknown> {
+  isErr(): boolean;
+  Err(): unknown;
+  Ok(): T;
+}
+
+interface CallAIChat {
+  readonly sectionStream: ReadableStream<unknown>;
+  prompt(req: LLMRequest): Promise<ResultLike>;
+}
+
+export interface CallAIApi {
+  openChat(req: {
+    readonly userSlug: string;
+    readonly appSlug: string;
+    readonly mode: "application";
+  }): Promise<ResultLike<CallAIChat>>;
+}
+
+interface SectionEventLike {
+  readonly type: "vibes.diy.section-event";
+  readonly promptId: string;
+  readonly blocks: readonly unknown[];
+}
+
+function isSectionEventLike(msg: unknown): msg is SectionEventLike {
+  if (typeof msg !== "object" || msg === null) {
+    return false;
+  }
+  const obj = msg as Record<string, unknown>;
+  return obj.type === "vibes.diy.section-event" && typeof obj.promptId === "string" && Array.isArray(obj.blocks);
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export interface CollectedResult {
+  readonly result: string;
+  readonly promptId: string;
+}
+
+export function buildCallAIPrompt(prompt: string, schema: unknown): LLMRequest {
+  const schemaMessages: ChatMessage[] = [
+    {
+      role: "system",
+      content: [
+        {
+          type: "text",
+          text: `Return a JSON object conforming to this schema: ${JSON.stringify(schema)}`,
+        },
+      ],
+    },
+  ];
+
+  const responseFormat: ResponseFormat = { type: "json_object" };
+
+  return {
+    messages: [
+      ...schemaMessages,
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: prompt,
+          },
+        ],
+      },
+    ],
+    response_format: responseFormat,
+  };
+}
+
+export async function collectStructuredResult(
+  stream: ReadableStream<unknown>
+): Promise<CollectedResult> {
+  let promptId: string | undefined;
+  let sawSectionEvent = false;
+  const textParts: string[] = [];
+
+  await processStream(stream, (msg) => {
+    if (!isSectionEventLike(msg)) {
+      return;
+    }
+
+    sawSectionEvent = true;
+    promptId = msg.promptId;
+    for (const block of msg.blocks) {
+      if (isToplevelLine(block)) {
+        textParts.push(block.line);
+      }
+    }
+  });
+
+  if (!sawSectionEvent || promptId === undefined) {
+    throw new Error("No section events received");
+  }
+
+  const result = textParts.join("\n");
+  if (result.length === 0) {
+    throw new Error("No toplevel text received");
+  }
+
+  return { result, promptId };
+}
+
+export async function executeCallAI(
+  req: ReqCallAI,
+  vibeDiyApi: CallAIApi
+): Promise<ResOkCallAI | ResErrorCallAI> {
+  const rChat = await vibeDiyApi.openChat({
+    userSlug: req.userSlug,
+    appSlug: req.appSlug,
+    mode: "application",
+  });
+
+  if (rChat.isErr()) {
+    return {
+      tid: req.tid,
+      type: "vibe.res.callAI",
+      status: "error",
+      message: toErrorMessage(rChat.Err()),
+    };
+  }
+
+  const chat = rChat.Ok();
+  const collectedPromise = collectStructuredResult(chat.sectionStream);
+  const promptReq = buildCallAIPrompt(req.prompt, req.schema);
+  const rPrompt = await chat.prompt(promptReq);
+
+  if (rPrompt.isErr()) {
+    void collectedPromise.catch(() => {});
+    return {
+      tid: req.tid,
+      type: "vibe.res.callAI",
+      status: "error",
+      message: toErrorMessage(rPrompt.Err()),
+    };
+  }
+
+  try {
+    const collected = await collectedPromise;
+    return {
+      tid: req.tid,
+      type: "vibe.res.callAI",
+      status: "ok",
+      promptId: collected.promptId,
+      result: collected.result,
+    };
+  } catch (error) {
+    return {
+      tid: req.tid,
+      type: "vibe.res.callAI",
+      status: "error",
+      message: toErrorMessage(error),
+    };
+  }
+}

--- a/vibes.diy/vibe/srv-sandbox/package.json
+++ b/vibes.diy/vibe/srv-sandbox/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "core-cli tsc",
     "pack": "core-cli build --doPack",
-    "publish": "core-cli build"
+    "publish": "core-cli build",
+    "test": "vitest run --config vitest.config.ts",
+    "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
     "@adviser/cement": "^0.5.32",

--- a/vibes.diy/vibe/srv-sandbox/srv-sandbox.test.ts
+++ b/vibes.diy/vibe/srv-sandbox/srv-sandbox.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { Result } from "@adviser/cement";
+import type { ReqCallAI } from "@vibes.diy/vibe-types";
+import type { LLMRequest } from "@vibes.diy/call-ai-v2";
+import { collectStructuredResult, executeCallAI } from "./call-ai-flow.js";
+import type { CallAIApi } from "./call-ai-flow.js";
+
+function createStream(events: readonly unknown[]): ReadableStream<unknown> {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(event);
+      }
+      controller.close();
+    },
+  });
+}
+
+function createBlockBase() {
+  return {
+    blockId: "block-1",
+    streamId: "stream-1",
+    seq: 2,
+    blockNr: 1,
+    timestamp: new Date(),
+  };
+}
+
+function createSectionEvent(blocks: readonly unknown[]) {
+  return {
+    type: "vibes.diy.section-event",
+    chatId: "chat-1",
+    promptId: "prompt-1",
+    blockSeq: 1,
+    timestamp: new Date(),
+    blocks,
+  };
+}
+
+function createToplevelLine(line: string) {
+  return {
+    ...createBlockBase(),
+    type: "block.toplevel.line",
+    sectionId: "section-1",
+    lineNr: 1,
+    line,
+  };
+}
+
+function makeReqCallAI(): ReqCallAI {
+  return {
+    tid: "tid-1",
+    type: "vibe.req.callAI",
+    userSlug: "user-1",
+    appSlug: "app-1",
+    prompt: "Describe a sandwich",
+    schema: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        layers: { type: "array", items: { type: "string" } },
+      },
+    },
+  };
+}
+
+interface MockApiState {
+  api: CallAIApi;
+  lastPromptReq: LLMRequest | undefined;
+}
+
+function makeApi(options: {
+  readonly openChatError?: string;
+  readonly promptError?: string;
+  readonly sectionEvents?: readonly unknown[];
+}): MockApiState {
+  const state: MockApiState = {
+    lastPromptReq: undefined,
+    api: {
+      openChat: async () => {
+        if (options.openChatError !== undefined) {
+          return Result.Err(new Error(options.openChatError));
+        }
+        return Result.Ok({
+          sectionStream: createStream(options.sectionEvents ?? []),
+          prompt: async (req: LLMRequest) => {
+            state.lastPromptReq = req;
+            if (options.promptError !== undefined) {
+              return Result.Err(new Error(options.promptError));
+            }
+            return Result.Ok({});
+          },
+        });
+      },
+    },
+  };
+
+  return state;
+}
+
+describe("collectStructuredResult", () => {
+  it("collects structured output from toplevel lines", async () => {
+    const jsonLine = '{"name":"club","layers":["bread","turkey"]}';
+    const stream = createStream([
+      createSectionEvent([createToplevelLine(jsonLine)]),
+    ]);
+
+    const res = await collectStructuredResult(stream);
+    expect(res.result).toBe(jsonLine);
+    expect(res.promptId).toBe("prompt-1");
+  });
+
+  it("rejects when stream has no section events", async () => {
+    await expect(collectStructuredResult(createStream([]))).rejects.toThrow("No section events received");
+  });
+});
+
+describe("executeCallAI", () => {
+  it("returns error when openChat fails", async () => {
+    const { api } = makeApi({ openChatError: "open chat failed" });
+    const res = await executeCallAI(makeReqCallAI(), api);
+    expect(res.status).toBe("error");
+    if (res.status === "error") {
+      expect(res.message).toContain("open chat failed");
+    }
+  });
+
+  it("returns error when prompt fails", async () => {
+    const { api } = makeApi({ promptError: "prompt failed" });
+    const res = await executeCallAI(makeReqCallAI(), api);
+    expect(res.status).toBe("error");
+    if (res.status === "error") {
+      expect(res.message).toContain("prompt failed");
+    }
+  });
+
+  it("returns ok with structured text and sends json_object response_format", async () => {
+    const jsonLine = '{"name":"club","layers":["bread"]}';
+    const state = makeApi({
+      sectionEvents: [createSectionEvent([createToplevelLine(jsonLine)])],
+    });
+
+    const res = await executeCallAI(makeReqCallAI(), state.api);
+    expect(res.status).toBe("ok");
+    if (res.status === "ok") {
+      expect(res.promptId).toBe("prompt-1");
+      expect(res.result).toBe(jsonLine);
+    }
+
+    expect(state.lastPromptReq).toBeDefined();
+    expect(state.lastPromptReq!.response_format).toEqual({ type: "json_object" });
+    expect(state.lastPromptReq!.messages[0].role).toBe("system");
+  });
+});

--- a/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
+++ b/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
@@ -10,9 +10,7 @@ import {
   EventoResult,
   EventoSendProvider,
   LRUMap,
-  processStream,
   EventoHandler,
-  Future,
   OnFunc,
 } from "@adviser/cement";
 import {
@@ -21,8 +19,6 @@ import {
   ResOkVibeRegisterFPDb,
   isReqCallAI,
   ReqCallAI,
-  ResErrorCallAI,
-  ResOkCallAI,
   EvtAttachFPDb,
   ReqFetchCloudToken,
   isReqFetchCloudToken,
@@ -31,8 +27,8 @@ import {
   EvtRuntimeReady,
 } from "@vibes.diy/vibe-types";
 import { clerkDashApi } from "@fireproof/core-protocols-dashboard";
-import { isSectionEvent, SectionEvent, VibesDiyApiIface } from "@vibes.diy/api-types";
-import { ChatMessage, CodeEndMsg, isCodeBegin, isCodeEnd, isCodeLine, isPromptReq, PromptReq } from "@vibes.diy/call-ai-v2";
+import { VibesDiyApiIface } from "@vibes.diy/api-types";
+import { executeCallAI } from "./call-ai-flow.js";
 
 export class MessageEventEventoEnDecoder implements EventoEnDecoder<MessageEvent, unknown> {
   async encode(me: MessageEvent): Promise<Result<unknown>> {
@@ -157,36 +153,6 @@ function vibeRegisterFPDB(sandbox: vibesDiySrvSandbox): EventoHandler {
   };
 }
 
-export function getCodeBlock(stream: ReadableStream<unknown>): Promise<{
-  code: string;
-  sectionEvt: SectionEvent;
-  promptReq: PromptReq;
-  codeEnd: CodeEndMsg;
-}> {
-  const codeParts: string[] = [];
-  let promptReq!: PromptReq;
-  const firstCodeBlock = new Future<{ code: string; sectionEvt: SectionEvent; promptReq: PromptReq; codeEnd: CodeEndMsg }>();
-  processStream(stream, (msg) => {
-    if (isSectionEvent(msg)) {
-      for (const block of msg.blocks) {
-        if (isPromptReq(block)) {
-          promptReq = block;
-        }
-        if (isCodeBegin(block) && block.lang.toLocaleUpperCase() === "JSON") {
-          codeParts.splice(0, codeParts.length); // clear previous code parts
-        }
-        if (isCodeLine(block)) {
-          codeParts.push(block.line);
-        }
-        if (isCodeEnd(block)) {
-          firstCodeBlock.resolve({ code: codeParts.join("\n"), sectionEvt: msg, promptReq, codeEnd: block });
-        }
-      }
-    }
-  });
-  return firstCodeBlock.asPromise();
-}
-
 function vibeFetchCloudToken(sandbox: vibesDiySrvSandbox): EventoHandler {
   const { dashApi } = sandbox.args;
   return {
@@ -230,69 +196,8 @@ function vibeCallAI(sandbox: vibesDiySrvSandbox): EventoHandler {
       return Promise.resolve(Result.Ok(Option.None()));
     },
     handle: async (ctx: HandleTriggerCtx<Request, ReqCallAI, unknown>): Promise<Result<EventoResultType>> => {
-      console.log(`Handling vibe.callAI event with validated data`, ctx);
-      await vibeDiyApi
-        .openChat({ userSlug: ctx.validated.userSlug, appSlug: ctx.validated.appSlug, mode: "application" })
-        .then(async (rChat) => {
-          console.log(`openChat result in callAI handler`, rChat);
-          if (rChat.isErr()) {
-            return ctx.send.send(ctx, {
-              tid: ctx.validated.tid,
-              type: "vibe.res.callAI",
-              status: "error",
-              message: rChat.Err().message,
-            } satisfies ResErrorCallAI);
-          }
-          getCodeBlock(rChat.Ok().sectionStream).then(({ code, sectionEvt: msg }) => {
-            ctx.send.send(ctx, {
-              tid: ctx.validated.tid,
-              type: "vibe.res.callAI",
-              status: "ok",
-              promptId: msg.promptId,
-              result: code,
-            } satisfies ResOkCallAI);
-          });
-          // console.log(`Sending prompt to chat`, ctx.validated.prompt);
-          const generateSchema: ChatMessage[] = [];
-          if (ctx.validated.schema) {
-            console.log(`Prompt has schema, sending schema`, ctx.validated.schema);
-            generateSchema.push({
-              role: "system",
-              content: [
-                {
-                  type: "text",
-                  text: `Here is the JSON schema for the expected response. 
-                    Please generate one result that conforms to this schema.
-                    Output like Code Blocks and like \`\`\`JSON 
-                    ${JSON.stringify(ctx.validated.schema)}`,
-                },
-              ],
-            });
-          }
-          const rPrompt = await rChat.Ok().prompt({
-            messages: [
-              ...generateSchema,
-              {
-                role: "user",
-                content: [
-                  {
-                    type: "text",
-                    text: ctx.validated.prompt,
-                  },
-                ],
-              },
-            ],
-          });
-
-          if (rPrompt.isErr()) {
-            return ctx.send.send(ctx, {
-              tid: ctx.validated.tid,
-              type: "vibe.res.callAI",
-              status: "error",
-              message: rPrompt.Err().message,
-            } satisfies ResErrorCallAI);
-          }
-        });
+      const response = await executeCallAI(ctx.validated, vibeDiyApi);
+      await ctx.send.send(ctx, response);
       return Result.Ok(EventoResult.Stop);
     },
   };

--- a/vibes.diy/vibe/srv-sandbox/vitest.config.ts
+++ b/vibes.diy/vibe/srv-sandbox/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "vibe-srv-sandbox",
+    environment: "node",
+    include: ["srv-sandbox.test.ts"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "prompts/tests/vitest.node.config.ts",
       "prompts/tests/vitest.browser.config.ts",
       "hosting/tests/unit/vitest.config.ts",
+      "vibes.diy/vibe/srv-sandbox/vitest.config.ts",
     ],
   },
 });


### PR DESCRIPTION
## Summary

- **`buildRequestBody`** — produces correct request bodies for OpenAI (`response_format: json_schema`) and Anthropic (`tools`/`tool_choice`), auto-detecting API style from URL
- **Recursive schema processing** — auto-populates `required` and `additionalProperties: false` at all nesting levels so schemas only need `properties`
- **CLI `--text` flag** — outputs clean accumulated text instead of JSON event wrappers
- **CLI `--schema`** — loads JSON schema file, works with `--dry-run` for inspection
- **Anthropic SSE** — handles `event:`+`data:` format and `input_json_delta` for tool_use structured output
- **Fixture-based tests** — 4 provider fixtures (OpenRouter GPT, OpenRouter Claude 4-6, OpenAI direct, Anthropic direct) captured via `capture.sh`, loaded with `loadAsset`

## Test plan

- [x] 158 tests pass (node + browser)
- [x] `--dry-run --schema` shows correct bodies for both API styles
- [x] `--text --src` outputs clean JSON from all 4 fixtures
- [x] Schemas without `required` auto-populate from property keys at all levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)