### PR TITLE
feat: wire prodv2/cli environments into deploy pipeline

### DIFF
--- a/.github/workflows/vibes-diy-deploy.yaml
+++ b/.github/workflows/vibes-diy-deploy.yaml
@@ -16,8 +16,8 @@ on:
 jobs:
   compile_test:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    environment: ${{ startsWith(github.ref, 'refs/tags/vibes-diy@s') && 'staging' || startsWith(github.ref, 'refs/tags/vibes-diy@p') && 'production' || 'dev' }}
+    if: ${{ !contains(github.event.head_commit.message || '', '[skip ci]') && !startsWith(github.ref, 'refs/tags/vibes-diy@c') }}
+    environment: ${{ startsWith(github.ref, 'refs/tags/vibes-diy@s') && 'staging' || startsWith(github.ref, 'refs/tags/vibes-diy@p') && 'prodv2' || 'dev' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -32,7 +32,6 @@ jobs:
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           DEVICE_ID_CA_PRIV_KEY: ${{ secrets.DEVICE_ID_CA_PRIV_KEY }}
           DEVICE_ID_CA_CERT: ${{ vars.DEVICE_ID_CA_CERT }}
-          WRAPPER_BASE_URL: ${{ vars.WRAPPER_BASE_URL }}
           FP_VERSION: ${{ vars.FP_VERSION }}
           FPCLOUD_URL: ${{ vars.FPCLOUD_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
@@ -43,7 +42,48 @@ jobs:
           VIBES_SVC_HOSTNAME_BASE: ${{ vars.VIBES_SVC_HOSTNAME_BASE }}
           VIBES_SVC_PROTOCOL: ${{ vars.VIBES_SVC_PROTOCOL }}
           LLM_BACKEND_API_KEY: ${{ secrets.LLM_BACKEND_API_KEY }}
+          LLM_BACKEND_URL: ${{ vars.LLM_BACKEND_URL }}
+          CLERK_PUB_JWT_URL: ${{ vars.CLERK_PUB_JWT_URL }}
           DB_FLAVOUR: ${{ vars.DB_FLAVOUR }}
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
           NEON_DATABASE_ADMIN_URL: ${{ secrets.NEON_DATABASE_ADMIN_URL }}
           MAX_APP_SLUG_PER_USER_ID: ${{ vars.MAX_APP_SLUG_PER_USER_ID }}
+          WORKSPACE_NPM_URL: ${{ vars.WORKSPACE_NPM_URL }}
+          VIBES_DIY_API_URL: ${{ vars.VIBES_DIY_API_URL }}
+
+  deploy_cli:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/vibes-diy@c')
+    environment: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./actions/base
+
+      - uses: ./vibes.diy/actions/deploy
+        with:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ENV: ${{ vars.CLOUDFLARE_ENV }}
+          CLOUD_SESSION_TOKEN_PUBLIC: ${{ vars.CLOUD_SESSION_TOKEN_PUBLIC }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+          DEVICE_ID_CA_PRIV_KEY: ${{ secrets.DEVICE_ID_CA_PRIV_KEY }}
+          DEVICE_ID_CA_CERT: ${{ vars.DEVICE_ID_CA_CERT }}
+          FP_VERSION: ${{ vars.FP_VERSION }}
+          FPCLOUD_URL: ${{ vars.FPCLOUD_URL }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          VIBES_DIY_PUBLIC_BASE_URL: ${{ vars.VIBES_DIY_PUBLIC_BASE_URL }}
+          CLOUD_SESSION_TOKEN_SECRET: ${{ secrets.CLOUD_SESSION_TOKEN_SECRET }}
+          CLOUD_SESSION_TOKEN_ISSUER: ${{ vars.CLOUD_SESSION_TOKEN_ISSUER }}
+          VIBES_DIY_FROM_EMAIL: ${{ vars.VIBES_DIY_FROM_EMAIL }}
+          VIBES_SVC_HOSTNAME_BASE: ${{ vars.VIBES_SVC_HOSTNAME_BASE }}
+          VIBES_SVC_PROTOCOL: ${{ vars.VIBES_SVC_PROTOCOL }}
+          LLM_BACKEND_API_KEY: ${{ secrets.LLM_BACKEND_API_KEY }}
+          LLM_BACKEND_URL: ${{ vars.LLM_BACKEND_URL }}
+          CLERK_PUB_JWT_URL: ${{ vars.CLERK_PUB_JWT_URL }}
+          DB_FLAVOUR: ${{ vars.DB_FLAVOUR }}
+          NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          NEON_DATABASE_ADMIN_URL: ${{ secrets.NEON_DATABASE_ADMIN_URL }}
+          MAX_APP_SLUG_PER_USER_ID: ${{ vars.MAX_APP_SLUG_PER_USER_ID }}
+          WORKSPACE_NPM_URL: ${{ vars.WORKSPACE_NPM_URL }}
+          VIBES_DIY_API_URL: ${{ vars.VIBES_DIY_API_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ node_modules
 .claude/
 
 .env*
-.dev.vars
-**/.dev.vars
+.*vars
+**/.*vars
 .netlify/
 .react-router/
 .wrangler/

--- a/agents/coding-standards.md
+++ b/agents/coding-standards.md
@@ -1,56 +1,29 @@
 # Coding Standards
 
+Team-wide standards for agent behavior and code review.
+
 ## No inline HTML in TypeScript
 
-Never put HTML inside TypeScript code as template literal strings (code-in-code). Keep HTML in separate files and load/serve them.
+Never put HTML inside TypeScript code as template literal strings (code-in-code). Keep HTML in separate files and load/serve them. When a worker needs to serve HTML, put the HTML in a separate file (e.g. `ui.html`) and load it at build time or serve it as a static asset.
 
-## @adviser/cement
+## No CSS imports across packages
 
-The codebase uses `@adviser/cement` as a core utility library. Key exports:
+Never use `@import "@vibes.diy/base/theme.css"` or `import "@pkg/foo.css"` across packages. The import map infrastructure requires every cross-package reference to be resolvable without extra import map entries. Any non-JS/TS asset (CSS, text, etc.) must be loaded via `loadAsset()` from `@adviser/cement`.
 
-- **`loadAsset(path, opts)`** — load non-JS assets (text, CSS, markdown). See below.
-- **`Result` / `exception2Result()`** — no throwing, wrap errors in Result
-- **`URI` / `BuildURI`** — use instead of `new URL()` (URL is not stable)
-- **`ResolveOnce` / `KeyedResolvOnce` / `Lazy`** — use instead of singletons
-- **`Option`** — use instead of falsy checks
-- **`Evento`** — event/message system across packages
-
-### loadAsset
-
-Use `loadAsset()` for any non-JS/TS asset (CSS, text, markdown, fixtures). Never use raw `@import` or `import` for CSS across packages.
-
-**Server/build-time** (with CDN fallback):
-
-```ts
-const rText = await loadAsset("./llms/claude.txt", {
-  fallBackUrl: "https://esm.sh/@vibes.diy/prompts/",
-  basePath: () => import.meta.url,
-});
-```
-
-**Browser** (from origin):
-
-```ts
-loadAsset("/app/routes/legal/tos-notes.md", {
-  basePath: () => window.location.origin,
-}).then((r) => setContent(r.Ok()));
-```
-
-**Tests** (with `urlDirname`):
-
-```ts
-const r = await loadAsset(pathOps.join("tests", "fixtures", filename), {
-  basePath: () => urlDirname(import.meta.url).toString(),
-  fallBackUrl: urlDirname(import.meta.url).toString(),
-});
-```
-
-Returns a `Result` — use `.Ok()` for the value, `.isErr()` to check failure.
+Use: `loadAsset("./file.css", { fallBackUrl: "https://esm.sh/@pkg/", basePath: () => import.meta.url })` and inject the result as a `<style>` tag. This repo avoids package.json `exports` fields entirely.
 
 ## Clickable links
 
-Every link in responses must be clickable. Never output a bare reference without making it a proper link. `owner/repo#123` shorthand is NOT clickable in VS Code or the terminal — always use full markdown `[text](url)` links.
+Every link in responses must be clickable. Never output a bare reference without making it a proper link. `owner/repo#123` shorthand is NOT clickable in VS Code or the terminal — always use full markdown `[text](url)` links for PRs, issues, files, deployment URLs, and any other reference.
+
+## Stable-entry param naming
+
+Use dots (`.stable-entry.`) not `@` signs (`@stable-entry@`) for query parameter names. `@` gets URL-encoded to `%40` in browser address bars, making links ugly and hard to share.
+
+## Logs are append-only
+
+Never modify existing entries in setup logs or similar chronological docs — only append new information. Logs are a historical record; editing past entries destroys the timeline.
 
 ## Review commits before pushing
 
-Read every commit diff before pushing. Check each pattern against the rules-bag — no `instanceof`, no complex stringification chains, no casts. If something looks like a workaround, rethink the approach.
+Read every commit diff before pushing. Check each pattern against the rules-bag — no `instanceof`, no complex stringification chains, no casts. If something looks like a workaround, it probably is. Ask for guidance or rethink the approach.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,7 +314,7 @@ importers:
         specifier: ^1.59.1
         version: 1.59.1
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       tsx:
         specifier: ^4.21.0
@@ -435,7 +435,7 @@ importers:
         specifier: workspace:*
         version: link:../../../call-ai/pkg
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -475,7 +475,7 @@ importers:
   use-vibes/examples/react-example:
     dependencies:
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -628,7 +628,7 @@ importers:
         specifier: ^1.59.1
         version: 1.59.1
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       tsx:
         specifier: ^4.21.0
@@ -838,7 +838,7 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       react:
-        specifier: ^19.2.3
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -1048,7 +1048,7 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       react:
-        specifier: ^19.2.3
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -1189,7 +1189,7 @@ importers:
         specifier: ^11.13.5
         version: 11.13.5
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
     devDependencies:
       '@types/react':
@@ -1301,7 +1301,7 @@ importers:
         specifier: ^1.365.5
         version: 1.365.5
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-cookie-consent:
         specifier: ^10.0.1
@@ -1428,7 +1428,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -1468,7 +1468,7 @@ importers:
         specifier: workspace:*
         version: link:../../prompts/pkg
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -1532,7 +1532,7 @@ importers:
         specifier: ^1.365.5
         version: 1.365.5
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-cookie-consent:
         specifier: ^10.0.1
@@ -1638,7 +1638,7 @@ importers:
         specifier: ^1.365.5
         version: 1.365.5
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-cookie-consent:
         specifier: ^10.0.1
@@ -1717,7 +1717,7 @@ importers:
         specifier: ^35.2.1
         version: 35.2.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -1763,7 +1763,7 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -1812,7 +1812,7 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -1846,7 +1846,7 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       react:
-        specifier: ^19.2.4
+        specifier: ^19.2.5
         version: 19.2.5
       react-dom:
         specifier: ^19.2.5
@@ -6979,7 +6979,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:

--- a/prompts/pkg/llms/callai.ts
+++ b/prompts/pkg/llms/callai.ts
@@ -3,7 +3,6 @@ import type { LlmConfig } from "./types.js";
 export const callaiConfig: LlmConfig = {
   name: "callai",
   label: "callAI",
-  llmsTxtUrl: "https://use-fireproof.com/callai-llms.txt",
   module: "openrouter",
   description: "easy API for LLM requests with streaming support",
   importModule: "call-ai",

--- a/prompts/pkg/llms/fireproof.ts
+++ b/prompts/pkg/llms/fireproof.ts
@@ -3,7 +3,6 @@ import type { LlmConfig } from "./types.js";
 export const fireproofConfig: LlmConfig = {
   name: "fireproof",
   label: "useFireproof",
-  llmsTxtUrl: "https://use-fireproof.com/llms-full.txt",
   module: "use-fireproof",
   description: "local-first database with encrypted live sync",
   importModule: "use-fireproof",

--- a/prompts/pkg/llms/image-gen.ts
+++ b/prompts/pkg/llms/image-gen.ts
@@ -3,7 +3,6 @@ import type { LlmConfig } from "./types.js";
 export const imageGenConfig: LlmConfig = {
   name: "image-gen",
   label: "Image Generation",
-  llmsTxtUrl: "https://use-fireproof.com/imggen-llms.txt",
   module: "OpenAi",
   description: "Generate and edit images",
   importModule: "use-vibes",

--- a/prompts/pkg/llms/types.ts
+++ b/prompts/pkg/llms/types.ts
@@ -6,5 +6,4 @@ export interface LlmConfig {
   importModule: string;
   importName: string;
   importType?: "named" | "namespace" | "default";
-  llmsTxtUrl?: string;
 }

--- a/prompts/tests/package.json
+++ b/prompts/tests/package.json
@@ -46,7 +46,7 @@
     "@vitest/browser-playwright": "~4.1.4",
     "playwright": "^1.59.1",
     "playwright-chromium": "^1.59.1",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vite-plugin-devtools-json": "^1.0.0",

--- a/prompts/tests/settings-prompt.test.ts
+++ b/prompts/tests/settings-prompt.test.ts
@@ -6,10 +6,10 @@ vi.mock("@vibes.diy/prompts", async () => {
   // Create a mock implementation that simulates the behavior of the original
   const llmsModules = {
     "./llms/module1.json": {
-      default: { llmsTxtUrl: "https://example.com/llm1.txt", label: "llm1" },
+      default: { label: "llm1" },
     },
     "./llms/module2.json": {
-      default: { llmsTxtUrl: "https://example.com/llm2.txt", label: "llm2" },
+      default: { label: "llm2" },
     },
   };
 

--- a/use-vibes/examples/hosted-dev/package.json
+++ b/use-vibes/examples/hosted-dev/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "call-ai": "workspace:*",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "use-vibes": "workspace:*"
   },

--- a/use-vibes/examples/react-example/package.json
+++ b/use-vibes/examples/react-example/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "use-vibes": "workspace:*"
   },

--- a/use-vibes/tests/package.json
+++ b/use-vibes/tests/package.json
@@ -47,7 +47,7 @@
     "call-ai": "workspace:*",
     "playwright": "^1.59.1",
     "playwright-chromium": "^1.59.1",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vite-plugin-devtools-json": "^1.0.0",

--- a/vibes-diy/cli/cli-ctx.ts
+++ b/vibes-diy/cli/cli-ctx.ts
@@ -3,7 +3,7 @@ import { cmd_tsStream } from "./cmd-ts-stream.js";
 import { SuperThis } from "@fireproof/core";
 import { flag, option, string } from "cmd-ts";
 
-export const DEFAULT_API_URL = "https://dev-v2.vibesdiy.net/api";
+export const DEFAULT_API_URL = "https://vibes.diy/api?@stable-entry@=cli";
 
 export function cmdTsDefaultArgs(ctx: CliCtx) {
   return {

--- a/vibes.diy/actions/deploy/action.yaml
+++ b/vibes.diy/actions/deploy/action.yaml
@@ -65,6 +65,19 @@ inputs:
   MAX_APP_SLUG_PER_USER_ID:
     description: "Maximum number of app slugs per user ID"
     required: false
+  LLM_BACKEND_URL:
+    description: "URL for LLM backend API endpoint"
+    required: false
+    default: "https://openrouter.ai/api/v1/chat/completions"
+  CLERK_PUB_JWT_URL:
+    description: "Clerk JWKS endpoint URL for JWT verification"
+    required: false
+  WORKSPACE_NPM_URL:
+    description: "URL for self-hosted workspace npm packages (e.g. https://prod-v2.vibesdiy.net/vibe-pkg/)"
+    required: true
+  VIBES_DIY_API_URL:
+    description: "Public API URL for vibes.diy WebSocket connection (e.g. https://vibes.diy/api)"
+    required: false
 
 runs:
   using: "composite"
@@ -97,10 +110,14 @@ runs:
         VIBES_SVC_HOSTNAME_BASE: ${{ inputs.VIBES_SVC_HOSTNAME_BASE }}
         VIBES_SVC_PROTOCOL: ${{ inputs.VIBES_SVC_PROTOCOL }}
         LLM_BACKEND_API_KEY: ${{ inputs.LLM_BACKEND_API_KEY }}
+        LLM_BACKEND_URL: ${{ inputs.LLM_BACKEND_URL }}
+        CLERK_PUB_JWT_URL: ${{ inputs.CLERK_PUB_JWT_URL }}
         DB_FLAVOUR: ${{ inputs.DB_FLAVOUR }}
         NEON_DATABASE_URL: ${{ inputs.NEON_DATABASE_URL }}
         NEON_DATABASE_ADMIN_URL: ${{ inputs.NEON_DATABASE_ADMIN_URL }}
         MAX_APP_SLUG_PER_USER_ID: ${{ inputs.MAX_APP_SLUG_PER_USER_ID }}
+        WORKSPACE_NPM_URL: ${{ inputs.WORKSPACE_NPM_URL }}
+        VIBES_DIY_API_URL: ${{ inputs.VIBES_DIY_API_URL }}
       run: |
         if [ "$DB_FLAVOUR" = "pg" ]; then
           NEON_DATABASE_URL="$NEON_DATABASE_ADMIN_URL" pnpm run drizzle:neon
@@ -122,13 +139,18 @@ runs:
           --fromEnv VIBES_SVC_HOSTNAME_BASE \
           --fromEnv VIBES_SVC_PROTOCOL \
           --fromEnv LLM_BACKEND_API_KEY \
+          --fromEnv LLM_BACKEND_URL \
+          --fromEnv CLERK_PUB_JWT_URL \
           --fromEnv DB_FLAVOUR \
           --fromEnv NEON_DATABASE_URL \
-          --fromEnv MAX_APP_SLUG_PER_USER_ID | \
+          --fromEnv MAX_APP_SLUG_PER_USER_ID \
+          --fromEnv WORKSPACE_NPM_URL \
+          --fromEnv VIBES_DIY_API_URL | \
           pnpm exec wrangler -c ./wrangler.toml secret --env ${{inputs.CLOUDFLARE_ENV}} bulk
         pnpm run deploy:${{inputs.CLOUDFLARE_ENV}}
 
     - name: Deploy api-queue consumer
+      if: ${{ inputs.CLOUDFLARE_ENV == 'prod' }}
       working-directory: vibes.diy/api/queue
       shell: bash
       env:
@@ -149,6 +171,8 @@ runs:
         VIBES_SVC_HOSTNAME_BASE: ${{ inputs.VIBES_SVC_HOSTNAME_BASE }}
         VIBES_SVC_PROTOCOL: ${{ inputs.VIBES_SVC_PROTOCOL }}
         LLM_BACKEND_API_KEY: ${{ inputs.LLM_BACKEND_API_KEY }}
+        LLM_BACKEND_URL: ${{ inputs.LLM_BACKEND_URL }}
+        CLERK_PUB_JWT_URL: ${{ inputs.CLERK_PUB_JWT_URL }}
         DB_FLAVOUR: ${{ inputs.DB_FLAVOUR }}
         NEON_DATABASE_URL: ${{ inputs.NEON_DATABASE_URL }}
         MAX_APP_SLUG_PER_USER_ID: ${{ inputs.MAX_APP_SLUG_PER_USER_ID }}
@@ -168,6 +192,8 @@ runs:
           --fromEnv VIBES_SVC_HOSTNAME_BASE \
           --fromEnv VIBES_SVC_PROTOCOL \
           --fromEnv LLM_BACKEND_API_KEY \
+          --fromEnv LLM_BACKEND_URL \
+          --fromEnv CLERK_PUB_JWT_URL \
           --fromEnv DB_FLAVOUR \
           --fromEnv NEON_DATABASE_URL \
           --fromEnv MAX_APP_SLUG_PER_USER_ID | \

--- a/vibes.diy/actions/deploy/gen-prod-secrets.sh
+++ b/vibes.diy/actions/deploy/gen-prod-secrets.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# Generate fresh prod secrets and write them directly to .prod.vars and GH environments.
+# Run from repo root or any directory.
+# Requires: core-cli (from ~/code/fp/fireproof), gh cli
+
+FIREPROOF_DIR="$HOME/code/fp/fireproof"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+PROD_VARS="$REPO_DIR/vibes.diy/pkg/.prod.vars"
+
+echo "=== Generating session token keypair ==="
+KEYPAIR=$(cd "$FIREPROOF_DIR" && pnpm exec core-cli key --generatePair 2>/dev/null)
+CST_PUBLIC=$(echo "$KEYPAIR" | grep CLOUD_SESSION_TOKEN_PUBLIC | cut -d= -f2)
+CST_SECRET=$(echo "$KEYPAIR" | grep CLOUD_SESSION_TOKEN_SECRET | cut -d= -f2)
+
+echo "=== Generating device ID CA cert ==="
+CA_OUTPUT=$(cd "$FIREPROOF_DIR" && pnpm exec core-cli deviceId ca-cert --envVars \
+  --common-name "vibes.diy" -o "Vibes DIY" -l "Portland" -s "Oregon" -c "US" 2>/dev/null)
+CA_PRIV_KEY=$(echo "$CA_OUTPUT" | grep DEVICE_ID_CA_PRIV_KEY | cut -d= -f2)
+CA_CERT=$(echo "$CA_OUTPUT" | grep DEVICE_ID_CA_CERT | cut -d= -f2)
+
+echo "=== Updating .prod.vars ==="
+if [[ "$(uname)" == "Darwin" ]]; then
+  SED_I="sed -i ''"
+else
+  SED_I="sed -i"
+fi
+
+# Use perl for reliable in-place replacement (handles long values better than sed)
+perl -i -pe "s|^CLOUD_SESSION_TOKEN_PUBLIC=.*|CLOUD_SESSION_TOKEN_PUBLIC=$CST_PUBLIC|" "$PROD_VARS"
+perl -i -pe "s|^CLOUD_SESSION_TOKEN_SECRET=.*|CLOUD_SESSION_TOKEN_SECRET=$CST_SECRET|" "$PROD_VARS"
+perl -i -pe "s|^DEVICE_ID_CA_PRIV_KEY=.*|DEVICE_ID_CA_PRIV_KEY=$CA_PRIV_KEY|" "$PROD_VARS"
+perl -i -pe "s|^DEVICE_ID_CA_CERT=.*|DEVICE_ID_CA_CERT=$CA_CERT|" "$PROD_VARS"
+
+echo "=== Setting GH environment variables and secrets ==="
+cd "$REPO_DIR"
+
+for ENV in prodv2 cli; do
+  echo "  Setting $ENV..."
+  gh variable set CLOUD_SESSION_TOKEN_PUBLIC --env "$ENV" --body "$CST_PUBLIC"
+  gh secret set CLOUD_SESSION_TOKEN_SECRET --env "$ENV" --body "$CST_SECRET"
+  gh secret set DEVICE_ID_CA_PRIV_KEY --env "$ENV" --body "$CA_PRIV_KEY"
+  gh variable set DEVICE_ID_CA_CERT --env "$ENV" --body "$CA_CERT"
+done
+
+echo ""
+echo "=== Done ==="
+echo "Session token and CA cert regenerated for prodv2 + cli."
+echo "Remaining manual secrets in .prod.vars (paste values yourself):"
+grep '<from' "$PROD_VARS" | sed 's/=.*//'

--- a/vibes.diy/api/README.md
+++ b/vibes.diy/api/README.md
@@ -162,11 +162,26 @@ The API is bundled into the main vibes.diy Cloudflare Worker (not a separate dep
 
 ### Environments
 
-| Trigger                 | Environment | Domain                   |
-| ----------------------- | ----------- | ------------------------ |
-| Tag `vibes-diy@s*`      | staging     | `*.dev-v2.vibesdiy.net`  |
-| Tag `vibes-diy@p*`      | production  | `*.prod-v2.vibesdiy.net` |
-| Path push or other tags | dev         | `*.dev-v2.vibesdiy.net`  |
+| Trigger                 | GH Environment | CF Env | Domain                   |
+| ----------------------- | -------------- | ------ | ------------------------ |
+| Tag `vibes-diy@p*`      | prodv2         | prod   | `*.prod-v2.vibesdiy.net` |
+| Tag `vibes-diy@c*`      | cli            | cli    | `*.cli-v2.vibesdiy.net`  |
+| Tag `vibes-diy@s*`      | staging        | dev    | `*.dev-v2.vibesdiy.net`  |
+| Path push or other tags | dev            | dev    | `*.dev-v2.vibesdiy.net`  |
+
+CLI shares prodv2's D1 database and Neon DB but has its own worker, queue, and routes.
+
+### Secret Rotation
+
+To rotate session tokens and CA certs for prodv2/cli:
+
+```bash
+./vibes.diy/actions/deploy/gen-prod-secrets.sh
+```
+
+This regenerates keys, updates `.prod.vars`, and sets GH secrets — without exposing values in terminal output.
+
+For the remaining manual secrets (`LLM_BACKEND_API_KEY`, `RESEND_API_KEY`, `NEON_DATABASE_URL`), edit `.prod.vars` directly and run `gh secret set` from the repo root.
 
 ### Deploy Steps
 

--- a/vibes.diy/api/pkg/package.json
+++ b/vibes.diy/api/pkg/package.json
@@ -23,7 +23,7 @@
     "arktype": "^2.2.0",
     "multiformats": "^13.4.2",
     "random-words": "^2.0.1",
-    "react": "^19.2.3",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
   "devDependencies": {

--- a/vibes.diy/api/svc/package.json
+++ b/vibes.diy/api/svc/package.json
@@ -40,7 +40,7 @@
     "mime": "^4.1.0",
     "multiformats": "^13.4.2",
     "random-words": "^2.0.1",
-    "react": "^19.2.3",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "sucrase": "^3.35.1",
     "ws": "^8.20.0"

--- a/vibes.diy/base/package.json
+++ b/vibes.diy/base/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@adviser/cement": "^0.5.34",
     "@emotion/css": "^11.13.5",
-    "react": "^19.2.4"
+    "react": "^19.2.5"
   },
   "devDependencies": {
     "@types/react": "^19.2.14"

--- a/vibes.diy/pkg/package.json
+++ b/vibes.diy/pkg/package.json
@@ -18,8 +18,9 @@
     "drizzle:neon": "drizzle-kit push --config ./drizzle.neon.config.ts",
     "build:dev": "CLOUDFLARE_ENV=dev react-router build",
     "build:prod": "CLOUDFLARE_ENV=prod react-router build",
-    "deploy:dev": "CLOUDFLARE_ENV=dev react-router build && wrangler deploy",
-    "deploy:prod": "CLOUDFLARE_ENV=prod react-router build && wrangler deploy",
+    "deploy:dev": "CLOUDFLARE_ENV=dev react-router build && wrangler deploy --env dev",
+    "deploy:prod": "CLOUDFLARE_ENV=prod react-router build && wrangler deploy --env prod",
+    "deploy:cli": "CLOUDFLARE_ENV=cli react-router build && wrangler deploy --env cli",
     "format:write": "prettier --write ."
   },
   "dependencies": {
@@ -57,7 +58,7 @@
     "monaco-editor": "^0.55.1",
     "multiformats": "^13.4.2",
     "posthog-js": "^1.365.5",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-cookie-consent": "^10.0.1",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.72.1",

--- a/vibes.diy/pkg/wrangler.toml
+++ b/vibes.diy/pkg/wrangler.toml
@@ -138,7 +138,7 @@ binding = "VIBES_SERVICE"
 name = "vibes-diy-v2-prod"
 vars = { ENVIRONMENT = "prod" }
 routes = [
-  { pattern = "prod-v2.vibesdiy.net", zone_name = "vibesdiy.net" },
+  { pattern = "prod-v2.vibesdiy.net/*", zone_name = "vibesdiy.net" },
   { pattern = "*.prod-v2.vibesdiy.net/*", zone_name = "vibesdiy.net" }
 ]
 
@@ -168,6 +168,43 @@ binding = "FS_IDS_BUCKET"
 bucket_name = "vibes-diy-fs-ids"
 
 [[env.prod.queues.producers]]
+queue = "vibes-service-prod"
+binding = "VIBES_SERVICE"
+
+[env.cli]
+name = "vibes-diy-v2-cli"
+vars = { ENVIRONMENT = "cli" }
+routes = [
+  { pattern = "cli-v2.vibesdiy.net/*", zone_name = "vibesdiy.net" },
+  { pattern = "*.cli-v2.vibesdiy.net/*", zone_name = "vibesdiy.net" }
+]
+
+[env.cli.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = true
+persist = true
+
+[env.cli.browser]
+binding = "BROWSER"
+
+[env.cli.durable_objects]
+bindings = [{ name = "CHAT_SESSIONS", class_name = "ChatSessions" }]
+
+[[env.cli.migrations]]
+tag = "v1"
+new_classes = ["ChatSessions"]
+
+[[env.cli.d1_databases]]
+binding = "DB"
+database_name = "prod-vibes-diy-v2"
+database_id = "0f783eae-91cf-49c4-a706-6e4d2498cb4a"
+
+[[env.cli.r2_buckets]]
+binding = "FS_IDS_BUCKET"
+bucket_name = "vibes-diy-fs-ids"
+
+[[env.cli.queues.producers]]
 queue = "vibes-service-prod"
 binding = "VIBES_SERVICE"
 

--- a/vibes.diy/stable-entry/package.json
+++ b/vibes.diy/stable-entry/package.json
@@ -15,7 +15,7 @@
     "@tanstack/react-table": "^8.21.3",
     "@vibes.diy/base": "workspace:*",
     "cookie": "^1.1.1",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
   "devDependencies": {

--- a/vibes.diy/stories/package.json
+++ b/vibes.diy/stories/package.json
@@ -12,7 +12,7 @@
     "@types/react": "^19.2.14",
     "@vibes.diy/base": "workspace:*",
     "@vibes.diy/prompts": "workspace:*",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
   "devDependencies": {

--- a/vibes.diy/tests/app/package.json
+++ b/vibes.diy/tests/app/package.json
@@ -28,7 +28,7 @@
     "jose": "^6.2.2",
     "multiformats": "^13.4.2",
     "posthog-js": "^1.365.5",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-cookie-consent": "^10.0.1",
     "react-dom": "^19.2.5",
     "react-ga4": "^2.1.0",

--- a/vibes.diy/tests/simple-chat/package.json
+++ b/vibes.diy/tests/simple-chat/package.json
@@ -27,7 +27,7 @@
     "jose": "^6.2.2",
     "multiformats": "^13.4.2",
     "posthog-js": "^1.365.5",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-cookie-consent": "^10.0.1",
     "react-dom": "^19.2.5",
     "react-ga4": "^2.1.0",

--- a/vibes.diy/vibe/db-explorer/package.json
+++ b/vibes.diy/vibe/db-explorer/package.json
@@ -34,7 +34,7 @@
     "@vibes.diy/base": "workspace:*",
     "ag-grid-community": "^35.2.1",
     "ag-grid-react": "^35.2.1",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router": "^7.13.2",
     "react-router-dom": "^7.14.0"

--- a/vibes.diy/vibe/runtime/package.json
+++ b/vibes.diy/vibe/runtime/package.json
@@ -14,7 +14,7 @@
     "@vibes.diy/base": "workspace:*",
     "@vibes.diy/vibe-types": "workspace:*",
     "arktype": "^2.2.0",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "use-fireproof": "0.24.16"
   },

--- a/vibes.diy/vibe/srv-sandbox/package.json
+++ b/vibes.diy/vibe/srv-sandbox/package.json
@@ -19,7 +19,7 @@
     "@vibes.diy/prompts": "workspace:^",
     "@vibes.diy/vibe-types": "workspace:*",
     "arktype": "^2.2.0",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "use-fireproof": "0.24.16"
   },

--- a/vibes.diy/vibe/types/package.json
+++ b/vibes.diy/vibe/types/package.json
@@ -14,7 +14,7 @@
     "@vibes.diy/api-types": "workspace:*",
     "@vibes.diy/base": "workspace:*",
     "arktype": "^2.2.0",
-    "react": "^19.2.4",
+    "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "use-fireproof": "0.24.16"
   },


### PR DESCRIPTION
## Summary

- **Wire prodv2/cli environments into deploy pipeline** — add `prodv2` and `cli` environment support to the deploy workflow, with secrets generation script and wrangler config for multi-environment deploys
- **Remove FeaturedVibes from homepage** — clean up unused component
- **Propagate stable-entry group to sandbox iframes** — read `x-stable-entry` header in root loader and append `@stable-entry@=<group>` to `pkgRepos.workspace`, so the sandbox iframe's import map routes `/vibe-pkg/` requests through the correct stable-entry backend
- **Fix unused import lint error** in chat route

## Test plan

- [x] Deployed to dev via `vibes-diy@d0.2.9-stable-entry-v2` — verified `@stable-entry@=dev` appears in import map `/vibe-pkg/` URLs, not in `esm.sh` URLs
- [x] Deployed to prod via `vibes-diy@p0.2.8` — success
- [x] Deployed to cli via `vibes-diy@c0.2.3` — success
- [ ] Verify stable-entry routing end-to-end on prod with `se-group` cookie set

🤖 Generated with [Claude Code](https://claude.com/claude-code)