### PR TITLE
feat: automatic PR preview deployments

### DIFF
--- a/.github/workflows/vibes-diy-pr-cleanup.yaml
+++ b/.github/workflows/vibes-diy-pr-cleanup.yaml
@@ -1,0 +1,69 @@
+name: 'Cleanup vibes.diy PR Preview'
+
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - 'vibes.diy/**/*'
+      - '.github/workflows/vibes-diy-pr-preview.yaml'
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node and pnpm
+        uses: ./actions/runtime
+
+      - name: Install wrangler
+        run: pnpm install -g wrangler
+
+      - name: Set PR info
+        id: pr
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          WORKER_NAME="pr-${PR_NUMBER}-vibes-diy-v2"
+          echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "worker_name=${WORKER_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Delete preview worker
+        id: delete
+        run: |
+          set -e
+          OUTPUT=$(wrangler delete ${{ steps.pr.outputs.worker_name }} --force 2>&1) && STATUS="deleted" || {
+            if echo "$OUTPUT" | grep -qi "not found"; then
+              STATUS="not_found"
+            else
+              echo "::error::Failed to delete worker: $OUTPUT"
+              exit 1
+            fi
+          }
+          echo "status=${STATUS}" >> $GITHUB_OUTPUT
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const workerName = '${{ steps.pr.outputs.worker_name }}';
+            const status = '${{ steps.delete.outputs.status }}';
+            const note = status === 'not_found'
+              ? 'No preview worker was found (may not have been deployed for this PR).'
+              : `Preview worker \`${workerName}\` has been deleted.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `## Preview Cleanup\n\n${note}\n\n---\n<sub>Resources cleaned up automatically on PR close.</sub>`,
+            });

--- a/.github/workflows/vibes-diy-pr-cleanup.yaml
+++ b/.github/workflows/vibes-diy-pr-cleanup.yaml
@@ -9,10 +9,12 @@ on:
 
 jobs:
   cleanup-preview:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     environment: dev
     permissions:
       contents: read
+      issues: write
       pull-requests: write
 
     steps:
@@ -23,7 +25,7 @@ jobs:
         uses: ./actions/runtime
 
       - name: Install wrangler
-        run: pnpm install -g wrangler
+        run: pnpm add -g wrangler@4.80.0
 
       - name: Set PR info
         id: pr

