### PR TITLE
Fix login overlay blocking interaction when not signed in

### DIFF
--- a/vibes.diy/pkg/app/routes/chat/prompt.tsx
+++ b/vibes.diy/pkg/app/routes/chat/prompt.tsx
@@ -62,7 +62,7 @@ export default function ChatPrompt() {
   return (
     <>
       <Chat inConstruction />
-      {createPortal(
+      {isSignedIn && prompt64 && createPortal(
         <div
           style={{
             position: "fixed",


### PR DESCRIPTION
The "Preparing AI Session" overlay was rendered unconditionally via createPortal, covering the entire screen with z-index 9999. When a user is not signed in, this blocks all interaction including the login button. Now the overlay only renders when isSignedIn && prompt64.