### PR TITLE
fix: gray focus styles on /settings in dark mode

### DIFF
--- a/vibes.diy/pkg/app/components/ModelSettingsCards.tsx
+++ b/vibes.diy/pkg/app/components/ModelSettingsCards.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect, useRef } from "react";
 import type { AIParams } from "@vibes.diy/api-types";
 import { useVibesDiy } from "../vibes-diy-provider.js";
 
+const cardControlClassName =
+  "flex-1 rounded border border-[color:var(--vibes-card-border)] bg-[var(--vibes-card-bg)] px-2 py-1 text-xs text-[color:var(--vibes-card-text)] outline-none focus-visible:ring-2 focus-visible:ring-[rgba(128,128,128,0.3)]";
+
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <li className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3">
@@ -17,12 +20,7 @@ function SaveBtn({ saving, onClick }: { saving: boolean; onClick: () => void }) 
       type="button"
       disabled={saving}
       onClick={onClick}
-      className="rounded px-2 py-1 text-xs font-medium disabled:opacity-50"
-      style={{
-        background: "transparent",
-        color: "var(--vibes-card-text)",
-        border: "1px solid var(--vibes-card-border)",
-      }}
+      className="rounded border border-[color:var(--vibes-card-border)] bg-transparent px-2 py-1 text-xs font-medium text-[color:var(--vibes-card-text)] outline-none disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-[rgba(128,128,128,0.3)]"
     >
       {saving ? "Saving…" : "Save"}
     </button>