--- a/.github/workflows/vibes-diy-pr-preview.yaml
+++ b/.github/workflows/vibes-diy-pr-preview.yaml
@@ -1,0 +1,145 @@
+name: 'Deploy vibes.diy PR Preview'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'vibes.diy/**/*'
+      - '.github/workflows/vibes-diy-pr-preview.yaml'
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup runtime environment
+        uses: ./actions/base
+
+      - name: Set PR info
+        id: pr
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          WORKER_NAME="pr-${PR_NUMBER}-vibes-diy-v2"
+          PREVIEW_URL="https://${WORKER_NAME}.jchris.workers.dev"
+          echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "worker_name=${WORKER_NAME}" >> $GITHUB_OUTPUT
+          echo "preview_url=${PREVIEW_URL}" >> $GITHUB_OUTPUT
+
+      - name: Build and deploy preview
+        working-directory: vibes.diy/pkg
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUD_SESSION_TOKEN_PUBLIC: ${{ vars.CLOUD_SESSION_TOKEN_PUBLIC }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+          DEVICE_ID_CA_PRIV_KEY: ${{ secrets.DEVICE_ID_CA_PRIV_KEY }}
+          DEVICE_ID_CA_CERT: ${{ vars.DEVICE_ID_CA_CERT }}
+          FP_VERSION: ${{ vars.FP_VERSION }}
+          FPCLOUD_URL: ${{ vars.FPCLOUD_URL }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          VIBES_DIY_PUBLIC_BASE_URL: ${{ vars.VIBES_DIY_PUBLIC_BASE_URL }}
+          CLOUD_SESSION_TOKEN_SECRET: ${{ secrets.CLOUD_SESSION_TOKEN_SECRET }}
+          CLOUD_SESSION_TOKEN_ISSUER: ${{ vars.CLOUD_SESSION_TOKEN_ISSUER }}
+          VIBES_DIY_FROM_EMAIL: ${{ vars.VIBES_DIY_FROM_EMAIL }}
+          VIBES_SVC_HOSTNAME_BASE: ${{ vars.VIBES_SVC_HOSTNAME_BASE }}
+          VIBES_SVC_PROTOCOL: ${{ vars.VIBES_SVC_PROTOCOL }}
+          LLM_BACKEND_API_KEY: ${{ secrets.LLM_BACKEND_API_KEY }}
+          LLM_BACKEND_URL: ${{ vars.LLM_BACKEND_URL }}
+          CLERK_PUB_JWT_URL: ${{ vars.CLERK_PUB_JWT_URL }}
+          DB_FLAVOUR: ${{ vars.DB_FLAVOUR }}
+          NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+          MAX_APP_SLUG_PER_USER_ID: ${{ vars.MAX_APP_SLUG_PER_USER_ID }}
+          WORKSPACE_NPM_URL: ${{ vars.WORKSPACE_NPM_URL }}
+          VIBES_DIY_API_URL: ${{ vars.VIBES_DIY_API_URL }}
+          WORKER_NAME: ${{ steps.pr.outputs.worker_name }}
+        run: |
+          set -e
+
+          # Build using preview env (no routes, workers.dev only)
+          CLOUDFLARE_ENV=preview react-router build
+
+          # No migrations — merge to main for schema changes
+
+          # Set secrets on the preview worker
+          pnpm exec core-cli writeEnv --out - --json \
+            --fromEnv CLOUD_SESSION_TOKEN_PUBLIC \
+            --fromEnv CLERK_PUBLISHABLE_KEY \
+            --fromEnv DEVICE_ID_CA_PRIV_KEY \
+            --fromEnv DEVICE_ID_CA_CERT \
+            --fromEnv FP_VERSION \
+            --fromEnv FPCLOUD_URL \
+            --fromEnv RESEND_API_KEY \
+            --fromEnv VIBES_DIY_PUBLIC_BASE_URL \
+            --fromEnv CLOUD_SESSION_TOKEN_SECRET \
+            --fromEnv CLOUD_SESSION_TOKEN_ISSUER \
+            --fromEnv VIBES_DIY_FROM_EMAIL \
+            --fromEnv VIBES_SVC_HOSTNAME_BASE \
+            --fromEnv VIBES_SVC_PROTOCOL \
+            --fromEnv LLM_BACKEND_API_KEY \
+            --fromEnv LLM_BACKEND_URL \
+            --fromEnv CLERK_PUB_JWT_URL \
+            --fromEnv DB_FLAVOUR \
+            --fromEnv NEON_DATABASE_URL \
+            --fromEnv MAX_APP_SLUG_PER_USER_ID \
+            --fromEnv WORKSPACE_NPM_URL \
+            --fromEnv VIBES_DIY_API_URL | \
+            pnpm exec wrangler -c ./wrangler.toml secret --env preview --name $WORKER_NAME bulk
+
+          # Deploy with custom worker name (preview env has no routes)
+          pnpm exec wrangler deploy --env preview --name $WORKER_NAME
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const previewUrl = '${{ steps.pr.outputs.preview_url }}';
+            const workerName = '${{ steps.pr.outputs.worker_name }}';
+            const sha = context.sha.substring(0, 7);
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Preview Deployment')
+            );
+
+            const commentBody = `## Preview Deployment
+
+            **Preview URL:** ${previewUrl}
+            **Worker:** \`${workerName}\`
+            **Commit:** ${sha}
+
+            ---
+            <sub>Updated on each push to this PR. Worker is deleted when the PR closes.</sub>`;
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody,
+              });
+            }

--- a/.github/workflows/vibes-diy-pr-preview.yaml
+++ b/.github/workflows/vibes-diy-pr-preview.yaml
@@ -70,7 +70,7 @@ jobs:
           set -e
 
           # Build using preview env (no routes, workers.dev only)
