### PR TITLE
fix: graceful WebSocket reconnection on stale connections (v2)

### DIFF
--- a/vibes.diy/api/impl/api-connection.ts
+++ b/vibes.diy/api/impl/api-connection.ts
@@ -1,4 +1,4 @@
-import { ReturnOnFunc } from "@adviser/cement";
+import { Result, ReturnOnFunc } from "@adviser/cement";
 import { W3CWebSocketErrorEvent, W3CWebSocketMessageEvent, W3CWebSocketCloseEvent } from "@vibes.diy/api-types";
 
 export interface VibeDiyApiConnection {
@@ -6,6 +6,6 @@ export interface VibeDiyApiConnection {
   onError: ReturnOnFunc<[W3CWebSocketErrorEvent]>;
   onMessage: ReturnOnFunc<[W3CWebSocketMessageEvent]>;
   onClose: ReturnOnFunc<[W3CWebSocketCloseEvent]>;
-  send(data: Uint8Array<ArrayBuffer>): void;
+  send(data: Uint8Array<ArrayBuffer>): Result<void>;
   close(): Promise<void>;
 }

--- a/vibes.diy/api/impl/index.ts
+++ b/vibes.diy/api/impl/index.ts
@@ -248,7 +248,15 @@ export class VibesDiyApi implements VibesDiyApiIface<{
     const ende = JSONEnDecoderSingleton();
     const uint8ify = ende.uint8ify(msgBox);
     // console.log("Encoded message to Uint8Array:", msgParam.tid, uint8ify.length, conn.send.toString());
-    conn.send(uint8ify);
+    const rSend = conn.send(uint8ify);
+    if (rSend.isErr()) {
+      return Result.Err<MsgBox<WithAuth<T>>, VibesDiyError>({
+        type: "vibes.diy.error",
+        name: "VibesDiyError",
+        message: `Reconnecting, please retry (${String(rSend.Err())})`,
+        code: "websocket-send-failed",
+      });
+    }
     return Result.Ok(msgBox as MsgBox<WithAuth<T>>);
   }
 

--- a/vibes.diy/api/impl/websocket-connection.ts
+++ b/vibes.diy/api/impl/websocket-connection.ts
@@ -19,38 +19,55 @@ export function getVibesDiyWebSocketConnection(url: string, presetWs?: WebSocket
   const wsSocketUrl = BuildURI.from(url)
     .protocol(["https", "wss"].find((i) => URI.from(url).protocol.startsWith(i)) ? "wss:" : "ws:")
     .toString();
-  return vibesDiyApiPerConnection.get(wsSocketUrl).once(async ({ ctx }) => {
+  const slot = vibesDiyApiPerConnection.get(wsSocketUrl);
+  return slot.once(async ({ ctx }) => {
     const url = ctx.givenKey;
     const ws = presetWs ?? (await createWebSocket(wsSocketUrl, ca));
     const waitOpen = new Future<WebSocket>();
     const onError = OnFunc<(event: W3CWebSocketErrorEvent) => void>();
     const onMessage = OnFunc<(event: W3CWebSocketMessageEvent) => void>();
     const onClose = OnFunc<(event: W3CWebSocketCloseEvent) => void>();
-    // const ende = JSONEnDecoderSingleton();
 
     const nativeClose = ws.close?.bind(ws);
+    let opened = false;
+
+    // Only evict if this socket's slot is still the one cached for this URL.
+    // After delete + re-get, a new slot is created, so stale onclose can't evict it.
+    const evictIfCurrent = () => {
+      if (vibesDiyApiPerConnection.has(url) && vibesDiyApiPerConnection.get(url) === slot) {
+        vibesDiyApiPerConnection.delete(url);
+      }
+    };
+
+    const fail = (msg: string): Result<void> => {
+      evictIfCurrent();
+      nativeClose?.();
+      return Result.Err(msg);
+    };
 
     ws.onopen = () => {
+      opened = true;
       waitOpen.resolve(ws);
     };
     ws.onerror = (event) => {
       onError.invoke({ type: "ErrorEvent", event: event as W3CWebSocketErrorEvent["event"] });
-      vibesDiyApiPerConnection.delete(url);
-      waitOpen.reject(new Error(`WebSocket error: ${event}`));
+      evictIfCurrent();
+      if (!opened) {
+        waitOpen.reject(new Error(`WebSocket error: ${event}`));
+      }
     };
     ws.onclose = (event) => {
-      // Only evict if this socket still owns the cache entry
-      const cached = vibesDiyApiPerConnection.get(url);
-      if (cached) {
-        vibesDiyApiPerConnection.delete(url);
-      }
+      evictIfCurrent();
       onClose.invoke({ type: "CloseEvent", event: { wasClean: event.wasClean, code: event.code, reason: event.reason } });
-      waitOpen.reject(new Error(`WebSocket closed: code=${event.code} reason=${event.reason}`));
+      if (!opened) {
+        waitOpen.reject(new Error(`WebSocket closed before open: code=${event.code} reason=${event.reason}`));
+      }
     };
     ws.onmessage = (event) => {
       onMessage.invoke({ type: "MessageEvent", event });
     };
     if (ws.readyState === WebSocket.OPEN) {
+      opened = true;
       waitOpen.resolve(ws);
     }
     return waitOpen.asPromise().then((ws) => ({
@@ -59,19 +76,17 @@ export function getVibesDiyWebSocketConnection(url: string, presetWs?: WebSocket
       onMessage,
       onClose,
       close: () => {
-        vibesDiyApiPerConnection.delete(url);
+        evictIfCurrent();
         nativeClose?.();
         return Promise.resolve();
       },
       send: (data: Uint8Array<ArrayBuffer>): Result<void> => {
         if (ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
-          vibesDiyApiPerConnection.delete(url);
-          return Result.Err(`WebSocket is not open (readyState=${ws.readyState})`);
+          return fail(`WebSocket is not open (readyState=${ws.readyState})`);
         }
         const rSend = exception2Result(() => ws.send(data));
         if (rSend.isErr()) {
-          vibesDiyApiPerConnection.delete(url);
-          return Result.Err(`WebSocket send failed: ${String(rSend.Err())}`);
+          return fail(`WebSocket send failed: ${String(rSend.Err())}`);
         }
         return Result.Ok(undefined);
       },

--- a/vibes.diy/api/impl/websocket-connection.ts
+++ b/vibes.diy/api/impl/websocket-connection.ts
@@ -1,4 +1,4 @@
-import { BuildURI, Future, KeyedResolvOnce, OnFunc, runtimeFn, URI } from "@adviser/cement";
+import { BuildURI, exception2Result, Future, KeyedResolvOnce, OnFunc, Result, runtimeFn, URI } from "@adviser/cement";
 import { VibeDiyApiConnection } from "./api-connection.js";
 import { W3CWebSocketErrorEvent, W3CWebSocketMessageEvent, W3CWebSocketCloseEvent } from "@vibes.diy/api-types";
 
@@ -28,16 +28,24 @@ export function getVibesDiyWebSocketConnection(url: string, presetWs?: WebSocket
     const onClose = OnFunc<(event: W3CWebSocketCloseEvent) => void>();
     // const ende = JSONEnDecoderSingleton();
 
+    const nativeClose = ws.close?.bind(ws);
+
     ws.onopen = () => {
       waitOpen.resolve(ws);
     };
     ws.onerror = (event) => {
       onError.invoke({ type: "ErrorEvent", event: event as W3CWebSocketErrorEvent["event"] });
+      vibesDiyApiPerConnection.delete(url);
       waitOpen.reject(new Error(`WebSocket error: ${event}`));
     };
-    ws.close = (code, reason) => {
-      onClose.invoke({ type: "CloseEvent", event: { wasClean: true, code: code ?? 1000, reason: reason ?? "Closed by client" } });
-      vibesDiyApiPerConnection.delete(url);
+    ws.onclose = (event) => {
+      // Only evict if this socket still owns the cache entry
+      const cached = vibesDiyApiPerConnection.get(url);
+      if (cached) {
+        vibesDiyApiPerConnection.delete(url);
+      }
+      onClose.invoke({ type: "CloseEvent", event: { wasClean: event.wasClean, code: event.code, reason: event.reason } });
+      waitOpen.reject(new Error(`WebSocket closed: code=${event.code} reason=${event.reason}`));
     };
     ws.onmessage = (event) => {
       onMessage.invoke({ type: "MessageEvent", event });
@@ -51,12 +59,21 @@ export function getVibesDiyWebSocketConnection(url: string, presetWs?: WebSocket
       onMessage,
       onClose,
       close: () => {
-        ws.close();
-        // console.log('ws-close', x)
+        vibesDiyApiPerConnection.delete(url);
+        nativeClose?.();
         return Promise.resolve();
       },
-      send: (data: Uint8Array<ArrayBuffer>) => {
-        ws.send(data);
+      send: (data: Uint8Array<ArrayBuffer>): Result<void> => {
+        if (ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+          vibesDiyApiPerConnection.delete(url);
+          return Result.Err(`WebSocket is not open (readyState=${ws.readyState})`);
+        }
+        const rSend = exception2Result(() => ws.send(data));
+        if (rSend.isErr()) {
+          vibesDiyApiPerConnection.delete(url);
+          return Result.Err(`WebSocket send failed: ${String(rSend.Err())}`);
+        }
+        return Result.Ok(undefined);
       },
     }));
   });

--- a/vibes.diy/api/tests/ws-reconnect.test.ts
+++ b/vibes.diy/api/tests/ws-reconnect.test.ts
@@ -1,0 +1,140 @@
+import { VibesDiyApi } from "@vibes.diy/api-impl";
+import { assert, beforeAll, describe, expect, inject, it } from "vitest";
+import { Result, TestFetchPair, TestWSPair } from "@adviser/cement";
+import { ensureSuperThis } from "@fireproof/core-runtime";
+import { createTestDeviceCA, createTestUser } from "@fireproof/core-device-id";
+import { cfServe, CFInject, noopCache, vibesMsgEvento, WSSendProvider } from "@vibes.diy/api-svc";
+import { Request as CFRequest, ExecutionContext } from "@cloudflare/workers-types";
+import { isResEnsureAppSlugOk } from "@vibes.diy/api-types";
+import { createVibeDiyTestCtx } from "./vibe-diy-test-ctx.js";
+import { createIsolatedDB } from "./globalSetup.libsql.js";
+
+describe("WebSocket disconnection", { timeout: (inject("DB_FLAVOUR" as never) as string) === "pg" ? 30000 : 5000 }, () => {
+  const sthis = ensureSuperThis();
+
+  let api: VibesDiyApi;
+  let wsPair: ReturnType<typeof TestWSPair.create>;
+  let appCtx: Awaited<ReturnType<typeof createVibeDiyTestCtx>>;
+
+  beforeAll(async () => {
+    const deviceCA = await createTestDeviceCA(sthis);
+    const isolatedDbUrl = await createIsolatedDB(import.meta.dirname, "ws-reconnect");
+    appCtx = await createVibeDiyTestCtx(sthis, deviceCA, isolatedDbUrl);
+    const testUser = await createTestUser({ sthis, deviceCA });
+
+    const fetchPair = TestFetchPair.create();
+    wsPair = TestWSPair.create();
+
+    fetchPair.server.onServe(async (req: Request) => {
+      return cfServe(
+        req as unknown as CFRequest,
+        {
+          appCtx: appCtx.appCtx,
+          cache: noopCache,
+          drizzle: appCtx.vibesCtx.sql.db,
+          webSocket: {
+            connections: new Set(),
+            webSocketPair: () => ({
+              client: wsPair.p1,
+              server: wsPair.p2,
+            }),
+          },
+        } as unknown as ExecutionContext & CFInject
+      ) as unknown as Promise<Response>;
+    });
+
+    const wsEvento = vibesMsgEvento();
+    const wsSendProvider = new WSSendProvider(wsPair.p2 as unknown as WebSocket);
+    appCtx.vibesCtx.connections.add(wsSendProvider);
+
+    wsPair.p2.onmessage = (event: MessageEvent) => {
+      wsEvento.trigger({ ctx: appCtx.appCtx, request: { type: "MessageEvent", event }, send: wsSendProvider });
+    };
+
+    api = new VibesDiyApi({
+      apiUrl: "http://localhost:9999/api",
+      ws: wsPair.p1 as unknown as WebSocket,
+      fetch: fetchPair.client.fetch,
+      timeoutMs: 2000,
+      getToken: async () => {
+        return Result.Ok(await testUser.getDashBoardToken());
+      },
+    });
+  });
+
+  it("successful request before disconnect", async () => {
+    const rRes = await api.ensureAppSlug({
+      mode: "dev",
+      fileSystem: [
+        {
+          type: "code-block",
+          lang: "jsx",
+          filename: "/App.jsx",
+          content: "function App() { return <div>Hello</div>; }",
+        },
+      ],
+    });
+    if (rRes.isErr()) {
+      assert.fail("Expected ensureAppSlug to succeed, got: " + JSON.stringify(rRes.Err()));
+    }
+    const res = rRes.Ok();
+    if (!isResEnsureAppSlugOk(res)) {
+      assert.fail("Expected ensureAppSlug to return ResEnsureAppSlugOk");
+    }
+    expect(res.appSlug).toBeTruthy();
+  });
+
+  it("send on dead WebSocket returns websocket-send-failed error", async () => {
+    // Simulate the WebSocket dying (e.g. network disconnect, backgrounded tab)
+    const ws = wsPair.p1 as unknown as WebSocket;
+    Object.defineProperty(ws, "readyState", { value: 3 /* WebSocket.CLOSED */, writable: true, configurable: true });
+
+    const rRes = await api.ensureAppSlug({
+      mode: "dev",
+      fileSystem: [
+        {
+          type: "code-block",
+          lang: "jsx",
+          filename: "/App.jsx",
+          content: "function App() { return <div>Dead</div>; }",
+        },
+      ],
+    });
+
+    // Should get a clean Result.Err with websocket-send-failed, not a thrown exception
+    expect(rRes.isErr()).toBe(true);
+    const err = rRes.Err();
+    expect(err).toMatchObject({
+      code: "websocket-send-failed",
+      message: expect.stringContaining("Reconnecting, please retry"),
+    });
+  });
+
+  it("reconnects after dead WebSocket when readyState recovers", async () => {
+    // Reset readyState to OPEN so the mock can send again
+    const ws = wsPair.p1 as unknown as WebSocket;
+    Object.defineProperty(ws, "readyState", { value: 1 /* WebSocket.OPEN */, writable: true, configurable: true });
+
+    // The previous test cleared the connection cache, so this should create a fresh connection
+    const rRes = await api.ensureAppSlug({
+      mode: "dev",
+      fileSystem: [
+        {
+          type: "code-block",
+          lang: "jsx",
+          filename: "/App.jsx",
+          content: "function App() { return <div>Recovered</div>; }",
+        },
+      ],
+    });
+
+    if (rRes.isErr()) {
+      assert.fail("Expected ensureAppSlug to succeed after reconnect, got: " + JSON.stringify(rRes.Err()));
+    }
+    const res = rRes.Ok();
+    if (!isResEnsureAppSlugOk(res)) {
+      assert.fail("Expected ensureAppSlug to return ResEnsureAppSlugOk after reconnect");
+    }
+    expect(res.appSlug).toBeTruthy();
+  });
+});

--- a/vibes.diy/api/tests/ws-reconnect.test.ts
+++ b/vibes.diy/api/tests/ws-reconnect.test.ts
@@ -1,4 +1,4 @@
-import { VibesDiyApi } from "@vibes.diy/api-impl";
+import { VibesDiyApi, VibesDiyApiParam } from "@vibes.diy/api-impl";
 import { assert, beforeAll, describe, expect, inject, it } from "vitest";
 import { Result, TestFetchPair, TestWSPair } from "@adviser/cement";
 import { ensureSuperThis } from "@fireproof/core-runtime";
@@ -9,20 +9,33 @@ import { isResEnsureAppSlugOk } from "@vibes.diy/api-types";
 import { createVibeDiyTestCtx } from "./vibe-diy-test-ctx.js";
 import { createIsolatedDB } from "./globalSetup.libsql.js";
 
+function wireUpWsPair(wsPair: ReturnType<typeof TestWSPair.create>, appCtx: Awaited<ReturnType<typeof createVibeDiyTestCtx>>) {
+  const wsEvento = vibesMsgEvento();
+  const wsSendProvider = new WSSendProvider(wsPair.p2 as unknown as WebSocket);
+  appCtx.vibesCtx.connections.add(wsSendProvider);
+  wsPair.p2.onmessage = (event: MessageEvent) => {
+    wsEvento.trigger({ ctx: appCtx.appCtx, request: { type: "MessageEvent", event }, send: wsSendProvider });
+  };
+  return wsSendProvider;
+}
+
 describe("WebSocket disconnection", { timeout: (inject("DB_FLAVOUR" as never) as string) === "pg" ? 30000 : 5000 }, () => {
   const sthis = ensureSuperThis();
 
   let api: VibesDiyApi;
   let wsPair: ReturnType<typeof TestWSPair.create>;
   let appCtx: Awaited<ReturnType<typeof createVibeDiyTestCtx>>;
+  let fetchPair: ReturnType<typeof TestFetchPair.create>;
+  let getToken: VibesDiyApiParam["getToken"];
 
   beforeAll(async () => {
     const deviceCA = await createTestDeviceCA(sthis);
     const isolatedDbUrl = await createIsolatedDB(import.meta.dirname, "ws-reconnect");
     appCtx = await createVibeDiyTestCtx(sthis, deviceCA, isolatedDbUrl);
     const testUser = await createTestUser({ sthis, deviceCA });
+    getToken = async () => Result.Ok(await testUser.getDashBoardToken());
 
-    const fetchPair = TestFetchPair.create();
+    fetchPair = TestFetchPair.create();
     wsPair = TestWSPair.create();
 
     fetchPair.server.onServe(async (req: Request) => {
@@ -43,22 +56,14 @@ describe("WebSocket disconnection", { timeout: (inject("DB_FLAVOUR" as never) as
       ) as unknown as Promise<Response>;
     });
 
-    const wsEvento = vibesMsgEvento();
-    const wsSendProvider = new WSSendProvider(wsPair.p2 as unknown as WebSocket);
-    appCtx.vibesCtx.connections.add(wsSendProvider);
-
-    wsPair.p2.onmessage = (event: MessageEvent) => {
-      wsEvento.trigger({ ctx: appCtx.appCtx, request: { type: "MessageEvent", event }, send: wsSendProvider });
-    };
+    wireUpWsPair(wsPair, appCtx);
 
     api = new VibesDiyApi({
       apiUrl: "http://localhost:9999/api",
       ws: wsPair.p1 as unknown as WebSocket,
       fetch: fetchPair.client.fetch,
       timeoutMs: 2000,
-      getToken: async () => {
-        return Result.Ok(await testUser.getDashBoardToken());
-      },
+      getToken,
     });
   });
 
@@ -110,20 +115,29 @@ describe("WebSocket disconnection", { timeout: (inject("DB_FLAVOUR" as never) as
     });
   });
 
-  it("reconnects after dead WebSocket when readyState recovers", async () => {
-    // Reset readyState to OPEN so the mock can send again
-    const ws = wsPair.p1 as unknown as WebSocket;
-    Object.defineProperty(ws, "readyState", { value: 1 /* WebSocket.OPEN */, writable: true, configurable: true });
+  it("reconnects with a fresh WebSocket after cache eviction", async () => {
+    // Previous test evicted the connection cache via send failure.
+    // Create a completely new WS pair + API instance on the same URL
+    // to prove the cached dead connection was removed.
+    const freshWsPair = TestWSPair.create();
+    wireUpWsPair(freshWsPair, appCtx);
 
-    // The previous test cleared the connection cache, so this should create a fresh connection
-    const rRes = await api.ensureAppSlug({
+    const freshApi = new VibesDiyApi({
+      apiUrl: "http://localhost:9999/api",
+      ws: freshWsPair.p1 as unknown as WebSocket,
+      fetch: fetchPair.client.fetch,
+      timeoutMs: 2000,
+      getToken,
+    });
+
+    const rRes = await freshApi.ensureAppSlug({
       mode: "dev",
       fileSystem: [
         {
           type: "code-block",
           lang: "jsx",
           filename: "/App.jsx",
-          content: "function App() { return <div>Recovered</div>; }",
+          content: "function App() { return <div>Reconnected</div>; }",
         },
       ],
     });


### PR DESCRIPTION
## Summary
- Replaces #1329 with all review feedback addressed (two rounds)
- `send()` rejects CLOSING/CLOSED with `Result.Err`, wraps `ws.send` in `exception2Result` to catch runtime throws
- `close()` evicts cache proactively before calling nativeClose
- `onclose`/`onerror` use slot-based ownership guard to prevent stale sockets from evicting newer connections
- `waitOpen` only rejected if socket never reached OPEN state
- Failed sends close the underlying socket to prevent lingering duplicates
- Error detail from `send()` propagated into `VibesDiyError` message
- Reconnect test uses a fresh `TestWSPair` + `VibesDiyApi` to prove real reconnection

## Feedback requested

### 1. Slot identity as ownership guard
```ts
const slot = vibesDiyApiPerConnection.get(wsSocketUrl);
return slot.once(async ({ ctx }) => {
  const evictIfCurrent = () => {
    if (vibesDiyApiPerConnection.has(url) && vibesDiyApiPerConnection.get(url) === slot) {
      vibesDiyApiPerConnection.delete(url);
    }
  };
```
This relies on `KeyedResolvOnce.get()` returning a **new** `ResolveOnce` instance after `delete()` + `get()`, so the old slot's `===` check fails. Is this the right cement pattern, or is there a more idiomatic approach?

### 2. CLOSING/CLOSED vs OPEN-only check in send()
We check `readyState === CLOSING || CLOSED` rather than `!== OPEN` because `TestWSPair` mocks don't set `readyState` (it's `undefined`). An OPEN-only check would break all existing tests. Is adding `readyState` to `TestWSPair` the right path, or is the CLOSING/CLOSED check sufficient for production?

### 3. nativeClose in fail() path
When `send()` fails, we call `nativeClose?.()` to clean up the socket. This could trigger `onclose` which also calls `evictIfCurrent()` — the guard prevents double-eviction, but is there a timing concern with the `onclose` callback firing during `send()` return?

## Test plan
- [x] `ws-reconnect.test.ts`: request succeeds, dead socket returns `websocket-send-failed` error with specific code, fresh WS pair reconnects
- [x] All 62 API tests pass
- [x] Full `pnpm check` passes (589 tests)

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)