### PR TITLE
feat: add CLI Cloudflare Workers environment

### DIFF
--- a/.github/workflows/vibes-diy-deploy.yaml
+++ b/.github/workflows/vibes-diy-deploy.yaml
@@ -17,7 +17,7 @@ jobs:
   compile_test:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    environment: ${{ startsWith(github.ref, 'refs/tags/vibes-diy@s') && 'staging' || startsWith(github.ref, 'refs/tags/vibes-diy@p') && 'production' || 'dev' }}
+    environment: ${{ startsWith(github.ref, 'refs/tags/vibes-diy@s') && 'staging' || startsWith(github.ref, 'refs/tags/vibes-diy@p') && 'production' || startsWith(github.ref, 'refs/tags/vibes-diy@c') && 'cli' || 'dev' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/vibes-diy/cli/cli-ctx.ts
+++ b/vibes-diy/cli/cli-ctx.ts
@@ -3,7 +3,7 @@ import { cmd_tsStream } from "./cmd-ts-stream.js";
 import { SuperThis } from "@fireproof/core";
 import { flag, option, string } from "cmd-ts";
 
-export const DEFAULT_API_URL = "https://dev-v2.vibesdiy.net/api";
+export const DEFAULT_API_URL = "https://cli-v2.vibesdiy.net/api";
 
 export function cmdTsDefaultArgs(ctx: CliCtx) {
   return {

--- a/vibes.diy/api/queue/wrangler.toml
+++ b/vibes.diy/api/queue/wrangler.toml
@@ -59,3 +59,23 @@ bucket_name = "vibes-diy-fs-ids"
 queue = "vibes-service-prod"
 max_batch_size = 10
 max_batch_timeout = 5
+
+[env.cli]
+name = "vibes-diy-v2-queue-consumer-cli"
+
+[env.cli.browser]
+binding = "BROWSER"
+
+[[env.cli.d1_databases]]
+binding = "DB"
+database_name = "prod-vibes-diy-v2"
+database_id = "0f783eae-91cf-49c4-a706-6e4d2498cb4a"
+
+[[env.cli.r2_buckets]]
+binding = "FS_IDS_BUCKET"
+bucket_name = "vibes-diy-fs-ids"
+
+[[env.cli.queues.consumers]]
+queue = "vibes-service-cli"
+max_batch_size = 10
+max_batch_timeout = 5

--- a/vibes.diy/pkg/wrangler.toml
+++ b/vibes.diy/pkg/wrangler.toml
@@ -140,3 +140,40 @@ bucket_name = "vibes-diy-fs-ids"
 queue = "vibes-service-prod"
 binding = "VIBES_SERVICE"
 
+[env.cli]
+name = "vibes-diy-v2-cli"
+vars = { ENVIRONMENT = "cli" }
+routes = [
+  { pattern = "cli-v2.vibesdiy.net/*", zone_name = "vibesdiy.net" },
+  { pattern = "*.cli-v2.vibesdiy.net/*", zone_name = "vibesdiy.net" }
+]
+
+[env.cli.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = true
+persist = true
+
+[env.cli.browser]
+binding = "BROWSER"
+
+[env.cli.durable_objects]
+bindings = [{ name = "CHAT_SESSIONS", class_name = "ChatSessions" }]
+
+[[env.cli.migrations]]
+tag = "v1"
+new_classes = ["ChatSessions"]
+
+[[env.cli.d1_databases]]
+binding = "DB"
+database_name = "prod-vibes-diy-v2"
+database_id = "0f783eae-91cf-49c4-a706-6e4d2498cb4a"
+
+[[env.cli.r2_buckets]]
+binding = "FS_IDS_BUCKET"
+bucket_name = "vibes-diy-fs-ids"
+
+[[env.cli.queues.producers]]
+queue = "vibes-service-cli"
+binding = "VIBES_SERVICE"
+


### PR DESCRIPTION
## Summary
- Add `[env.cli]` to wrangler.toml (app + queue consumer) — clone of prod with shared D1, own queue, routes on `cli-v2.vibesdiy.net`
- Map `vibes-diy@c*` tags to the `cli` GH environment in deploy workflow
- Update CLI default API URL to `cli-v2.vibesdiy.net/api`

Cross-domain safe: vibes pushed via CLI load in web app iframes because data is in shared D1, lookups use (userSlug, appSlug, fsId) not origin, iframe URLs driven by web app config.

## Test plan
- [ ] Tag `vibes-diy@c0.1.0` triggers deploy to cli environment
- [ ] `curl https://cli-v2.vibesdiy.net/` returns a response
- [ ] `npx vibes-diy@dev login --api-url https://cli-v2.vibesdiy.net/api` works
- [ ] `npx vibes-diy@dev push --api-url https://cli-v2.vibesdiy.net/api` works
- [ ] Pushed vibe loads in web app iframe at vibes.diy

🤖 Generated with [Claude Code](https://claude.com/claude-code)