### PR TITLE
feat: sidebar redesign with recent vibes

### DIFF
--- a/vibes.diy/pkg/app/components/AppLayout.tsx
+++ b/vibes.diy/pkg/app/components/AppLayout.tsx
@@ -1,9 +1,10 @@
-import { VibesSwitch, gridBackground, cx } from "@vibes.diy/base";
+import { gridBackground, cx } from "@vibes.diy/base";
 import React from "react";
 import { useDocumentTitle } from "../hooks/useDocumentTitle.js";
 import type { ReactNode } from "react";
 import { useShareableDB } from "../hooks/useShareableDB.js";
 import { AllowFireproofSharing } from "./AllowFireproofSharing.js";
+import { PillPortal, PILL_CLEARANCE } from "./PillPortal.js";
 
 interface AppLayoutProps {
   chatPanel: ReactNode;
@@ -37,6 +38,8 @@ export default function AppLayout({
 
   return (
     <div className={cx(gridBackground, "page-grid-background relative flex h-dvh flex-col md:flex-row md:overflow-hidden")}>
+      <PillPortal isActive={isSidebarVisible} onToggle={setIsSidebarVisible} />
+
       {/* Content with relative positioning to appear above the background */}
       <div
         className={`flex w-full flex-col ${fullWidthChat ? "md:w-full" : "md:w-1/3"} ${
@@ -44,9 +47,7 @@ export default function AppLayout({
         } relative z-10 transition-all duration-300 ease-in-out`}
       >
         <div className="flex h-[4rem] items-center p-2">
-          <div className="mb-8 ml-6 relative z-20">
-            <VibesSwitch size={75} isActive={isSidebarVisible} onToggle={setIsSidebarVisible} className="cursor-pointer" />
-          </div>
+          <div style={{ width: PILL_CLEARANCE }} />
           {headerLeft}
         </div>
 

--- a/vibes.diy/pkg/app/components/ChatHeaderContent.tsx
+++ b/vibes.diy/pkg/app/components/ChatHeaderContent.tsx
@@ -1,27 +1,16 @@
 import React, { memo } from "react";
-import { MenuIcon } from "./ChatHeaderIcons.js";
+import { PILL_CLEARANCE } from "./PillPortal.js";
 
 interface ChatHeaderContentProps {
-  onOpenSidebar: () => void;
   title: string;
   promptProcessing: boolean;
   codeReady: boolean;
   remixOf?: string;
 }
 
-function ChatHeaderContent({ onOpenSidebar, title, promptProcessing, codeReady, remixOf }: ChatHeaderContentProps) {
+function ChatHeaderContent({ title, promptProcessing, codeReady, remixOf }: ChatHeaderContentProps) {
   return (
-    <div className="flex h-full w-full items-center justify-between p-2 py-4">
-      <div className="flex items-center">
-        <button
-          type="button"
-          onClick={onOpenSidebar}
-          className="text-light-primary dark:text-dark-primary hover:text-accent-02-light dark:hover:text-accent-02-dark mr-3 px-2 py-4"
-          aria-label="Open chat history"
-        >
-          <MenuIcon />
-        </button>
-      </div>
+    <div className="flex h-full w-full items-center justify-between p-2 py-4" style={{ paddingLeft: PILL_CLEARANCE }}>
       <div className="text-light-primary dark:text-dark-primary text-center text-sm">
         {remixOf ? (
           <>
@@ -60,13 +49,9 @@ function ChatHeaderContent({ onOpenSidebar, title, promptProcessing, codeReady, 
   );
 }
 
-// Use React.memo with a custom comparison function to ensure the component only
-// re-renders when its props actually change
 export default memo(ChatHeaderContent, (prevProps, nextProps) => {
-  // Only re-render if title or onOpenSidebar changes
   return (
     prevProps.remixOf === nextProps.remixOf &&
-    prevProps.onOpenSidebar === nextProps.onOpenSidebar &&
     prevProps.title === nextProps.title &&
     prevProps.promptProcessing === nextProps.promptProcessing &&
     prevProps.codeReady === nextProps.codeReady

--- a/vibes.diy/pkg/app/components/ChatInterface.tsx
+++ b/vibes.diy/pkg/app/components/ChatInterface.tsx
@@ -61,10 +61,8 @@ function ChatInterface({
           />
         </div>
       ) : (
-        <div className="flex flex-grow flex-col justify-between">
-          <div className="flex-grow pb-4">
-            <WelcomeScreen />
-          </div>
+        <div className="flex flex-grow items-center justify-center">
+          <WelcomeScreen />
         </div>
       )}
     </div>

--- a/vibes.diy/pkg/app/components/HomePage.tsx
+++ b/vibes.diy/pkg/app/components/HomePage.tsx
@@ -4,7 +4,8 @@ import { quickSuggestions } from "../data/quick-suggestions-data.js";
 import { useVibesDiy } from "../vibes-diy-provider.js";
 import { useNavigate } from "react-router";
 import { BuildURI } from "@adviser/cement";
-import { VibesSwitch, VibesButton, ArrowLeftIcon, ArrowRightIcon, gridBackground, cx } from "@vibes.diy/base";
+import { VibesButton, ArrowLeftIcon, ArrowRightIcon, gridBackground, cx } from "@vibes.diy/base";
+import { PillPortal, PILL_CLEARANCE_Y } from "./PillPortal.js";
 import { isMobileViewport } from "../utils/ViewState.js";
 import VibeGallery from "./NewSessionContent/VibeGallery.js";
 import {
@@ -152,11 +153,10 @@ export default function HomePage() {
 
   return (
     <>
+      <PillPortal isActive={isSidebarVisible} onToggle={setIsSidebarVisible} />
       <div className={cx(gridBackground, "page-grid-background min-h-screen min-h-[100svh] min-h-[100dvh] w-full")}>
         <div className="px-6 md:px-8 pb-8 pt-0">
-          <div className="mb-4 md:mb-8 ml-2 md:ml-6 relative z-20">
-            <VibesSwitch size={75} isActive={isSidebarVisible} onToggle={setIsSidebarVisible} className="cursor-pointer" />
-          </div>
+          <div style={{ height: PILL_CLEARANCE_Y }} />
 
           <div style={getContainerStyle(mobile)}>
             <h1 style={getTitle(mobile)}>

--- a/vibes.diy/pkg/app/components/PillPortal.tsx
+++ b/vibes.diy/pkg/app/components/PillPortal.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { VibesSwitch } from "@vibes.diy/base";
+import { useAuth } from "@clerk/react";
+import { Link } from "react-router-dom";
+
+/** Width reserved in headers/layouts so content clears the fixed pill. */
+export const PILL_CLEARANCE = 125;
+
+/** Height reserved below the pill for vertical clearance. */
+export const PILL_CLEARANCE_Y = 60;
+
+interface PillPortalProps {
+  isActive: boolean;
+  onToggle: (active: boolean) => void;
+}
+
+export function PillPortal({ isActive, onToggle }: PillPortalProps) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const { isSignedIn } = useAuth();
+
+  if (!mounted) return null;
+
+  const showNewVibe = isActive && isSignedIn;
+  return createPortal(
+    <div
+      style={{
+        position: "fixed",
+        top: -9,
+        left: 4,
+        width: 248,
+        zIndex: 40,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+      }}
+    >
+      <VibesSwitch size={75} isActive={isActive} onToggle={onToggle} className="cursor-pointer" />
+      <Link
+        to="/"
+        aria-label="New vibe"
+        data-new-vibe-btn
+        className="hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+        onClick={() => onToggle(false)}
+        style={{
+          alignItems: "center",
+          justifyContent: "center",
+          width: 32,
+          height: 32,
+          borderRadius: 8,
+          color: "var(--vibes-near-black, #1a1a1a)",
+          marginTop: 28,
+          marginRight: 14,
+          display: "flex",
+          opacity: showNewVibe ? 1 : 0,
+          pointerEvents: showNewVibe ? "auto" : "none",
+          transition: showNewVibe ? "opacity 0.3s ease 0.3s" : "opacity 0.15s ease",
+        }}
+      >
+        <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+        </svg>
+      </Link>
+    </div>,
+    document.body
+  );
+}

--- a/vibes.diy/pkg/app/components/RecentVibes.tsx
+++ b/vibes.diy/pkg/app/components/RecentVibes.tsx
@@ -1,0 +1,108 @@
+import { useAuth } from "@clerk/react";
+import type { ResListUserSlugAppSlugItem } from "@vibes.diy/api-types";
+import React, { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useVibesDiy } from "../vibes-diy-provider.js";
+
+interface RecentVibesProps {
+  onNavigate?: () => void;
+}
+
+interface RecentVibeItem {
+  userSlug: string;
+  appSlug: string;
+}
+
+export function toRecentVibes(items: ResListUserSlugAppSlugItem[], limit: number): RecentVibeItem[] {
+  if (limit <= 0) return [];
+  const out: RecentVibeItem[] = [];
+  for (const item of items) {
+    for (const appSlug of item.appSlugs) {
+      out.push({ userSlug: item.userSlug, appSlug });
+      if (out.length >= limit) return out;
+    }
+  }
+  return out;
+}
+
+export function RecentVibes({ onNavigate }: RecentVibesProps) {
+  const { isSignedIn } = useAuth();
+  const { vibeDiyApi } = useVibesDiy();
+  const [vibeItems, setVibeItems] = useState<ResListUserSlugAppSlugItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const items = useMemo(() => toRecentVibes(vibeItems, 20), [vibeItems]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!isSignedIn) {
+      setVibeItems([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    vibeDiyApi
+      .listUserSlugAppSlug({})
+      .then((res) => {
+        if (cancelled) return;
+        if (res.isOk()) setVibeItems(res.Ok().items);
+        else setVibeItems([]);
+      })
+      .catch(() => {
+        if (!cancelled) setVibeItems([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isSignedIn, vibeDiyApi]);
+
+  if (!isSignedIn) return null;
+
+  return (
+    <div>
+      {loading ? (
+        <div className="flex justify-center py-2">
+          <div className="h-4 w-4 animate-spin rounded-full border-t-2 border-b-2 border-blue-500" />
+        </div>
+      ) : items.length > 0 ? (
+        <>
+          <h3 className="px-4 pb-2 text-xs font-semibold uppercase tracking-wider opacity-50">Recent</h3>
+          <ul>
+            {items.map((item) => (
+              <li key={`${item.userSlug}/${item.appSlug}`}>
+                <Link
+                  to={`/chat/${item.userSlug}/${item.appSlug}`}
+                  onClick={onNavigate}
+                  className="flex items-center px-4 py-2 text-sm transition-colors hover:bg-black/5 dark:hover:bg-white/5 border-b border-black/5 dark:border-white/5"
+                >
+                  <span className="flex flex-col min-w-0">
+                    <span className="truncate">{item.appSlug}</span>
+                    <span className="text-xs truncate opacity-50">{item.userSlug}</span>
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <Link
+            to="/vibes/mine"
+            onClick={onNavigate}
+            className="flex items-center justify-center gap-2 px-4 py-3 text-xs font-medium opacity-60 transition-colors hover:opacity-100 hover:bg-black/5 dark:hover:bg-white/5"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+            </svg>
+            <span>See all vibes</span>
+          </Link>
+        </>
+      ) : (
+        <div className="px-4 pb-1 text-xs opacity-60">No recent vibes yet.</div>
+      )}
+    </div>
+  );
+}

--- a/vibes.diy/pkg/app/components/SessionSidebar.tsx
+++ b/vibes.diy/pkg/app/components/SessionSidebar.tsx
@@ -1,46 +1,28 @@
 import React, { memo, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { SignIn, useAuth, useClerk, useUser } from "@clerk/react";
 import type { SessionSidebarProps } from "@vibes.diy/prompts";
 import { GearIcon } from "./SessionSidebar/GearIcon.js";
-import { HomeIcon } from "./SessionSidebar/HomeIcon.js";
-import { InfoIcon } from "./SessionSidebar/InfoIcon.js";
-import { StarIcon } from "./SessionSidebar/StarIcon.js";
-import { DevBoxIcon } from "./SessionSidebar/DevBoxIcon.js";
-
-/**
- * Component that displays a navigation sidebar with menu items
- */
-function parseDevBoxContext(pathname: string): { userSlug: string; appSlug: string; fsId?: string } | null {
-  const chat = pathname.match(/^\/chat\/([^/]+)\/([^/]+)(?:\/([^/]+))?/);
-  if (chat) return { userSlug: chat[1], appSlug: chat[2], fsId: chat[3] };
-  const vibe = pathname.match(/^\/vibe\/([^/]+)\/([^/]+)(?:\/([^/]+))?/);
-  if (vibe) return { userSlug: vibe[1], appSlug: vibe[2], fsId: vibe[3] };
-  return null;
-}
+import { RecentVibes } from "./RecentVibes.js";
 
 function SessionSidebar({ isVisible, onClose }: SessionSidebarProps) {
   const sidebarRef = useRef<HTMLDivElement>(null);
   const { isSignedIn: isAuthenticated, isLoaded } = useAuth();
-  const { pathname } = useLocation();
-  const devBox = parseDevBoxContext(pathname);
   const isLoading = !isLoaded;
   const clerk = useClerk();
   const { user } = useUser();
   const userEmail = user?.primaryEmailAddress?.emailAddress;
   const [showSignIn, setShowSignIn] = useState(false);
 
-  // Clerk doesn't have polling state like the old auth system
-  const isPolling = false;
-  const pollError = null;
-
   // Handle clicks outside the sidebar to close it
   useEffect(() => {
     if (!isVisible) return;
 
     function handleClickOutside(event: MouseEvent) {
-      if (sidebarRef.current && !sidebarRef.current.contains(event.target as Node)) {
+      const target = event.target as HTMLElement;
+      if (target.closest("[data-new-vibe-btn]")) return;
+      if (sidebarRef.current && !sidebarRef.current.contains(target)) {
         onClose();
       }
     }
@@ -63,74 +45,24 @@ function SessionSidebar({ isVisible, onClose }: SessionSidebarProps) {
         isVisible ? "w-64 translate-x-0" : "w-64 -translate-x-full"
       }`}
     >
-      <div className="flex h-full flex-col overflow-auto pt-32">
-        <nav className="flex-grow p-4">
-          <ul className="space-y-4">
-            <li>
-              <a
-                href="/"
-                className="flex items-center rounded-xl px-4 py-3 text-sm font-medium tracking-wide border-2 border-[var(--vibes-border-primary)] bg-[var(--vibes-card-bg)] shadow-[4px_5px_0_var(--vibes-shadow-color)] transition-all duration-150 ease-in-out hover:shadow-[2px_3px_0_var(--vibes-shadow-color)] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[5px]"
-              >
-                <HomeIcon className="text-accent-01 mr-3 h-5 w-5" />
-                <span>Home</span>
-              </a>
-            </li>
-            {devBox && (
-              <li>
-                <Link
-                  to={`/chat/${devBox.userSlug}/${devBox.appSlug}`}
-                  onClick={() => onClose()}
-                  className="flex items-center rounded-xl px-4 py-3 text-sm font-medium tracking-wide border-2 border-[var(--vibes-border-primary)] bg-[var(--vibes-card-bg)] shadow-[4px_5px_0_var(--vibes-shadow-color)] transition-all duration-150 ease-in-out hover:shadow-[2px_3px_0_var(--vibes-shadow-color)] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[5px]"
-                >
-                  <DevBoxIcon className="text-accent-01 mr-3 h-5 w-5" />
-                  <span className="flex flex-col min-w-0">
-                    <span>DevBox</span>
-                    <span className="text-xs font-normal truncate opacity-60">
-                      {devBox.userSlug}/{devBox.appSlug}
-                    </span>
-                  </span>
-                </Link>
-              </li>
-            )}
-            <li>
-              <Link
-                to="/vibes/mine"
-                onClick={() => onClose()}
-                className="flex items-center rounded-xl px-4 py-3 text-sm font-medium tracking-wide border-2 border-[var(--vibes-border-primary)] bg-[var(--vibes-card-bg)] shadow-[4px_5px_0_var(--vibes-shadow-color)] transition-all duration-150 ease-in-out hover:shadow-[2px_3px_0_var(--vibes-shadow-color)] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[5px]"
-              >
-                <StarIcon className="text-accent-01 mr-3 h-5 w-5" />
-                <span>My Vibes</span>
-              </Link>
-            </li>
-            <li>
-              {isAuthenticated ? (
-                // SETTINGS
-                <Link
-                  to="/settings"
-                  onClick={() => onClose()}
-                  className="flex items-center rounded-xl px-4 py-3 text-sm font-medium tracking-wide border-2 border-[var(--vibes-border-primary)] bg-[var(--vibes-card-bg)] shadow-[4px_5px_0_var(--vibes-shadow-color)] transition-all duration-150 ease-in-out hover:shadow-[2px_3px_0_var(--vibes-shadow-color)] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[5px]"
-                >
-                  <GearIcon className="text-accent-01 mr-3 h-5 w-5" />
-                  <span>Settings</span>
-                </Link>
-              ) : null}
-            </li>
-            <li>
-              <Link
-                to="/about"
-                onClick={() => onClose()}
-                className="flex items-center rounded-xl px-4 py-3 text-sm font-medium tracking-wide border-2 border-[var(--vibes-border-primary)] bg-[var(--vibes-card-bg)] shadow-[4px_5px_0_var(--vibes-shadow-color)] transition-all duration-150 ease-in-out hover:shadow-[2px_3px_0_var(--vibes-shadow-color)] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[5px]"
-              >
-                <InfoIcon className="text-accent-01 mr-3 h-5 w-5" />
-                <span>About</span>
-              </Link>
-            </li>
-          </ul>
+      <div className="flex h-full flex-col overflow-hidden pt-16">
+        <nav className="flex-1 overflow-y-auto min-h-0 p-4">
+          <RecentVibes onNavigate={onClose} />
         </nav>
 
-        {/* Login Status Indicator */}
-        <div className="mt-auto">
-          <nav className="flex-grow p-2">
+        {/* Bottom section — pinned */}
+        <div className="shrink-0 pb-6 px-4 space-y-3">
+          {isAuthenticated && (
+            <Link
+              to="/settings"
+              onClick={() => onClose()}
+              className="flex items-center px-4 py-3 text-sm font-medium tracking-wide transition-colors duration-150 hover:bg-black/5 dark:hover:bg-white/10 border-t border-black/10 dark:border-white/10"
+            >
+              <GearIcon className="text-accent-01 mr-3 h-5 w-5" />
+              <span>Settings</span>
+            </Link>
+          )}
+          <nav>
             <ul className="space-y-2">
               {isLoading ? (
                 // LOADING
@@ -146,37 +78,21 @@ function SessionSidebar({ isVisible, onClose }: SessionSidebarProps) {
                       await clerk.signOut();
                       onClose();
                     }}
-                    className="bg-light-decorative-02 dark:bg-dark-decorative-01 text-white dark:text-dark-primary flex w-full items-center rounded-xl px-4 py-3 text-left text-sm font-bold tracking-wide border-2 border-[var(--vibes-border-primary)] shadow-[4px_5px_0_var(--vibes-shadow-color)] transition-all duration-150 ease-in-out hover:shadow-[2px_3px_0_var(--vibes-shadow-color)] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[5px]"
+                    className="bg-light-decorative-02 dark:bg-dark-decorative-01 text-white dark:text-dark-primary flex w-full items-center rounded-xl px-4 py-3 text-left text-sm font-bold tracking-wide border-2 border-[var(--vibes-border-primary)] transition-colors duration-150 hover:bg-black/20"
                   >
                     <span>Logout {userEmail}</span>
                   </button>
                 </li>
-              ) : isPolling ? (
-                <li>
-                  <div className="flex flex-col gap-1 px-4 py-3 text-sm font-medium">
-                    <span className="">Opening log in window...</span>
-                    <span className="font-small text-xs italic">
-                      Don't see it? Please check your browser for a blocked pop-up window
-                    </span>
-                  </div>
-                </li>
               ) : (
-                <>
-                  <li>
-                    <div className="flex flex-col px-1 py-1 text-sm font-medium">
-                      {pollError && <span className="font-small text-xs text-gray-400 italic">{pollError}</span>}
-                    </div>
-                  </li>
-                  <li>
-                    <button
-                      type="button"
-                      onClick={() => setShowSignIn(true)}
-                      className="bg-light-decorative-02 dark:bg-dark-decorative-01 text-white dark:text-dark-primary flex w-full items-center rounded-xl px-4 py-3 text-left text-sm font-bold tracking-wide border-2 border-[var(--vibes-border-primary)] shadow-[4px_5px_0_var(--vibes-shadow-color)] transition-all duration-150 ease-in-out hover:shadow-[2px_3px_0_var(--vibes-shadow-color)] hover:translate-x-[2px] hover:translate-y-[2px] active:shadow-none active:translate-x-[4px] active:translate-y-[5px]"
-                    >
-                      <span>Log in</span>
-                    </button>
-                  </li>
-                </>
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => setShowSignIn(true)}
+                    className="bg-light-decorative-02 dark:bg-dark-decorative-01 text-white dark:text-dark-primary flex w-full items-center rounded-xl px-4 py-3 text-left text-sm font-bold tracking-wide border-2 border-[var(--vibes-border-primary)] transition-colors duration-150 hover:bg-black/20"
+                  >
+                    <span>Log in</span>
+                  </button>
+                </li>
               )}
             </ul>
           </nav>

--- a/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
+++ b/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
@@ -260,10 +260,6 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
         })()
       : undefined;
 
-  const openSidebar = useCallback(() => {
-    setIsSidebarVisible(true);
-  }, []);
-
   const closeSidebar = useCallback(() => {
     setIsSidebarVisible(false);
   }, []);
@@ -375,7 +371,6 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
         headerLeft={
           <ChatHeaderContent
             remixOf={/*chatState.vibeDoc?.remixOf*/ undefined}
-            onOpenSidebar={openSidebar}
             promptProcessing={promptState.running}
             codeReady={promptState.hasCode}
             title={promptState.title}

--- a/vibes.diy/tests/app/memoization.test.tsx
+++ b/vibes.diy/tests/app/memoization.test.tsx
@@ -64,13 +64,6 @@ describe("Component Memoization", () => {
       // Create a wrapper component for testing
       const { Component: TrackedHeader, getRenderCount } = createRenderTracker(ChatHeader);
 
-      // Create stable callback functions outside the component
-      const onOpenSidebar = () => {
-        /* no-op */
-      };
-      // const onNewChat = () => {
-      //   /* no-op */
-      // };
       const isStreaming = false;
 
       function TestWrapper() {
@@ -85,13 +78,7 @@ describe("Component Memoization", () => {
               Force Re-render
             </button>
             {/* Pass required props */}
-            <TrackedHeader
-              onOpenSidebar={onOpenSidebar}
-              // onNewChat={onNewChat}
-              promptProcessing={isStreaming}
-              title={""}
-              codeReady={false}
-            />
+            <TrackedHeader promptProcessing={isStreaming} title={""} codeReady={false} />
           </div>
         );
       }

--- a/vibes.diy/tests/app/toRecentVibes.test.ts
+++ b/vibes.diy/tests/app/toRecentVibes.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { toRecentVibes } from "~/vibes.diy/app/components/RecentVibes.js";
+
+function slugItem(userSlug: string, appSlugs: string[]) {
+  return { userId: `uid-${userSlug}`, userSlug, appSlugs };
+}
+
+describe("toRecentVibes", () => {
+  it("flattens grouped items into userSlug/appSlug pairs", () => {
+    const items = [slugItem("alice", ["todo", "notes"]), slugItem("bob", ["gallery"])];
+    expect(toRecentVibes(items, 20)).toEqual([
+      { userSlug: "alice", appSlug: "todo" },
+      { userSlug: "alice", appSlug: "notes" },
+      { userSlug: "bob", appSlug: "gallery" },
+    ]);
+  });
+
+  it("limits output to the requested count", () => {
+    const items = [slugItem("alice", ["a1", "a2", "a3", "a4", "a5"]), slugItem("bob", ["b1", "b2", "b3"])];
+    expect(toRecentVibes(items, 3)).toHaveLength(3);
+    expect(toRecentVibes(items, 3)).toEqual([
+      { userSlug: "alice", appSlug: "a1" },
+      { userSlug: "alice", appSlug: "a2" },
+      { userSlug: "alice", appSlug: "a3" },
+    ]);
+  });
+
+  it("skips items with empty appSlugs arrays", () => {
+    const items = [slugItem("alice", []), slugItem("bob", ["notes"])];
+    expect(toRecentVibes(items, 20)).toEqual([{ userSlug: "bob", appSlug: "notes" }]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(toRecentVibes([], 20)).toEqual([]);
+  });
+
+  it("returns empty array for limit=0", () => {
+    const items = [slugItem("alice", ["todo"])];
+    expect(toRecentVibes(items, 0)).toEqual([]);
+  });
+
+  it("preserves order from input", () => {
+    const items = [slugItem("first", ["app1"]), slugItem("second", ["app2"]), slugItem("third", ["app3"])];
+    const result = toRecentVibes(items, 20);
+    expect(result.map((r) => r.userSlug)).toEqual(["first", "second", "third"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Redesigned sidebar UI: flat nav rows, scrollable recents, pinned settings/auth
- Switched data source from `listApplicationChats` to `listUserSlugAppSlug`
- Extracted shared `PillPortal` component with `PILL_CLEARANCE` constant
- Fixed double-scroll and pinned bottom layout
- Removed dead `onOpenSidebar` prop chain
- Added `toRecentVibes` unit tests

Replaces #1324 with rebased, squashed commit on latest mabels.

## Test plan

- [ ] Preview deploy loads and sidebar opens/closes via pill toggle
- [ ] Recent vibes list shows same apps as /vibes/mine
- [ ] Bottom section (settings/auth) stays pinned while recents scroll
- [ ] `pnpm check` passes (build + lint + app tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)