### PR TITLE
feat: add OpenRouter verbosity for initial prompts

### DIFF
--- a/call-ai/v2/prompt-type.ts
+++ b/call-ai/v2/prompt-type.ts
@@ -30,6 +30,7 @@ export const LLMRequest = type({
   "frequency_penalty?": "number",
   "presence_penalty?": "number",
   "stop?": "string | string[]",
+  "verbosity?": "'low' | 'medium' | 'high' | 'max'",
 });
 
 export type LLMRequest = typeof LLMRequest.infer;

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -493,6 +493,8 @@ async function handlerLlmRequest({
   //   return Result.Err(withSystemPrompt);
   // }
   // console.log("Sending LLM request for promptId:", promptId);
+  // "Initial turn" means we only have the current user message in the conversation history.
+  const isInitialTurn = withSystemPrompt.messages.filter((m) => m.role === "user").length <= 1;
   const llmReq: LLMRequest & { headers: LLMHeaders } = {
     // ...vctx.params.llm.default,
     // model,
@@ -505,6 +507,7 @@ async function handlerLlmRequest({
     headers: vctx.params.llm.headers,
     logprobs: true,
     stream: true,
+    ...(isInitialTurn ? { verbosity: "low" as const } : {}),
   };
 
   // add system prompt here


### PR DESCRIPTION
## Summary

- Add `verbosity` field to `LLMRequest` type so it survives `onDeepUndeclaredKey(\"delete\")` stripping
- Set `verbosity: \"low\"` for the initial turn (<= 1 user message in conversation history) to reduce reasoning overhead
- Follow-up turns omit the field, using the provider default effort

Closes #1320

## Test plan
- [x] `pnpm check` passes (build + lint + tests; 3 pre-existing API timeout failures unrelated)
- [ ] Verify `verbosity` appears in outgoing request body for initial prompts
- [ ] Confirm initial code gen responses are faster
- [ ] Confirm follow-up iteration quality is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)