@@ -56,7 +54,6 @@ function ModelSection({
   });
 
   useEffect(() => {
-    console.log("ModelSection useEffect triggered with usage:", usage, "and config:", config, viewState);
     if (viewState.current === "start") {
       viewState.current = "loading";
       vibeDiyApi.listModels({}).then((res) => {
@@ -100,14 +97,7 @@ function ModelSection({
             onChange={(e) =>
               setAIParam((prev) => (prev ? { ...prev, model: models.find((m) => m.id === e.target.value) || prev.model } : prev))
             }
-            className="flex-1 rounded px-2 py-1 text-xs outline-none"
-            style={{
-              border: "1px solid var(--vibes-card-border)",
-              background: "var(--vibes-card-bg)",
-              color: "var(--vibes-card-text)",
-            }}
-            onFocus={(e) => { e.currentTarget.style.boxShadow = "0 0 0 2px rgba(128,128,128,0.3)"; }}
-            onBlur={(e) => { e.currentTarget.style.boxShadow = "none"; }}
+            className={cardControlClassName}
           >
             {models.map((opt) => (
               <option key={opt.id} value={opt.id}>
@@ -132,14 +122,7 @@ function ModelSection({
               value={aiParam?.apiKey ?? ""}
               onChange={(e) => setAIParam((prev) => ({ ...prev, apiKey: e.target.value }))}
               placeholder="sk-…"
-              className="flex-1 rounded px-2 py-1 text-xs outline-none"
-              style={{
-                border: "1px solid var(--vibes-card-border)",
-                background: "var(--vibes-card-bg)",
-                color: "var(--vibes-card-text)",
-              }}
-              onFocus={(e) => { e.currentTarget.style.boxShadow = "0 0 0 2px rgba(128,128,128,0.3)"; }}
-              onBlur={(e) => { e.currentTarget.style.boxShadow = "none"; }}
+              className={cardControlClassName}
             />
           </div>
           <div className="flex justify-end">

--- a/vibes.diy/pkg/app/components/ModelSettingsCards.tsx
+++ b/vibes.diy/pkg/app/components/ModelSettingsCards.tsx
@@ -17,7 +17,12 @@ function SaveBtn({ saving, onClick }: { saving: boolean; onClick: () => void }) 
       type="button"
       disabled={saving}
       onClick={onClick}
-      className="rounded px-2 py-1 text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700/60 dark:text-gray-300 disabled:opacity-50"
+      className="rounded px-2 py-1 text-xs font-medium disabled:opacity-50"
+      style={{
+        background: "transparent",
+        color: "var(--vibes-card-text)",
+        border: "1px solid var(--vibes-card-border)",
+      }}
     >
       {saving ? "Saving…" : "Save"}
     </button>
@@ -95,7 +100,14 @@ function ModelSection({
             onChange={(e) =>
               setAIParam((prev) => (prev ? { ...prev, model: models.find((m) => m.id === e.target.value) || prev.model } : prev))
             }
-            className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs text-gray-800 dark:text-gray-200 outline-none focus:ring-1 focus:ring-gray-400"
+            className="flex-1 rounded px-2 py-1 text-xs outline-none"
+            style={{
+              border: "1px solid var(--vibes-card-border)",
+              background: "var(--vibes-card-bg)",
+              color: "var(--vibes-card-text)",
+            }}
+            onFocus={(e) => { e.currentTarget.style.boxShadow = "0 0 0 2px rgba(128,128,128,0.3)"; }}
+            onBlur={(e) => { e.currentTarget.style.boxShadow = "none"; }}
           >
             {models.map((opt) => (
               <option key={opt.id} value={opt.id}>
@@ -120,7 +132,14 @@ function ModelSection({
               value={aiParam?.apiKey ?? ""}
               onChange={(e) => setAIParam((prev) => ({ ...prev, apiKey: e.target.value }))}
               placeholder="sk-…"
-              className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs text-gray-800 dark:text-gray-200 outline-none focus:ring-1 focus:ring-gray-400"
+              className="flex-1 rounded px-2 py-1 text-xs outline-none"
+              style={{
+                border: "1px solid var(--vibes-card-border)",
+                background: "var(--vibes-card-bg)",
+                color: "var(--vibes-card-text)",
+              }}
+              onFocus={(e) => { e.currentTarget.style.boxShadow = "0 0 0 2px rgba(128,128,128,0.3)"; }}
+              onBlur={(e) => { e.currentTarget.style.boxShadow = "none"; }}
             />
           </div>
           <div className="flex justify-end">

--- a/vibes.diy/pkg/app/components/ModelSettingsCards.tsx
+++ b/vibes.diy/pkg/app/components/ModelSettingsCards.tsx
@@ -17,7 +17,7 @@ function SaveBtn({ saving, onClick }: { saving: boolean; onClick: () => void }) 
       type="button"
       disabled={saving}
       onClick={onClick}
-      className="rounded px-2 py-1 text-xs font-medium bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 disabled:opacity-50"
+      className="rounded px-2 py-1 text-xs font-medium bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700/60 dark:text-gray-300 disabled:opacity-50"
     >
       {saving ? "Saving…" : "Save"}
     </button>
@@ -95,7 +95,7 @@ function ModelSection({
             onChange={(e) =>
               setAIParam((prev) => (prev ? { ...prev, model: models.find((m) => m.id === e.target.value) || prev.model } : prev))
             }
-            className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs text-gray-800 dark:text-gray-200 outline-none focus:ring-1 focus:ring-blue-400"
+            className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs text-gray-800 dark:text-gray-200 outline-none focus:ring-1 focus:ring-gray-400"
           >
             {models.map((opt) => (
               <option key={opt.id} value={opt.id}>
@@ -120,7 +120,7 @@ function ModelSection({
               value={aiParam?.apiKey ?? ""}
               onChange={(e) => setAIParam((prev) => ({ ...prev, apiKey: e.target.value }))}
               placeholder="sk-…"
-              className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs text-gray-800 dark:text-gray-200 outline-none focus:ring-1 focus:ring-blue-400"
+              className="flex-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-1 text-xs text-gray-800 dark:text-gray-200 outline-none focus:ring-1 focus:ring-gray-400"
             />
           </div>
           <div className="flex justify-end">


### PR DESCRIPTION
## Summary
- Replace `blue-*` Tailwind classes with `gray-*` equivalents in `ModelSettingsCards`
- Affects the Save button, model select, and API key input focus rings on the `/settings` page

## Changes
- `SaveBtn`: `bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300` → gray equivalents
- `select` + `input` focus ring: `focus:ring-blue-400` → `focus:ring-gray-400`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)