### PR TITLE
feat: improve mobile header touch targets

### DIFF
--- a/vibes.diy/pkg/app/components/AppLayout.tsx
+++ b/vibes.diy/pkg/app/components/AppLayout.tsx
@@ -71,7 +71,7 @@ export default function AppLayout({
         } relative z-10 transition-all duration-300 ease-in-out`}
       >
         <div
-          className={`flex items-center overflow-hidden p-2 ${fullWidthChat ? "h-0" : "h-[4rem]"} transition-all duration-300 ease-in-out`}
+          className={`flex items-center px-2 py-2 md:p-2 ${fullWidthChat && !mobilePreviewShown ? "h-0 overflow-hidden" : "md:h-[4rem] md:overflow-hidden"} transition-all duration-300 ease-in-out`}
         >
           {headerRight}
         </div>

--- a/vibes.diy/pkg/app/components/ResultPreview/BackButton.tsx
+++ b/vibes.diy/pkg/app/components/ResultPreview/BackButton.tsx
@@ -10,7 +10,7 @@ export const BackButton: React.FC<BackButtonProps> = ({ onBackClick }) => {
     <button
       type="button"
       onClick={onBackClick}
-      className="bg-light-decorative-00 dark:bg-dark-decorative-00 text-light-primary dark:text-dark-primary hover:bg-light-decorative-01 dark:hover:bg-dark-decorative-01 flex items-center justify-center rounded-md p-2 transition-colors md:hidden"
+      className="bg-light-decorative-00 dark:bg-dark-decorative-00 text-light-primary dark:text-dark-primary hover:bg-light-decorative-01 dark:hover:bg-dark-decorative-01 flex items-center justify-center rounded-md p-3 transition-colors md:hidden"
       aria-label="Back to chat"
     >
       <BackArrowIcon />

--- a/vibes.diy/pkg/app/components/ResultPreview/ResultPreviewHeaderContent.tsx
+++ b/vibes.diy/pkg/app/components/ResultPreview/ResultPreviewHeaderContent.tsx
@@ -48,28 +48,27 @@ function ResultPreviewHeaderContent({
 }: React.PropsWithChildren<ResultPreviewHeaderContentProps>) {
   // console.log("Rendering ResultPreviewHeaderContent with props:", currentView, hasCodeChanges)
   return (
-    <div className="flex h-full w-full items-center px-2 py-4">
-      <div className="flex w-1/4 items-center justify-start">
+    <div className="flex h-full w-full items-center px-2 py-1">
+      <div className="flex shrink-0 items-center justify-start">
         <BackButton
           onBackClick={() => {
             console.log("click-back");
           }}
         />
-        <div className="h-10" />
       </div>
 
       {/* Center - View controls */}
-      <div className="flex w-1/2 items-center justify-center">
+      <div className="flex flex-1 items-center justify-center">
         <ViewControls
           viewControls={viewControls}
-          currentView={currentView} // Use displayView for the currently active button highlight
+          currentView={currentView}
           onClick={navigateToView}
           onDoubleClick={(view) => view == "preview" && openVibe?.()}
           onContextMenu={onContextMenu}
         />
       </div>
       {/* Right side - Save and Publish buttons */}
-      <div className="flex w-1/4 items-center justify-end">
+      <div className="flex shrink-0 items-center justify-end">
         <div className="flex items-center gap-2">
           {/* Save button - show when in code view and has changes */}
           {currentView === "code" && hasCodeChanges && (

--- a/vibes.diy/pkg/app/components/ResultPreview/ViewControls.tsx
+++ b/vibes.diy/pkg/app/components/ResultPreview/ViewControls.tsx
@@ -20,11 +20,10 @@ interface ViewControlsProps {
 
 export const ViewControls: React.FC<ViewControlsProps> = ({ viewControls, currentView, onClick, onDoubleClick, onContextMenu }) => {
   return (
-    <div className="bg-light-decorative-00 dark:bg-dark-decorative-00 flex justify-center gap-1 rounded-md p-1 shadow-sm">
+    <div className="bg-light-decorative-00 dark:bg-dark-decorative-00 flex justify-center gap-1 rounded-lg p-1.5 shadow-sm md:rounded-md md:p-1">
       {Object.entries(viewControls)
         .filter(([viewType]) => viewType !== "chat")
         .map(([viewType, control]) => {
-          // console.log(`ViewControls`, viewType, currentView )
           const viewTypeKey = viewType as ViewType;
           const isActive = currentView === viewTypeKey;
 
@@ -39,7 +38,7 @@ export const ViewControls: React.FC<ViewControlsProps> = ({ viewControls, curren
                 e.preventDefault();
                 onContextMenu?.(viewTypeKey, e);
               }}
-              className={`flex items-center justify-center space-x-1 rounded px-3 py-1.5 text-xs font-medium transition-colors sm:space-x-1.5 sm:px-4 sm:text-sm ${
+              className={`flex items-center justify-center space-x-1 rounded-md px-3 py-2 text-base font-medium transition-colors md:space-x-1.5 md:rounded md:px-4 md:py-1.5 md:text-sm ${
                 isActive
                   ? "bg-light-background-00 dark:bg-dark-background-00 text-light-primary dark:text-dark-primary shadow-sm"
                   : "text-light-primary/90 dark:text-dark-primary/90 hover:bg-light-decorative-01 dark:hover:bg-dark-decorative-01 hover:text-light-primary dark:hover:text-dark-primary"
@@ -48,16 +47,16 @@ export const ViewControls: React.FC<ViewControlsProps> = ({ viewControls, curren
             >
               {viewTypeKey === "preview" && (
                 <PreviewIcon
-                  className="h-4 w-4"
+                  className="h-5 w-5 md:h-4 md:w-4"
                   isLoading={!!control.loading}
                   title={control.loading ? "App is fetching data" : "Preview icon"}
                 />
               )}
               {viewTypeKey === "code" && (
-                <CodeIcon className="h-3.5 w-3.5 sm:h-4 sm:w-4" isLoading={currentView === "preview" && !!control.loading} />
+                <CodeIcon className="h-5 w-5 md:h-4 md:w-4" isLoading={currentView === "preview" && !!control.loading} />
               )}
-              {viewTypeKey === "data" && <DataIcon className="h-3.5 w-3.5 sm:h-4 sm:w-4" />}
-              {viewTypeKey === "settings" && <SettingsIcon className="h-4 w-4" />}
+              {viewTypeKey === "data" && <DataIcon className="h-5 w-5 md:h-4 md:w-4" />}
+              {viewTypeKey === "settings" && <SettingsIcon className="h-5 w-5 md:h-4 md:w-4" />}
               <span className="hidden min-[480px]:inline">{control.label}</span>
             </button>
           );


### PR DESCRIPTION
## Summary
- Show result preview header when mobile preview is visible (was hidden by fullWidthChat)
- Increase mobile icon sizes and button padding for better touch targets
- Use flex layout instead of fixed width columns to prevent overflow at narrow widths
- Use md: breakpoints consistently for mobile/desktop split

## Test plan
- [ ] Verify mobile view has larger, touchable header icons
- [ ] Verify desktop view is unchanged (compact header with labels)
- [ ] Verify header appears on mobile when viewing preview/code/data/settings
- [ ] Verify no overflow at narrow desktop widths (768px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)