### PR TITLE
feat: unified layout v2 — mobile tab bar + view routing

### DIFF
--- a/vibes.diy/pkg/drizzle.d1-local-backend.config.ts
+++ b/vibes.diy/pkg/drizzle.d1-local-backend.config.ts
@@ -22,7 +22,7 @@ function getLocalD1DB(): string {
 
 export default defineConfig({
   dialect: "sqlite",
-  schema: "./node_modules/@vibes.diy/api-svc/sql/vibes-diy-api-schema-sqlite.ts",
+  schema: "./node_modules/@vibes.diy/api-sql/vibes-diy-api-schema-sqlite.ts",
   out: "./dist",
   dbCredentials: {
     url: getLocalD1DB(),

--- a/vibes.diy/pkg/drizzle.d1-remote.config.ts
+++ b/vibes.diy/pkg/drizzle.d1-remote.config.ts
@@ -74,7 +74,7 @@ if (!databaseId) {
 
 export default defineConfig({
   dialect: "sqlite",
-  schema: "./node_modules/@vibes.diy/api-svc/sql/vibes-diy-api-schema-sqlite.ts",
+  schema: "./node_modules/@vibes.diy/api-sql/vibes-diy-api-schema-sqlite.ts",
   out: "./dist",
   driver: "d1-http",
   dbCredentials: {


### PR DESCRIPTION
## Summary
- Port layout behavior from PR #1300 onto the design-system branch (`mabels/vibes-diy-api`)
- MVP scope: mobile tab bar (5 views) + smart content routing
- Fix drizzle schema path (`api-svc` → `api-sql`) that was breaking `pnpm dev`

## Deferred
- Pin/unpin modes, floating modal, drag, swipe gestures, animations

## Test plan
- [ ] PR preview deploys successfully
- [ ] Mobile: bottom tab bar navigates between views
- [ ] Desktop: 2-panel layout unchanged
- [ ] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)