-          CLOUDFLARE_ENV=preview react-router build
+          CLOUDFLARE_ENV=preview pnpm exec react-router build
 
           # No migrations — merge to main for schema changes
 

--- a/.github/workflows/vibes-diy-pr-preview.yaml
+++ b/.github/workflows/vibes-diy-pr-preview.yaml
@@ -24,7 +24,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup runtime environment
-        uses: ./actions/base
+        uses: ./actions/runtime
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Set PR info
         id: pr

--- a/.github/workflows/vibes-diy-pr-preview.yaml
+++ b/.github/workflows/vibes-diy-pr-preview.yaml
@@ -13,10 +13,12 @@ concurrency:
 
 jobs:
   deploy-preview:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     environment: dev
     permissions:
       contents: read
+      issues: write
       pull-requests: write
 
     steps:
@@ -51,7 +53,7 @@ jobs:
           FP_VERSION: ${{ vars.FP_VERSION }}
           FPCLOUD_URL: ${{ vars.FPCLOUD_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          VIBES_DIY_PUBLIC_BASE_URL: ${{ vars.VIBES_DIY_PUBLIC_BASE_URL }}
+          VIBES_DIY_PUBLIC_BASE_URL: ${{ steps.pr.outputs.preview_url }}
           CLOUD_SESSION_TOKEN_SECRET: ${{ secrets.CLOUD_SESSION_TOKEN_SECRET }}
           CLOUD_SESSION_TOKEN_ISSUER: ${{ vars.CLOUD_SESSION_TOKEN_ISSUER }}
           VIBES_DIY_FROM_EMAIL: ${{ vars.VIBES_DIY_FROM_EMAIL }}
@@ -119,10 +121,11 @@ jobs:
 
             const botComment = comments.find(comment =>
               comment.user.type === 'Bot' &&
-              comment.body.includes('Preview Deployment')
+              comment.body.includes('<!-- vibes-diy-preview -->')
             );
 
-            const commentBody = `## Preview Deployment
+            const commentBody = `<!-- vibes-diy-preview -->
+            ## Preview Deployment
 
             **Preview URL:** ${previewUrl}
             **Worker:** \`${workerName}\`

--- a/.github/workflows/vibes-diy-pr-preview.yaml
+++ b/.github/workflows/vibes-diy-pr-preview.yaml
@@ -97,7 +97,7 @@ jobs:
             --fromEnv MAX_APP_SLUG_PER_USER_ID \
             --fromEnv WORKSPACE_NPM_URL \
             --fromEnv VIBES_DIY_API_URL | \
-            pnpm exec wrangler -c ./wrangler.toml secret --env preview --name $WORKER_NAME bulk
+            pnpm exec wrangler secret --name $WORKER_NAME bulk
 
           # Deploy with custom worker name (preview env has no routes)
           pnpm exec wrangler deploy --env preview --name $WORKER_NAME

--- a/.github/workflows/vibes-diy-pr-preview.yaml
+++ b/.github/workflows/vibes-diy-pr-preview.yaml
@@ -65,8 +65,8 @@ jobs:
           DB_FLAVOUR: ${{ vars.DB_FLAVOUR }}
           NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
           MAX_APP_SLUG_PER_USER_ID: ${{ vars.MAX_APP_SLUG_PER_USER_ID }}
-          WORKSPACE_NPM_URL: ${{ vars.WORKSPACE_NPM_URL }}
-          VIBES_DIY_API_URL: ${{ vars.VIBES_DIY_API_URL }}
+          WORKSPACE_NPM_URL: ${{ steps.pr.outputs.preview_url }}/vibe-pkg/
+          VIBES_DIY_API_URL: ${{ steps.pr.outputs.preview_url }}/api
           WORKER_NAME: ${{ steps.pr.outputs.worker_name }}
         run: |
           set -e

--- a/vibes.diy/pkg/wrangler.toml
+++ b/vibes.diy/pkg/wrangler.toml
@@ -103,6 +103,34 @@ bucket_name = "vibes-diy-fs-ids"
 queue = "vibes-service-dev"
 binding = "VIBES_SERVICE"
 
+[env.preview]
+name = "vibes-diy-v2-preview"
+vars = { ENVIRONMENT = "preview" }
+# No routes — preview workers are accessed via workers.dev URLs only
+
+[env.preview.browser]
+binding = "BROWSER"
+
+[env.preview.durable_objects]
+bindings = [{ name = "CHAT_SESSIONS", class_name = "ChatSessions" }]
+
+[[env.preview.migrations]]
+tag = "v1"
+new_classes = ["ChatSessions"]
+
+[[env.preview.d1_databases]]
+binding = "DB"
+database_name = "dev-vibes-diy-v2"
+database_id = "105530de-9900-435b-92f4-15347af604f6"
+
+[[env.preview.r2_buckets]]
+binding = "FS_IDS_BUCKET"
+bucket_name = "vibes-diy-fs-ids"
+
+[[env.preview.queues.producers]]
+queue = "vibes-service-dev"
+binding = "VIBES_SERVICE"
+
 [env.prod]
 name = "vibes-diy-v2-prod"
 vars = { ENVIRONMENT = "prod" }

--- a/vibes.diy/pkg/wrangler.toml
+++ b/vibes.diy/pkg/wrangler.toml
@@ -108,6 +108,12 @@ name = "vibes-diy-v2-preview"
 vars = { ENVIRONMENT = "preview" }
 # No routes — preview workers are accessed via workers.dev URLs only
 
+[env.preview.observability.logs]
+enabled = true
+head_sampling_rate = 1
+invocation_logs = true
+persist = true
+
 [env.preview.browser]
 binding = "BROWSER"
 

--- a/vibes.diy/pkg/wrangler.toml
+++ b/vibes.diy/pkg/wrangler.toml
@@ -105,6 +105,7 @@ binding = "VIBES_SERVICE"
 
 [env.preview]
 name = "vibes-diy-v2-preview"
+workers_dev = true
 vars = { ENVIRONMENT = "preview" }
 # No routes — preview workers are accessed via workers.dev URLs only
 
@@ -118,11 +119,7 @@ persist = true
 binding = "BROWSER"
 
 [env.preview.durable_objects]
-bindings = [{ name = "CHAT_SESSIONS", class_name = "ChatSessions" }]
-
-[[env.preview.migrations]]
-tag = "v1"
-new_classes = ["ChatSessions"]
+bindings = [{ name = "CHAT_SESSIONS", class_name = "ChatSessions", script_name = "vibes-diy-v2-dev" }]
 
 [[env.preview.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Summary

- Adds `[env.preview]` to wrangler.toml — shares dev's D1/R2/DO/queue bindings but has **no routes** (workers.dev only)
- New workflow deploys `pr-{N}-vibes-diy-v2` worker on PR open/push, posts preview URL as PR comment
- Cleanup workflow deletes the worker on PR close with proper error handling (fails on real errors, tolerates "not found")
- Uses `dev` GitHub environment (single data plane — same Neon DB as prod)
- No schema migrations on preview — merge to main first

### How it works

1. PR opens/updates touching `vibes.diy/**/*`
2. Workflow builds with `CLOUDFLARE_ENV=preview`, deploys with `--env preview --name pr-{N}-vibes-diy-v2`
3. Bot comments the live URL on the PR (updates on each push)
4. PR closes → cleanup workflow deletes the worker

### Design decisions

| Decision | Why |
|----------|-----|
| `[env.preview]` not `--env dev` | dev has `dev-v2.vibesdiy.net/*` routes — deploying with `--env dev --name <custom>` would hijack them |
| No migrations | Unmerged branches shouldn't mutate shared schema |
| Lightweight cleanup | Uses `actions/runtime` not `actions/base` — no lint/build/test just to delete a worker |
| Proper delete error handling | Only swallows "not found"; real API failures surface |

Closes #1301

## Test plan

- [ ] This PR itself triggers the preview workflow (touches `vibes.diy/pkg/wrangler.toml`)
- [ ] Verify bot comment appears with preview URL
- [ ] Visit preview URL and confirm the app loads
- [ ] Close and reopen PR to verify cleanup + redeploy cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)