### PR TITLE
feat: stable-entry cookie persistence + rename param to dots

### DIFF
--- a/vibes.diy/stable-entry/App.tsx
+++ b/vibes.diy/stable-entry/App.tsx
@@ -20,12 +20,12 @@ const columnHelper = createColumnHelper<RowData>();
 const GROUPING = ["path"];
 
 async function fetchGroups(): Promise<ApiResponse> {
-  const res = await fetch("/@stable-entry/api");
+  const res = await fetch("/.stable-entry/api");
   return res.json() as Promise<ApiResponse>;
 }
 
 async function selectGroup(path: string, key: string): Promise<ApiResponse> {
-  const res = await fetch("/@stable-entry/api", {
+  const res = await fetch("/.stable-entry/api", {
     method: "PUT",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ path, key }),

--- a/vibes.diy/stable-entry/README.md
+++ b/vibes.diy/stable-entry/README.md
@@ -1,6 +1,6 @@
 # stable-entry
 
-A Cloudflare Worker that proxies requests to different backends based on a per-path cookie. A small React SPA at `/@stable-entry/` lets you switch routes interactively.
+A Cloudflare Worker that proxies requests to different backends based on a per-path cookie. A small React SPA at `/.stable-entry/` lets you switch routes interactively.
 
 ## Environment variables
 
@@ -66,7 +66,7 @@ Every proxied response includes an `X-Stable-Entry` header with the resolved gro
 
 ## UI
 
-Visit `/@stable-entry/` to see all configured paths and groups, switch the active group per path, and copy a ready-to-use `curl` command with the current cookie.
+Visit `/.stable-entry/` to see all configured paths and groups, switch the active group per path, and copy a ready-to-use `curl` command with the current cookie.
 
 ## Deployment
 

--- a/vibes.diy/stable-entry/README.md
+++ b/vibes.diy/stable-entry/README.md
@@ -57,10 +57,10 @@ which decodes to `{"/api":"dev","/":"prod"}`.
 You can also override routing for a single request with a query parameter — useful for testing without touching the cookie:
 
 ```
-https://example.com/some/page?@stable-entry@=dev
+https://example.com/some/page?.stable-entry.=dev
 ```
 
-The parameter is stripped before the request is forwarded upstream.
+The parameter is stripped before the request is forwarded upstream. When present, the routing choice is also persisted into the `se-group` cookie so subsequent requests continue routing to that backend.
 
 Every proxied response includes an `X-Stable-Entry` header with the resolved group key.
 

--- a/vibes.diy/stable-entry/spa-api.ts
+++ b/vibes.diy/stable-entry/spa-api.ts
@@ -31,21 +31,23 @@ function handleGet(request: Request, env: Env): Response {
   return Response.json({ routes: buildRoutes(env, routingGroups), cookie: routingGroups } satisfies ApiResponse);
 }
 
-async function handlePut(request: Request, env: Env, origin: string): Promise<Response> {
-  const { path, key } = (await request.json()) as { path: string; key: string };
-  const routingGroups = parseRoutingCookie(request.headers.get("cookie") ?? "");
-
+export function updateRoutingCookie(routingGroups: Record<string, string>, path: string, key: string): string {
   if (key === "*") {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete routingGroups[path];
   } else {
     routingGroups[path] = key;
   }
-
   const hasSelections = Object.keys(routingGroups).length > 0;
-  const cookieHeader = hasSelections
+  return hasSelections
     ? serializeCookie(ROUTING_COOKIE, encodeURIComponent(JSON.stringify(routingGroups)), { path: "/" })
     : serializeCookie(ROUTING_COOKIE, "", { maxAge: 0, path: "/" });
+}
+
+async function handlePut(request: Request, env: Env, origin: string): Promise<Response> {
+  const { path, key } = (await request.json()) as { path: string; key: string };
+  const routingGroups = parseRoutingCookie(request.headers.get("cookie") ?? "");
+  const cookieHeader = updateRoutingCookie(routingGroups, path, key);
 
   return new Response(null, {
     status: 303,

--- a/vibes.diy/stable-entry/types.ts
+++ b/vibes.diy/stable-entry/types.ts
@@ -2,7 +2,8 @@ import type { Fetcher } from "@cloudflare/workers-types";
 import { Result, exception2Result, Lazy } from "@adviser/cement";
 
 export const ROUTING_COOKIE = "se-group";
-export const SPA_PREFIX = "/@stable-entry";
+export const SPA_PREFIX = "/.stable-entry";
+export const OLD_SPA_PREFIX = "/@stable-entry";
 export const API_PATH = `${SPA_PREFIX}/api`;
 
 // ─── Input (raw from JSON) ────────────────────────────────────────────────────

--- a/vibes.diy/stable-entry/vite.config.ts
+++ b/vibes.diy/stable-entry/vite.config.ts
@@ -4,7 +4,7 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import { readFileSync } from "fs";
 import { join } from "path";
 
-const SPA_PREFIX = "/@stable-entry";
+const SPA_PREFIX = "/.stable-entry";
 
 // Vite-internal paths stay at root — never prefix these
 const VITE_INTERNAL = ["/node_modules/", "/@vite/", "/@fs/", "/__vite"];
@@ -13,7 +13,7 @@ function isViteInternal(p: string): boolean {
   return VITE_INTERNAL.some((prefix) => p.startsWith(prefix));
 }
 
-// Rewrite absolute app-module imports to include /@stable-entry prefix
+// Rewrite absolute app-module imports to include /.stable-entry prefix
 // so the browser routes them back through the worker → ASSETS → this middleware.
 // Vite-internal paths are left untouched.
 function rewriteImports(code: string): string {

--- a/vibes.diy/stable-entry/worker.ts
+++ b/vibes.diy/stable-entry/worker.ts
@@ -72,7 +72,7 @@ export default {
     const response = await proxyRequest(request, target, url.pathname, search, resolvedKey);
 
     // Persist routing choice as cookie when ?.stable-entry. query param is present
-    if (paramKey && matchedPath !== undefined) {
+    if (paramKey != null && matchedPath !== undefined) {
       if (resolvedKey === "*") {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete routingGroups[matchedPath];

--- a/vibes.diy/stable-entry/worker.ts
+++ b/vibes.diy/stable-entry/worker.ts
@@ -1,8 +1,9 @@
 import type { Env, RouteTarget } from "./types.js";
-import { getBackendConfig, SPA_PREFIX } from "./types.js";
+import { getBackendConfig, SPA_PREFIX, ROUTING_COOKIE } from "./types.js";
 import { isSpaApi, handleSpaApi, parseRoutingCookie } from "./spa-api.js";
 import type { Request as CFRequest } from "@cloudflare/workers-types";
 import { URI } from "@adviser/cement";
+import { serialize as serializeCookie } from "cookie";
 
 async function proxyRequest(
   request: Request,
@@ -68,6 +69,23 @@ export default {
     const routeTarget = groups[resolvedKey];
     const target = routeTarget?.target ?? env.BACKEND;
 
-    return proxyRequest(request, target, url.pathname, search, resolvedKey);
+    const response = await proxyRequest(request, target, url.pathname, search, resolvedKey);
+
+    // Persist routing choice as cookie when ?@stable-entry@ query param is present
+    if (paramKey && matchedPath !== undefined) {
+      if (resolvedKey === "*") {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete routingGroups[matchedPath];
+      } else {
+        routingGroups[matchedPath] = resolvedKey;
+      }
+      const hasSelections = Object.keys(routingGroups).length > 0;
+      const cookieHeader = hasSelections
+        ? serializeCookie(ROUTING_COOKIE, encodeURIComponent(JSON.stringify(routingGroups)), { path: "/" })
+        : serializeCookie(ROUTING_COOKIE, "", { maxAge: 0, path: "/" });
+      response.headers.append("set-cookie", cookieHeader);
+    }
+
+    return response;
   },
 };

--- a/vibes.diy/stable-entry/worker.ts
+++ b/vibes.diy/stable-entry/worker.ts
@@ -57,8 +57,8 @@ export default {
 
     const routingGroups = parseRoutingCookie(request.headers.get("cookie") ?? "");
     const uri = URI.from(request.url);
-    const paramKey = uri.getParam("@stable-entry@");
-    const search = uri.build().delParam("@stable-entry@").asURL().search;
+    const paramKey = uri.getParam(".stable-entry.");
+    const search = uri.build().delParam(".stable-entry.").asURL().search;
 
     // first path prefix match wins (longest-first order from parse)
     const pathEntry = Object.entries(cfg).find(([path]) => url.pathname.startsWith(path));
@@ -71,7 +71,7 @@ export default {
 
     const response = await proxyRequest(request, target, url.pathname, search, resolvedKey);
 
-    // Persist routing choice as cookie when ?@stable-entry@ query param is present
+    // Persist routing choice as cookie when ?.stable-entry. query param is present
     if (paramKey && matchedPath !== undefined) {
       if (resolvedKey === "*") {
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete

--- a/vibes.diy/stable-entry/worker.ts
+++ b/vibes.diy/stable-entry/worker.ts
@@ -1,9 +1,8 @@
 import type { Env, RouteTarget } from "./types.js";
-import { getBackendConfig, SPA_PREFIX, ROUTING_COOKIE } from "./types.js";
-import { isSpaApi, handleSpaApi, parseRoutingCookie } from "./spa-api.js";
+import { getBackendConfig, SPA_PREFIX, OLD_SPA_PREFIX } from "./types.js";
+import { isSpaApi, handleSpaApi, parseRoutingCookie, updateRoutingCookie } from "./spa-api.js";
 import type { Request as CFRequest } from "@cloudflare/workers-types";
 import { URI } from "@adviser/cement";
-import { serialize as serializeCookie } from "cookie";
 
 async function proxyRequest(
   request: Request,
@@ -38,9 +37,18 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
+    // Redirect old /@stable-entry/ path to new /.stable-entry/
+    if (url.pathname.startsWith(OLD_SPA_PREFIX)) {
+      const newPath = SPA_PREFIX + url.pathname.slice(OLD_SPA_PREFIX.length);
+      return new Response(null, {
+        status: 302,
+        headers: { location: `${url.origin}${newPath}${url.search}` },
+      });
+    }
+
     if (url.pathname.startsWith(SPA_PREFIX)) {
       if (isSpaApi(url.pathname)) return handleSpaApi(request, env);
-      // Dev: pass full URL so the Vite middleware handles /@stable-entry/* routing.
+      // Dev: pass full URL so the Vite middleware handles /.stable-entry/* routing.
       // Prod: strip prefix so ASSETS finds files at the root of dist/spa/.
       const assetPath = url.pathname.slice(SPA_PREFIX.length) || "/";
       const assetReq = import.meta.env.DEV ? request : new Request(new URL(assetPath, url.origin), request);
@@ -57,8 +65,8 @@ export default {
 
     const routingGroups = parseRoutingCookie(request.headers.get("cookie") ?? "");
     const uri = URI.from(request.url);
-    const paramKey = uri.getParam(".stable-entry.");
-    const search = uri.build().delParam(".stable-entry.").asURL().search;
+    const paramKey = uri.getParam(".stable-entry.") ?? uri.getParam("@stable-entry@");
+    const search = uri.build().delParam(".stable-entry.").delParam("@stable-entry@").asURL().search;
 
     // first path prefix match wins (longest-first order from parse)
     const pathEntry = Object.entries(cfg).find(([path]) => url.pathname.startsWith(path));
@@ -73,17 +81,7 @@ export default {
 
     // Persist routing choice as cookie when ?.stable-entry. query param is present
     if (paramKey != null && matchedPath !== undefined) {
-      if (resolvedKey === "*") {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete routingGroups[matchedPath];
-      } else {
-        routingGroups[matchedPath] = resolvedKey;
-      }
-      const hasSelections = Object.keys(routingGroups).length > 0;
-      const cookieHeader = hasSelections
-        ? serializeCookie(ROUTING_COOKIE, encodeURIComponent(JSON.stringify(routingGroups)), { path: "/" })
-        : serializeCookie(ROUTING_COOKIE, "", { maxAge: 0, path: "/" });
-      response.headers.append("set-cookie", cookieHeader);
+      response.headers.append("set-cookie", updateRoutingCookie(routingGroups, matchedPath, resolvedKey));
     }
 
     return response;


### PR DESCRIPTION
## Summary

Two commits:

- **`4a5b6141` — cookie persistence** (cherry-picked from `jchris/prodv2-env-setup`): When `?@stable-entry@=dev` is on the URL, the routing choice is now persisted into the `se-group` cookie. Uses `resolvedKey` so invalid values fall back to `*`. Already deployed via `se@v0.0.3`.

- **`20e67c32` — rename param from `@` to `.`**: `@` gets URL-encoded to `%40` in browser address bars, making links ugly. Dots pass through clean: `?.stable-entry.=dev`

## Deploy

Tag `se@v0.0.4` after merge to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)