### PR TITLE
Simplify callAI docs and improve system prompt

### DIFF
--- a/prompts/pkg/llms/callai.txt
+++ b/prompts/pkg/llms/callai.txt
@@ -26,6 +26,7 @@ const todoResponse = await callAI("Give me a todo list for learning React", {
     properties: {
       todos: {
         type: "array",
+        description: "List of actionable todo items",
         items: { type: "string" }
       }
     }
@@ -55,10 +56,10 @@ const response = await callAI("Generate 4 items with label, status, priority (lo
         items: {
           type: "object",
           properties: {
-            label: { type: "string" },
-            status: { type: "string" },
-            priority: { type: "string" },
-            notes: { type: "string" }
+            label: { type: "string", description: "Short name for the item" },
+            status: { type: "string", description: "Current status (active, done, blocked)" },
+            priority: { type: "string", description: "Priority level (low, medium, high, critical)" },
+            notes: { type: "string", description: "Additional context or details" }
           }
         }
       }

--- a/prompts/pkg/llms/callai.txt
+++ b/prompts/pkg/llms/callai.txt
@@ -11,24 +11,7 @@ import { callAI } from 'call-ai';
 
 // Default behavior - returns a Promise<string>
 const response = await callAI("Write a haiku");
-
-// Use the complete response directly
 console.log(response); // Complete response text
-```
-
-## Streaming Mode
-
-If you prefer to receive the response incrementally as it's generated, set `stream: true`. This returns an AsyncGenerator which must be awaited:
-
-```javascript
-import { callAI } from 'call-ai';
-
-// Enable streaming mode explicitly - returns an AsyncGenerator
-const generator = await callAI("Write an epic poem", { stream: true });
-// Process the streaming response
-for await (const partialResponse of generator) {
-  console.log(partialResponse); // Updates incrementally
-}
 ```
 
 ## JSON Schema Responses
@@ -40,7 +23,6 @@ import { callAI } from 'call-ai';
 
 const todoResponse = await callAI("Give me a todo list for learning React", {
   schema: {
-    name: "todo",  // Optional - defaults to "result" if not provided
     properties: {
       todos: {
         type: "array",
@@ -53,189 +35,19 @@ const todoData = JSON.parse(todoResponse);
 console.log(todoData.todos); // Array of todo items
 ```
 
-## JSON with Streaming
-
-In this example, we're using the `callAI` helper function to get weather data in a structured format with streaming preview:
-
-```javascript
-import { callAI } from 'call-ai';
-
-// Get weather data with streaming updates
-const generator = await callAI("What's the weather like in Paris today?", {
-  stream: true,
-  schema: {
-    properties: {
-      location: {
-        type: "string",
-        description: "City or location name"
-      },
-      temperature: {
-        type: "number",
-        description: "Temperature in Celsius"
-      },
-      conditions: {
-        type: "string",
-        description: "Weather conditions description"
-      }
-    }
-  }
-});
-
-// Preview streaming updates as they arrive, don't parse until the end
-const resultElement = document.getElementById('result');
-let finalResponse;
-
-for await (const partialResponse of generator) {
-  resultElement.textContent = partialResponse;
-  finalResponse = partialResponse;
-}
-
-// Parse final result
-try {
-  const weatherData = JSON.parse(finalResponse);
-  
-  // Access individual fields
-  const { location, temperature, conditions } = weatherData;
-  
-  // Update UI with formatted data
-  document.getElementById('location').textContent = location;
-  document.getElementById('temperature').textContent = `${temperature}°C`;
-  document.getElementById('conditions').textContent = conditions;
-} catch (error) {
-  console.error("Failed to parse response:", error);
-}
-```
-
 ### Schema Structure Recommendations
 
 1. **Flat schemas perform better across all models**. If you need maximum compatibility, avoid deeply nested structures.
 
 2. **Field names matter**. Some models have preferences for certain property naming patterns:
-   - Use simple, common naming patterns like `name`, `type`, `items`, `price` 
+   - Use simple, common naming patterns like `name`, `type`, `items`, `price`
    - Avoid deeply nested object hierarchies (more than 2 levels deep)
    - Keep array items simple (strings or flat objects)
-
-## Specifying a Model
-
-By default, the function uses `openrouter/auto` (automatic model selection). You can specify a different model:
-
-```javascript
-import { callAI } from 'call-ai';
-
-// Use a specific model via options
-const response = await callAI(
-  "Explain quantum computing in simple terms", 
-  { model: "openai/gpt-4o" }
-);
-
-console.log(response);
-```
-
-## Additional Options
-
-You can pass extra parameters to customize the request:
-
-```javascript
-import { callAI } from 'call-ai';
-
-const response = await callAI(
-  "Write a creative story",
-  {
-    model: "anthropic/claude-3-opus",
-    temperature: 0.8,     // Higher for more creativity (0-1)
-    max_tokens: 1000,     // Limit response length
-    top_p: 0.95           // Control randomness
-  }
-);
-
-console.log(response);
-```
-
-## Message History
-
-For multi-turn conversations, you can pass an array of messages:
-
-```javascript
-import { callAI } from 'call-ai';
-
-// Create a conversation
-const messages = [
-  { role: "system", content: "You are a helpful coding assistant." },
-  { role: "user", content: "How do I use React hooks?" },
-  { role: "assistant", content: "React hooks are functions that let you use state and other React features in functional components..." },
-  { role: "user", content: "Can you show me an example of useState?" }
-];
-
-// Pass the entire conversation history
-const response = await callAI(messages);
-console.log(response);
-
-// To continue the conversation, add the new response and send again
-messages.push({ role: "assistant", content: response });
-messages.push({ role: "user", content: "What about useEffect?" });
-
-// Call again with updated history
-const nextResponse = await callAI(messages);
-console.log(nextResponse);
-```
-
-## Recommended Models
-
-| Model | Best For | Speed vs Quality |
-|-------|----------|------------------|
-| `openrouter/auto` | Default, automatically selects | Adaptive |
-| `openai/gpt-4o-mini` | data generation | Fast, good quality |
-| `anthropic/claude-3-haiku` | Cost-effective | Fast, good quality |
-| `openai/gpt-4o` | Best overall quality | Medium speed, highest quality |
-| `anthropic/claude-3-opus` | Complex reasoning | Slower, highest quality |
-| `mistralai/mistral-large` | Open weights alternative | Good balance |
-
-
-## Items with lists
-
-```javascript
-import { callAI } from 'call-ai';
-
-const generator = await callAI([
-  {
-    role: "user",
-    content: "Generate 3 JSON records with name, description, tags, and priority (0 is highest, 5 is lowest)."
-  }
-], {
-  stream: true,
-  schema: {
-    properties: {
-      records: {
-        type: "array",
-        items: {
-          type: "object",
-          properties: {
-            name: { type: "string" },
-            description: { type: "string" },
-            tags: {
-              type: "array",
-              items: { type: "string" }
-            },
-            priority: { type: "integer" }
-          }
-        }
-      }
-    }
-  }
-});
-
-for await (const partialResponse of generator) {
-  console.log(partialResponse);
-}
-
-const recordData = JSON.parse(/* final response */);
-console.log(recordData.records); // Array of records
-```
 
 ## Items with properties
 
 ```javascript
-const demoData = await callAI("Generate 4 items with label, status, priority (low, medium, high, critical), and notes. Return as structured JSON with these fields.", {
+const response = await callAI("Generate 4 items with label, status, priority (low, medium, high, critical), and notes. Return as structured JSON with these fields.", {
   schema: {
     properties: {
       items: {
@@ -253,64 +65,88 @@ const demoData = await callAI("Generate 4 items with label, status, priority (lo
     }
   }
 });
+const demoData = JSON.parse(response);
+console.log(demoData.items); // Array of item objects
 ```
 
-## Error Handling
+## Streaming Mode
 
-Errors are handled through standard JavaScript try/catch blocks:
+For text responses you want to display incrementally, set `stream: true`. This returns an AsyncGenerator that yields chunks of text as they arrive:
+
+```javascript
+import { callAI } from 'call-ai';
+
+const generator = await callAI("Write an epic poem", { stream: true });
+let full = '';
+for await (const chunk of generator) {
+  full += chunk;
+  console.log(full); // Append each chunk to build the full response
+}
+```
+
+## Specifying a Model
+
+By default, the function uses `openrouter/auto` (automatic model selection). You can specify a different model:
+
+```javascript
+import { callAI } from 'call-ai';
+
+const response = await callAI(
+  "Explain quantum computing in simple terms",
+  { model: "openai/gpt-4o" }
+);
+```
+
+## Message History
+
+For multi-turn conversations, you can pass an array of messages:
+
+```javascript
+import { callAI } from 'call-ai';
+
+const messages = [
+  { role: "system", content: "You are a helpful coding assistant." },
+  { role: "user", content: "How do I use React hooks?" },
+  { role: "assistant", content: "React hooks are functions that let you use state and other React features in functional components..." },
+  { role: "user", content: "Can you show me an example of useState?" }
+];
+
+const response = await callAI(messages);
+console.log(response);
+
+// To continue the conversation, add the new response and send again
+messages.push({ role: "assistant", content: response });
+messages.push({ role: "user", content: "What about useEffect?" });
+
+const nextResponse = await callAI(messages);
+```
+
+## Recommended Models
+
+| Model | Best For | Speed vs Quality |
+|-------|----------|------------------|
+| `openrouter/auto` | Default, automatically selects | Adaptive |
+| `openai/gpt-4o-mini` | data generation | Fast, good quality |
+| `anthropic/claude-3-haiku` | Cost-effective | Fast, good quality |
+| `openai/gpt-4o` | Best overall quality | Medium speed, highest quality |
+| `anthropic/claude-3-opus` | Complex reasoning | Slower, highest quality |
+| `mistralai/mistral-large` | Open weights alternative | Good balance |
+
+## Error Handling
 
 ```javascript
 import { callAI } from 'call-ai';
 
 try {
-
-  const response = await callAI("Generate some content", {
-    apiKey: "invalid-key" // Invalid or missing API key
-  });
-  
-  // If no error was thrown, process the normal response
+  const response = await callAI("Generate some content");
   console.log(response);
 } catch (error) {
-  // API errors are standard Error objects with useful properties
   console.error("API error:", error.message);
   console.error("Status code:", error.status);
   console.error("Error type:", error.errorType);
   console.error("Error details:", error.details);
 }
 ```
-
-For streaming mode, error handling works the same way:
-
-```javascript
-import { callAI } from 'call-ai';
-
-try {
-  const generator = await callAI("Generate some content", {
-    apiKey: "invalid-key", // Invalid or missing API key
-    stream: true
-  });
-  
-  // Any error during streaming will throw an exception
-  let finalResponse = '';
-  for await (const chunk of generator) {
-    finalResponse = chunk;
-    console.log("Chunk:", chunk);
-  }
-  
-  // Process the final response
-  console.log("Final response:", finalResponse);
-} catch (error) {
-  // Handle errors with standard try/catch
-  console.error("API error:", error.message);
-  console.error("Error properties:", {
-    status: error.status,
-    type: error.errorType,
-    details: error.details
-  });
-}
-```
-
-This approach is idiomatic and consistent with standard JavaScript practices. Errors provide rich information for better debugging and error handling in your applications.
 
 ## Image Recognition Example
 
@@ -319,29 +155,25 @@ Call-AI supports image recognition using multimodal models like GPT-4o. You can 
 ```javascript
 import { callAI } from 'call-ai';
 
-// Function to analyze an image using GPT-4o
 async function analyzeImage(imageFile, prompt = 'Describe this image in detail') {
-  // Convert the image file to a data URL
   const dataUrl = await fileToDataUrl(imageFile);
-  
+
   const content = [
     { type: 'text', text: prompt },
     { type: 'image_url', image_url: { url: dataUrl } }
   ];
-  
-  // Call the model with the multimodal content
+
   const result = await callAI(
     [{ role: 'user', content }],
     {
-      model: 'openai/gpt-4o-2024-08-06', // Or 'openai/gpt-4o-latest'
+      model: 'openai/gpt-4o-2024-08-06',
       apiKey: window.CALLAI_API_KEY,
     }
   );
-  
+
   return result;
 }
 
-// Helper function to convert File to data URL
 async function fileToDataUrl(file) {
   return new Promise((resolve) => {
     const reader = new FileReader();

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -397,7 +397,7 @@ export async function makeBaseSystemPrompt(
     ...(userPrompt ? [userPrompt, ""] : []),
     "IMPORTANT: You are working in one JavaScript file, use tailwind classes for styling. Remember to use brackets like bg-[#242424] for custom colors.",
     "",
-    "Before writing code, provide a title and brief description of the app. Then list the top 3 features that are the best fit for a browser-only database with real-time collaboration and describe a short planned workflow showing how those features connect into a coherent user experience.",
+    "Before writing code, provide a title and brief description of the app. Then list the top 3 features that are the best fit for a mobile web database with real-time collaboration and describe a short planned workflow showing how those features connect into a coherent user experience.",
     "",
     "Then write the full component code block. After the code block, add a short message (1-2 sentences) describing the core workflow the app supports.",
     "",

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -418,8 +418,3 @@ export async function makeBaseSystemPrompt(
     model,
   };
 }
-
-// Response format requirements
-export const RESPONSE_FORMAT = {
-  structure: ["Title and description", "Top 7 features", "Top 3 for browser-only collab", "Planned workflow", "Component code", "Core workflow summary"],
-};

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -358,7 +358,7 @@ export async function makeBaseSystemPrompt(
   const stylePrompt = sessionDoc?.stylePrompt || defaultStylePrompt;
 
   const demoDataLines = includeDemoData
-    ? `- If your app has a function that uses callAI with a schema to save data, include a Demo Data button that calls that function with an example prompt. Don't write an extra function, use real app code so the data illustrates what it looks like to use the app.\n- Never have have an instance of callAI that is only used to generate demo data, always use the same calls that are triggered by user actions in the app.\n`
+    ? `- If your app has a function that uses callAI with a schema to save data, include a Demo Data button that calls that function with an example prompt. Don't write an extra function, use real app code so the data illustrates what it looks like to use the app.\n- Never have an instance of callAI that is only used to generate demo data, always use the same calls that are triggered by user actions in the app.\n`
     : "";
 
   const systemPromptLines = [
@@ -371,7 +371,7 @@ export async function makeBaseSystemPrompt(
     "- Avoid using external libraries unless they are essential for the component to function",
     "- Always import the libraries you need at the top of the file",
     "- Use Fireproof for data persistence",
-    "- Use `callAI` to fetch AI (set `stream: true` to enable streaming), use Structured JSON Outputs like this: `callAI(prompt, { schema: { properties: { todos: { type: 'array', items: { type: 'string' } } } } })` and save final responses as individual Fireproof documents.",
+    "- Use `callAI` to fetch AI, use schema like this: `JSON.parse(await callAI(prompt, { schema: { properties: { todos: { type: 'array', items: { type: 'string' } } } } }))` and save final responses as individual Fireproof documents.",
     "- For file uploads use drag and drop and store using the `doc._files` API",
     "- Don't try to generate png or base64 data, use placeholder image APIs instead, like https://picsum.photos/400 where 400 is the square size",
     "- Consider and potentially reuse/extend code from previous responses if relevant",
@@ -381,7 +381,7 @@ export async function makeBaseSystemPrompt(
     "- Keep the database name stable as you edit the code",
     "- The system can send you crash reports, fix them by simplifying the affected code",
     "- List data items on the main page of your app so users don't have to hunt for them",
-    "- If you save data, make sure it is browseable in the app, eg lists should be clickable for more details",
+    "- If you save data, make sure it is browsable in the app, eg lists should be clickable for more details",
     demoDataLines,
   ];
 
@@ -397,7 +397,9 @@ export async function makeBaseSystemPrompt(
     ...(userPrompt ? [userPrompt, ""] : []),
     "IMPORTANT: You are working in one JavaScript file, use tailwind classes for styling. Remember to use brackets like bg-[#242424] for custom colors.",
     "",
-    "Provide a title and brief explanation followed by the component code. The component should demonstrate proper Fireproof integration with real-time updates and proper data persistence.",
+    "Before writing code, provide a title and brief description of the app. Then list the top 3 features that are the best fit for a browser-only database with real-time collaboration and describe a short planned workflow showing how those features connect into a coherent user experience.",
+    "",
+    "Then write the full component code block. After the code block, add a short message (1-2 sentences) describing the core workflow the app supports.",
     "",
     "Begin the component with the import statements. Use react and the following libraries:",
     "",
@@ -419,5 +421,5 @@ export async function makeBaseSystemPrompt(
 
 // Response format requirements
 export const RESPONSE_FORMAT = {
-  structure: ["Brief explanation", "Component code with proper Fireproof integration", "Real-time updates", "Data persistence"],
+  structure: ["Title and description", "Top 7 features", "Top 3 for browser-only collab", "Planned workflow", "Component code", "Core workflow summary"],
 };

--- a/prompts/tests/settings-prompt.test.ts
+++ b/prompts/tests/settings-prompt.test.ts
@@ -61,7 +61,7 @@ ${
     : ""
 }IMPORTANT: You are working in one JavaScript file, use tailwind classes for styling. Remember to use brackets like bg-[#242424] for custom colors.
 
-Before writing code, provide a title and brief description of the app. Then list the top 3 features that are the best fit for a browser-only database with real-time collaboration and describe a short planned workflow showing how those features connect into a coherent user experience.
+Before writing code, provide a title and brief description of the app. Then list the top 3 features that are the best fit for a mobile web database with real-time collaboration and describe a short planned workflow showing how those features connect into a coherent user experience.
 
 Then write the full component code block. After the code block, add a short message (1-2 sentences) describing the core workflow the app supports.
 

--- a/prompts/tests/settings-prompt.test.ts
+++ b/prompts/tests/settings-prompt.test.ts
@@ -43,7 +43,7 @@ You are an AI assistant tasked with creating React components. You should create
 - Avoid using external libraries unless they are essential for the component to function
 - Always import the libraries you need at the top of the file
 - Use Fireproof for data persistence
-- Use \`callAI\` to fetch AI (set \`stream: true\` to enable streaming), use Structured JSON Outputs like this: \`callAI(prompt, { schema: { properties: { todos: { type: 'array', items: { type: 'string' } } } } })\` and save final responses as individual Fireproof documents.
+- Use \`callAI\` to fetch AI, use schema like this: \`JSON.parse(await callAI(prompt, { schema: { properties: { todos: { type: 'array', items: { type: 'string' } } } } }))\` and save final responses as individual Fireproof documents.
 - For file uploads use drag and drop and store using the \`doc._files\` API
 - Don't try to generate png or base64 data, use placeholder image APIs instead
 - Consider and potentially reuse/extend code from previous responses if relevant
@@ -59,11 +59,13 @@ ${
 
 `
     : ""
-}IMPORTANT: You are working in one JavaScript file, use tailwind classes for styling.
+}IMPORTANT: You are working in one JavaScript file, use tailwind classes for styling. Remember to use brackets like bg-[#242424] for custom colors.
 
-Provide a title and brief explanation followed by the component code. The component should demonstrate proper Fireproof integration with real-time updates and proper data persistence.
+Before writing code, provide a title and brief description of the app. Then list the top 3 features that are the best fit for a browser-only database with real-time collaboration and describe a short planned workflow showing how those features connect into a coherent user experience.
 
-Begin the component with the import statements. Use react, use-fireproof, and call-ai:
+Then write the full component code block. After the code block, add a short message (1-2 sentences) describing the core workflow the app supports.
+
+Begin the component with the import statements. Use react and the following libraries:
 
 \`\`\`js
 import React, { ... } from "react"


### PR DESCRIPTION
## Summary
- Simplify callai.txt: remove streaming+schema combo examples, clarify schema always returns a string needing `JSON.parse`, add brief standalone streaming section showing chunk-based API
- Update system prompt: show `JSON.parse(await callAI(...))` pattern, add pre-code planning (top 3 features for browser-only collab DB, planned workflow) and post-code workflow summary
- Fix typos: "have have", "browseable", "compI gonent"

## Test plan
- [ ] Verify `pnpm check` passes
- [ ] Review generated system prompt output for clarity
- [ ] Test app generation to confirm model follows new response structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)