### PR TITLE
fix: prompts browser tests — mock fetch and harness cleanup

### DIFF
--- a/prompts/pkg/package.json
+++ b/prompts/pkg/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "scripts": {
     "build": "core-cli tsc",
-    "test": "vitest run",
+    "test": "vitest run --config ../tests/vitest.config.ts",
     "pack": "core-cli build -x '^' --doPack",
     "publish": "core-cli build -x '^'"
   },

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -307,45 +307,18 @@ export async function makeBaseSystemPrompt(
   const concatenatedLlmsTxts: string[] = [];
   for (const llm of chosenLlms) {
     const rText = await keyedLoadAsset.get(llm.name).once(async () => {
-      // console.log("Loading text asset for LLM:", llm.name, urlDirname(import.meta.url), import.meta.url);
       return loadAsset(`./llms/${llm.name}.txt`, {
         fallBackUrl: "https://esm.sh/prompts/",
-        basePath: () => {
-          const dir = import.meta.url;
-          // console.log("Base path for loading LLM text asset:", dir);
-          return dir;
-        },
+        basePath: () => import.meta.url,
         mock: {
           fetch: sessionDoc.fetch,
         },
-        // mock: {
-        //   fetch:
-        //     sessionDoc.fetchText &&
-        //     (async (): Promise<Response> => {
-        //       if (!sessionDoc.fetchText) {
-        //         console.warn("No fetchText function provided in sessionDoc for loading LLM text assets");
-        //         return new Response(null, { status: 404 });
-        //       }
-        //       console.log(`pre-Fetched text for LLM ${llm.name} with result:`, r);
-        //       const r = await sessionDoc.fetchText("prompts", `./llms/${llm.name}.txt`);
-        //       console.log(`post-Fetched text for LLM ${llm.name} with result:`, r);
-        //       if (r.isErr()) {
-        //         return new Response(null, { status: 404 });
-        //       }
-        //       return new Response(r.Ok(), { status: 200 });
-        //     }),
-        // },
       });
     });
     if (rText.isErr()) {
-      console.warn(`Failed to load text for LLM ${llm.name} at path ${import.meta.dirname}/./llms/${llm.name}.txt:`, rText.Err());
+      console.warn(`Failed to load text for LLM ${llm.name}:`, rText.Err());
       continue;
     }
-    // const text = await getTexts(llm.name, sessionDoc.fallBackUrl);
-    // if (!text) {
-    //   console.warn("Failed to load raw LLM text for:", llm.name, sessionDoc.fallBackUrl);
-    //   continue;
-    // }
     concatenatedLlmsTxts.push(`<${llm.label}-docs>`);
     concatenatedLlmsTxts.push(rText.Ok() ?? "");
     concatenatedLlmsTxts.push(`</${llm.label}-docs>`);

--- a/prompts/tests/helpers/load-mock-data.ts
+++ b/prompts/tests/helpers/load-mock-data.ts
@@ -1,74 +1,48 @@
-// Simplified mock helper - only mocks text files now
-// JSON configs are imported directly as TypeScript modules
-
 /**
- * Creates a mock fetch implementation that serves only text documentation files.
- * JSON configs are now loaded directly as TypeScript imports, no mocking needed.
+ * Creates a mock fetch implementation that serves text documentation files.
+ * Accepts string, URL, or Request (matching the real fetch signature) since
+ * loadAsset from @adviser/cement calls fetch with URL objects.
  */
-export function createMockFetchFromPkgFiles(): (url: string) => Promise<Response> {
-  return (url: string) => {
-    // Mock text files - serve actual text file contents (abbreviated for tests)
-    if (url.includes("callai.txt")) {
-      return Promise.resolve({
-        ok: true,
-        text: () =>
-          Promise.resolve(
-            "<callAI-docs>\n# CallAI Documentation\nReal callAI docs content from pkg/llms/callai.txt\n</callAI-docs>"
-          ),
-      } as Response);
+export function createMockFetchFromPkgFiles(): typeof fetch {
+  function getInputUrl(input: Parameters<typeof fetch>[0]): string {
+    if (typeof input === "string") return input;
+    if (typeof input === "object" && input !== null) {
+      const requestUrl = Reflect.get(input, "url");
+      if (typeof requestUrl === "string") return requestUrl;
+      const href = Reflect.get(input, "href");
+      if (typeof href === "string") return href;
+    }
+    return String(input);
+  }
+
+  async function mockFetch(input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]): Promise<Response> {
+    const url = getInputUrl(input);
+
+    const mockDocs: Record<string, string> = {
+      "callai.txt": "<callAI-docs>\n# CallAI Documentation\nReal callAI docs content from pkg/llms/callai.txt\n</callAI-docs>",
+      "fireproof.txt":
+        "<useFireproof-docs>\n# Fireproof Documentation\nReal Fireproof docs content from pkg/llms/fireproof.txt\n</useFireproof-docs>",
+      "image-gen.txt":
+        "<imageGen-docs>\n# Image Generation Documentation\nReal ImageGen docs content from pkg/llms/image-gen.txt\n</imageGen-docs>",
+      "web-audio.txt":
+        "<webAudio-docs>\n# Web Audio Documentation\nReal Web Audio docs content from pkg/llms/web-audio.txt\n</webAudio-docs>",
+      "d3.txt": "<D3.js-docs>\n# D3.js Documentation\nReal D3 docs content from pkg/llms/d3.md\n</D3.js-docs>",
+      "d3.md": "<D3.js-docs>\n# D3.js Documentation\nReal D3 docs content from pkg/llms/d3.md\n</D3.js-docs>",
+      "three-js.txt":
+        "<Three.js-docs>\n# Three.js Documentation\nReal Three.js docs content from pkg/llms/three-js.md\n</Three.js-docs>",
+      "three-js.md":
+        "<Three.js-docs>\n# Three.js Documentation\nReal Three.js docs content from pkg/llms/three-js.md\n</Three.js-docs>",
+    };
+
+    for (const [pattern, content] of Object.entries(mockDocs)) {
+      if (url.includes(pattern)) {
+        return new Response(content, { status: 200 });
+      }
     }
 
-    if (url.includes("fireproof.txt")) {
-      return Promise.resolve({
-        ok: true,
-        text: () =>
-          Promise.resolve(
-            "<useFireproof-docs>\n# Fireproof Documentation\nReal Fireproof docs content from pkg/llms/fireproof.txt\n</useFireproof-docs>"
-          ),
-      } as Response);
-    }
+    // Default fallback for unmatched text files
+    return new Response("<mock-docs>\n# Mock Documentation\nMock docs content\n</mock-docs>", { status: 200 });
+  }
 
-    if (url.includes("image-gen.txt")) {
-      return Promise.resolve({
-        ok: true,
-        text: () =>
-          Promise.resolve(
-            "<imageGen-docs>\n# Image Generation Documentation\nReal ImageGen docs content from pkg/llms/image-gen.txt\n</imageGen-docs>"
-          ),
-      } as Response);
-    }
-
-    if (url.includes("web-audio.txt")) {
-      return Promise.resolve({
-        ok: true,
-        text: () =>
-          Promise.resolve(
-            "<webAudio-docs>\n# Web Audio Documentation\nReal Web Audio docs content from pkg/llms/web-audio.txt\n</webAudio-docs>"
-          ),
-      } as Response);
-    }
-
-    if (url.includes("d3.txt") || url.includes("d3.md")) {
-      return Promise.resolve({
-        ok: true,
-        text: () => Promise.resolve("<D3.js-docs>\n# D3.js Documentation\nReal D3 docs content from pkg/llms/d3.md\n</D3.js-docs>"),
-      } as Response);
-    }
-
-    if (url.includes("three-js.txt") || url.includes("three-js.md")) {
-      return Promise.resolve({
-        ok: true,
-        text: () =>
-          Promise.resolve(
-            "<Three.js-docs>\n# Three.js Documentation\nReal Three.js docs content from pkg/llms/three-js.md\n</Three.js-docs>"
-          ),
-      } as Response);
-    }
-
-    // Default response for other text files - fallback mock
-    return Promise.resolve({
-      ok: true,
-      text: () => Promise.resolve("<mock-docs>\n# Mock Documentation\nMock docs content\n</mock-docs>"),
-    } as Response);
-  };
+  return mockFetch;
 }

--- a/prompts/tests/prompt-builder.test.ts
+++ b/prompts/tests/prompt-builder.test.ts
@@ -6,84 +6,17 @@ import {
   makeBaseSystemPrompt,
   defaultStylePrompt,
 } from "@vibes.diy/prompts";
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Result } from "@adviser/cement";
 import { createMockFetchFromPkgFiles } from "./helpers/load-mock-data.js";
-
-// Create a fetchText mock that delegates to the mock fetch helper
-const mockFetchImpl = createMockFetchFromPkgFiles();
-function mockFetchText(_pkg: string, path: string): Promise<Result<string>> {
-  return mockFetchImpl(path).then(async (res) => {
-    if (res.ok) return Result.Ok(await res.text());
-    return Result.Err(new Error(`fetch failed for path: ${path}`));
-  });
-}
-
-// Mock global fetch for the tests
-const mockFetch = vi.fn();
-globalThis.fetch = mockFetch;
-// await import("~/vibes.diy/app/llms/catalog.js");
-
-// import * as mod from "~/vibes.diy/app/prompts.js";
 
 // Use a known finite set for testing, excluding three-js to keep tests stable
 const knownModuleNames = ["callai", "fireproof", "image-gen", "web-audio"];
 
-// Ensure we use the real implementation of ../app/prompts in this file only
-// Some tests and the global setup mock this module; undo that here before importing it.
-// (vi as any).doUnmock?.("~/vibes.diy/app/prompts");
-// vi.unmock("~/vibes.diy/app/prompts");
-// Reset the module registry and mock env before importing the module under test.
-// vi.resetModules();
-
-// vi.mock("~/vibes.diy/app/config/env.js", () => ({
-//   CALLAI_ENDPOINT: "http://localhost/test",
-//   APP_MODE: "test",
-// }));
-
-// Mock the callAI function to return our known finite set for testing
-// vi.mock("call-ai", () => ({
-//   callAI: vi.fn().mockResolvedValue(
-//     JSON.stringify({
-//       selected: knownModuleNames,
-//       instructionalText: true,
-//       demoData: true,
-//     }),
-//   ),
-// }));
-
-// Will be assigned in beforeAll after we unmock and re-import the module
-// let generateImportStatements: typeof generateImportStatements; // (llms: unknown[]) => string;
-// let makeBaseSystemPrompt: typeof makeBaseSystemPrompt;
-// let preloadLlmsText: () => Promise<void>;
-// no-op vars (past defaults not needed with schema-based selection)
-
-// Load actual LLM configs and txt content from app/llms
-// Use eager glob so it's resolved at import time in Vitest/Vite environment
-let llmsJsonModules: JsonDocs;
-// import.meta.glob("~/vibes.diy/app/llms/*.json", {
-//   eager: true,
-// }) as Record<string, { default: unknown }>;
-
-// Filter to only include our known set, deterministic order by name
-let orderedLlms: LlmCatalogEntry[];
-
-// Load the raw text files; key by filepath, value is file contents
-// let llmsTxtModules: TxtDocs;
-//  import.meta.glob("~/vibes.diy/app/llms/*.txt", {
-//   eager: true,
-//   as: "raw",
-// }) as Record<string, string>;
-
-// function textForName(name: string): string {
-//   const entry = Object.entries(llmsTxtModules).find(([p]) =>
-//     p.endsWith(`${name}.txt`)
-//   );
-//   return entry ? (entry[1] as unknown as string) : "";
-// }
+const mockFetchImpl = createMockFetchFromPkgFiles();
 
 const opts = {
-  fetchText: mockFetchText,
+  fetch: mockFetchImpl,
   callAi: {
     ModuleAndOptionsSelection: vi.fn().mockResolvedValue(
       Result.Ok(
@@ -97,21 +30,21 @@ const opts = {
   },
 };
 
-beforeAll(async () => {
-  // Set up mock using the same mock fetch helper used by mockFetchText
-  mockFetch.mockImplementation(mockFetchImpl);
+// Will be assigned in beforeAll after JSON docs load
+let llmsJsonModules: JsonDocs;
+let orderedLlms: LlmCatalogEntry[];
 
-  // Now load the data after mocks are set up
+beforeAll(async () => {
+  // getJsonDocs uses globalThis.fetch internally — mock it for this setup
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = mockFetchImpl;
   llmsJsonModules = await getJsonDocs();
+  globalThis.fetch = origFetch;
 
   orderedLlms = Object.entries(llmsJsonModules)
     .filter(([path, _]) => knownModuleNames.some((name) => path.includes(`${name}.json`)))
     .sort((a, b) => a[0].localeCompare(b[0]))
     .map(([_, mod]) => mod.obj);
-});
-
-beforeEach(() => {
-  mockFetch.mockClear();
 });
 
 describe("prompt builder (real implementation)", () => {
@@ -208,9 +141,6 @@ describe("prompt builder (real implementation)", () => {
   });
 
   it("makeBaseSystemPrompt: in test mode, non-override path includes all catalog imports and docs; default stylePrompt", async () => {
-    // Warm cache so docs are available via raw imports
-    // await preloadLlmsText();
-
     const result = await makeBaseSystemPrompt("test-model", {
       stylePrompt: undefined,
       userPrompt: undefined,
@@ -228,22 +158,12 @@ describe("prompt builder (real implementation)", () => {
       expect(result.systemPrompt).toContain(`<${llm.label}-docs>`);
       expect(result.systemPrompt).toContain(`</${llm.label}-docs>`);
     }
-    // Concatenated docs for chosen LLMs in the same order
-    // const expectedDocs = chosenLlms
-    //   .map(
-    //     (llm) =>
-    //       `\n<${llm.label}-docs>\n${textForName(llm.name) || ""}\n</${llm.label}-docs>\n`
-    //   )
-    //   .join("");
-    // expect(prompt).toContain(expectedDocs);
 
     // Default style prompt appears when undefined; assert against explicit export
     expect(result.systemPrompt).toContain(defaultStylePrompt);
   });
 
   it("makeBaseSystemPrompt: supports custom stylePrompt and userPrompt", async () => {
-    // await preloadLlmsText();
-
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
       stylePrompt: "custom",
@@ -263,7 +183,6 @@ describe("prompt builder (real implementation)", () => {
   });
 
   it("makeBaseSystemPrompt: honors explicit dependencies only when override=true", async () => {
-    // await preloadLlmsText();
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
       dependencies: ["fireproof"],
@@ -274,7 +193,6 @@ describe("prompt builder (real implementation)", () => {
   });
 
   it("makeBaseSystemPrompt: includes demo-data guidance when selector enables it (test mode)", async () => {
-    // await preloadLlmsText();
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
       stylePrompt: undefined,
@@ -286,7 +204,6 @@ describe("prompt builder (real implementation)", () => {
   });
 
   it("makeBaseSystemPrompt: respects demoDataOverride=false to disable demo data", async () => {
-    // await preloadLlmsText();
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
       stylePrompt: undefined,
@@ -299,7 +216,6 @@ describe("prompt builder (real implementation)", () => {
   });
 
   it("makeBaseSystemPrompt: respects demoDataOverride=true to force demo data", async () => {
-    // await preloadLlmsText();
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
       stylePrompt: undefined,

--- a/prompts/tests/prompts-dependencies.integration.test.ts
+++ b/prompts/tests/prompts-dependencies.integration.test.ts
@@ -1,44 +1,10 @@
 import * as mod from "@vibes.diy/prompts";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Result } from "@adviser/cement";
 import { createMockFetchFromPkgFiles } from "./helpers/load-mock-data.js";
 
-// Create a fetchText mock that delegates to the mock fetch helper
-const mockFetchImpl = createMockFetchFromPkgFiles();
-function mockFetchText(_pkg: string, path: string): Promise<Result<string>> {
-  return mockFetchImpl(path).then(async (res) => {
-    if (res.ok) return Result.Ok(await res.text());
-    return Result.Err(new Error(`fetch failed for path: ${path}`));
-  });
-}
-
-// Mock global fetch for the integration tests
-const mockFetch = vi.fn();
-globalThis.fetch = mockFetch;
-
-// Ensure real implementation
-// (vi as any).doUnmock?.("~/vibes.diy/app/prompts");
-//vi.unmock("~/vibes.diy/app/prompts.js");
-// vi.resetModules();
-
-// let makeBaseSystemPrompt: typeof mod.makeBaseSystemPrompt;
-// let preloadLlmsText: () => Promise<void>;
-
-beforeAll(async () => {
-  // const mod = await import("~/vibes.diy/app/prompts.js");
-  // makeBaseSystemPrompt = mod.makeBaseSystemPrompt;
-  // preloadLlmsText = mod.preloadLlmsText;
-});
-
-beforeEach(() => {
-  mockFetch.mockClear();
-
-  // Set up mock using real files from pkg directory
-  mockFetch.mockImplementation(createMockFetchFromPkgFiles());
-});
-
 const opts = {
-  fetchText: mockFetchText,
+  fetch: createMockFetchFromPkgFiles(),
   callAi: {
     ModuleAndOptionsSelection: vi.fn().mockResolvedValue(
       Result.Ok(
@@ -52,7 +18,6 @@ const opts = {
 
 describe("makeBaseSystemPrompt dependency selection", () => {
   it("when override is false/absent, uses schema-driven selection (test mode => all); includes core libs", async () => {
-    // await preloadLlmsText();
     const result = await mod.makeBaseSystemPrompt("anthropic/claude-sonnet-4.5", {
       ...opts,
       _id: "user_settings",
@@ -66,7 +31,6 @@ describe("makeBaseSystemPrompt dependency selection", () => {
   });
 
   it("honors explicit dependencies only when override=true", async () => {
-    // await preloadLlmsText();
     const result = await mod.makeBaseSystemPrompt("anthropic/claude-sonnet-4.5", {
       _id: "user_settings",
       dependencies: ["fireproof"],
@@ -81,7 +45,6 @@ describe("makeBaseSystemPrompt dependency selection", () => {
   });
 
   it("ignores explicit dependencies when override=false (still schema-driven)", async () => {
-    // await preloadLlmsText();
     const result = await mod.makeBaseSystemPrompt("anthropic/claude-sonnet-4.5", {
       _id: "user_settings",
       dependencies: ["fireproof"],

--- a/prompts/tests/vitest.config.ts
+++ b/prompts/tests/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
+
+const testsDir = path.dirname(new URL(import.meta.url).pathname);
 
 export default defineConfig({
   test: {
-    projects: ["vitest.node.config.ts", "vitest.browser.config.ts"],
+    projects: [
+      path.join(testsDir, "vitest.node.config.ts"),
+      path.join(testsDir, "vitest.browser.config.ts"),
+    ],
   },
 });


### PR DESCRIPTION
## Summary
- Fix prompts browser tests that were failing with `url.includes is not a function`
- Tests passed in node (loadAsset reads files from disk) but failed in browser (loadAsset calls fetch with URL objects, mock only accepted strings)
- Replace dead `fetchText` mock key with `fetch` (what the code actually reads)
- Clean up test files: remove globalThis.fetch side effects, dead code, commented-out blocks
- Fix `pnpm --filter prompts test` — now works standalone with correct config path

## Test plan
- [x] `npx vitest run --project "prompts:node"` — 30/30 pass
- [x] `npx vitest run --project "prompts:browser"` — 30/30 pass
- [x] `pnpm --filter prompts test` — 60/60 pass (both projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)