### PR TITLE
fix: look up fsId for CLI-pushed apps on chat load

### DIFF
--- a/vibes.diy/pkg/app/components/ResultPreview/ResultPreview.tsx
+++ b/vibes.diy/pkg/app/components/ResultPreview/ResultPreview.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, lazy } from "react";
+import { useParams } from "react-router";
 import { animationStyles } from "./ResultPreviewTemplates.js";
 import type { ResultPreviewProps } from "../../types/ResultPreviewTypes.js";
 import ClientOnly from "../ClientOnly.js";
@@ -72,7 +73,8 @@ function CodeEditorWrapper({
 // });
 
 function ResultPreview({ promptState, currentView, children, onCode }: ResultPreviewProps & { children?: React.ReactNode }) {
-  const showWelcome = !promptState.running && !promptState.hasCode;
+  const { fsId } = useParams<{ fsId?: string }>();
+  const showWelcome = !fsId && !promptState.running && !promptState.hasCode;
 
   const codeEditor = <CodeEditorWrapper promptState={promptState} onCode={onCode} currentView={currentView} />;
   let previewArea: React.ReactNode;

--- a/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
+++ b/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
@@ -173,6 +173,7 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
 
   useEffect(() => {
     if (inConstruction) return;
+    let cancelled = false;
     if (openingRef.current) {
       if (chat && promptToSend?.trim().length) {
         const newSearch = new URLSearchParams(searchParams);
@@ -207,14 +208,14 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
       return; // Already opened or opening
     }
     openingRef.current = true;
+    const basePath = `/chat/${userSlug}/${appSlug}`;
     vibeDiyApi.openChat({ userSlug, appSlug, mode: "chat" }).then((rChat) => {
+      if (cancelled) return;
       if (rChat.isErr()) {
         console.error("CHAT-Error", rChat.Err(), userSlug, appSlug);
         return;
       }
-      // console.log("Chat", rChat.Ok());
       setChat(rChat.Ok());
-      // console.log(`dispatch-initChat`, rChat.Ok())
       dispatch({ type: "initChat", chat: rChat.Ok() });
       void processStream(rChat.Ok().sectionStream, (msg) => {
         const se = sectionEvent(msg);
@@ -223,12 +224,24 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
           return;
         }
         for (const block of se.blocks) {
-          // console.log("recv-block", block)
           dispatch(block);
         }
       });
+      // For CLI-pushed apps with no chat history, look up the latest fsId
+      if (!fsId) {
+        void vibeDiyApi.getAppByFsId({ appSlug, userSlug }).then((rApp) => {
+          if (cancelled) return;
+          if (rApp.isErr() || !rApp.Ok().fsId) return;
+          // Only navigate if we're still on the fsId-less route
+          if (window.location.pathname !== basePath) return;
+          const sp = new URLSearchParams(searchParams);
+          if (!sp.has("view")) sp.set("view", "preview");
+          navigate({ pathname: `${basePath}/${rApp.Ok().fsId}`, search: sp.toString() }, { replace: true });
+        });
+      }
     });
     return () => {
+      cancelled = true;
       if (chat) {
         (chat as LLMChat).close();
       }


### PR DESCRIPTION
## Summary

- CLI-pushed apps appear in sidebar but clicking them shows an empty chat with no preview
- Root cause: no chat history exists, so the replay path never provides `fsId` for the preview URL
- Fix: after `openChat` succeeds with no `fsId` in URL, call `getAppByFsId({ appSlug, userSlug })` to fetch the latest and navigate to include it

Frontend-only change, no backend modifications.

## Test plan

- [ ] Push an app via CLI, click it in sidebar → should show preview
- [ ] Web-created apps still work (replay provides fsId before lookup completes)
- [ ] New blank chats gracefully show empty state


🤖 Generated with [Claude Code](https://claude.com/claude-code)