### PR TITLE
fix: stable db-name: restore assistant messages in conversation history

### DIFF
--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -380,7 +380,7 @@ export async function makeBaseSystemPrompt(
     "- Always output the full component code, keep the explanation short and concise",
     "- Never also output a small snippet to change, just the full component code",
     "- Keep your component file as short as possible for fast updates",
-    "- Keep the database name stable as you edit the code",
+    "- IMPORTANT: Never change the database name from what it was in the previous code. Changing the database name loses all existing user data. If the previous code used a specific database name, you MUST use that exact same name.",
     "- The system can send you crash reports, fix them by simplifying the affected code",
     "- List data items on the main page of your app so users don't have to hunt for them",
     "- If you save data, make sure it is browsable in the app, eg lists should be clickable for more details",

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -57,6 +57,7 @@ import {
   isCodeBegin,
   isCodeEnd,
   isCodeLine,
+  isToplevelLine,
   LLMRequest,
   ChatMessage,
   CodeMsg,
@@ -288,6 +289,44 @@ export async function handlePromptContext({
   return Result.Ok({ blockSeq, fsRef });
 }
 
+/**
+ * Reconstruct conversation messages (user + assistant) from stored section blocks.
+ * Assistant responses are rebuilt from ToplevelLine and Code block messages.
+ */
+export function reconstructConversationMessages(sectionMsgs: PromptAndBlockMsgs[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  const assistantLines: string[] = [];
+  for (const msg of sectionMsgs) {
+    if (isPromptReq(msg)) {
+      // Flush any accumulated assistant content before the next user message
+      if (assistantLines.length > 0) {
+        messages.push({
+          role: "assistant",
+          content: [{ type: "text", text: assistantLines.join("\n") }],
+        });
+        assistantLines.length = 0;
+      }
+      messages.push(...msg.request.messages.filter((m) => m.role === "user"));
+    } else if (isToplevelLine(msg)) {
+      assistantLines.push(msg.line);
+    } else if (isCodeBegin(msg)) {
+      assistantLines.push("```" + msg.lang);
+    } else if (isCodeLine(msg)) {
+      assistantLines.push(msg.line);
+    } else if (isCodeEnd(msg)) {
+      assistantLines.push("```");
+    }
+  }
+  // Flush any remaining assistant content
+  if (assistantLines.length > 0) {
+    messages.push({
+      role: "assistant",
+      content: [{ type: "text", text: assistantLines.join("\n") }],
+    });
+  }
+  return messages;
+}
+
 async function injectSystemPrompt(
   vctx: VibesApiSQLCtx,
   chatId: string,
@@ -303,17 +342,13 @@ async function injectSystemPrompt(
     .from(vctx.sql.tables.chatSections)
     .where(eq(vctx.sql.tables.chatSections.chatId, chatId))
     .orderBy(vctx.sql.tables.chatSections.created);
-  const userMessages: ChatMessage[] = [];
+  const conversationMessages: ChatMessage[] = [];
   for (const rowSection of sections) {
     const { filtered: sectionMsgs, warning: sectionWarning } = parseArrayWarning(rowSection.blocks, PromptAndBlockMsgs);
     if (sectionWarning.length > 0) {
       ensureLogger(vctx.sthis, "buildUserMessages").Warn().Any({ parseErrors: sectionWarning }).Msg("skip");
     }
-    for (const msg of sectionMsgs) {
-      if (isPromptReq(msg)) {
-        userMessages.push(...msg.request.messages.filter((m) => m.role === "user"));
-      }
-    }
+    conversationMessages.push(...reconstructConversationMessages(sectionMsgs));
   }
   const systemPrompt = await exception2Result(async () =>
     makeBaseSystemPrompt(await resolveEffectiveModel({ model }, {}), {
@@ -354,14 +389,14 @@ async function injectSystemPrompt(
     console.error("Failed to create system prompt:", systemPrompt.Err());
     return Result.Err(systemPrompt);
   }
-  if (userMessages.length === 0) {
+  if (conversationMessages.length === 0) {
     return Result.Err(`No user messages found in the prompt`);
   }
 
   return Result.Ok({
     model,
     messages: [
-      ...userMessages,
+      ...conversationMessages,
       {
         role: "system",
         content: [

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -296,16 +296,20 @@ export async function handlePromptContext({
 export function reconstructConversationMessages(sectionMsgs: PromptAndBlockMsgs[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
   const assistantLines: string[] = [];
+  const flushAssistant = () => {
+    if (assistantLines.length === 0) return;
+    messages.push({
+      role: "assistant",
+      content: [{ type: "text", text: assistantLines.join("\n") }],
+    });
+    assistantLines.length = 0;
+  };
   for (const msg of sectionMsgs) {
     if (isPromptReq(msg)) {
-      // Flush any accumulated assistant content before the next user message
-      if (assistantLines.length > 0) {
-        messages.push({
-          role: "assistant",
-          content: [{ type: "text", text: assistantLines.join("\n") }],
-        });
-        assistantLines.length = 0;
-      }
+      flushAssistant();
+      // Invariant: each stored prompt.req carries only the newest user turn
+      // (see handlePromptContext); full history is rebuilt across sections
+      // rather than duplicated per request.
       messages.push(...msg.request.messages.filter((m) => m.role === "user"));
     } else if (isToplevelLine(msg)) {
       assistantLines.push(msg.line);
@@ -317,13 +321,7 @@ export function reconstructConversationMessages(sectionMsgs: PromptAndBlockMsgs[
       assistantLines.push("```");
     }
   }
-  // Flush any remaining assistant content
-  if (assistantLines.length > 0) {
-    messages.push({
-      role: "assistant",
-      content: [{ type: "text", text: assistantLines.join("\n") }],
-    });
-  }
+  flushAssistant();
   return messages;
 }
 
@@ -342,14 +340,18 @@ async function injectSystemPrompt(
     .from(vctx.sql.tables.chatSections)
     .where(eq(vctx.sql.tables.chatSections.chatId, chatId))
     .orderBy(vctx.sql.tables.chatSections.created);
-  const conversationMessages: ChatMessage[] = [];
+  // A single assistant turn can span multiple chatSections rows (blockChunks
+  // boundary), so concat every section's parsed messages and reconstruct once —
+  // reconstructing per-row would flush mid-turn and fragment the assistant message.
+  const allSectionMsgs: PromptAndBlockMsgs[] = [];
   for (const rowSection of sections) {
     const { filtered: sectionMsgs, warning: sectionWarning } = parseArrayWarning(rowSection.blocks, PromptAndBlockMsgs);
     if (sectionWarning.length > 0) {
       ensureLogger(vctx.sthis, "buildUserMessages").Warn().Any({ parseErrors: sectionWarning }).Msg("skip");
     }
-    conversationMessages.push(...reconstructConversationMessages(sectionMsgs));
+    allSectionMsgs.push(...sectionMsgs);
   }
+  const conversationMessages = reconstructConversationMessages(allSectionMsgs);
   const systemPrompt = await exception2Result(async () =>
     makeBaseSystemPrompt(await resolveEffectiveModel({ model }, {}), {
       dependenciesUserOverride: true,
@@ -389,14 +391,13 @@ async function injectSystemPrompt(
     console.error("Failed to create system prompt:", systemPrompt.Err());
     return Result.Err(systemPrompt);
   }
-  if (conversationMessages.length === 0) {
+  if (!conversationMessages.some((m) => m.role === "user")) {
     return Result.Err(`No user messages found in the prompt`);
   }
 
   return Result.Ok({
     model,
     messages: [
-      ...conversationMessages,
       {
         role: "system",
         content: [
@@ -406,6 +407,7 @@ async function injectSystemPrompt(
           },
         ],
       },
+      ...conversationMessages,
     ],
   });
 }

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -296,29 +296,35 @@ export async function handlePromptContext({
 export function reconstructConversationMessages(sectionMsgs: PromptAndBlockMsgs[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
   const assistantLines: string[] = [];
-  const flushAssistant = () => {
+  function flushAssistant() {
     if (assistantLines.length === 0) return;
     messages.push({
       role: "assistant",
       content: [{ type: "text", text: assistantLines.join("\n") }],
     });
     assistantLines.length = 0;
-  };
+  }
   for (const msg of sectionMsgs) {
-    if (isPromptReq(msg)) {
-      flushAssistant();
-      // Invariant: each stored prompt.req carries only the newest user turn
-      // (see handlePromptContext); full history is rebuilt across sections
-      // rather than duplicated per request.
-      messages.push(...msg.request.messages.filter((m) => m.role === "user"));
-    } else if (isToplevelLine(msg)) {
-      assistantLines.push(msg.line);
-    } else if (isCodeBegin(msg)) {
-      assistantLines.push("```" + msg.lang);
-    } else if (isCodeLine(msg)) {
-      assistantLines.push(msg.line);
-    } else if (isCodeEnd(msg)) {
-      assistantLines.push("```");
+    switch (true) {
+      case isPromptReq(msg):
+        flushAssistant();
+        // Invariant: each stored prompt.req carries only the newest user turn
+        // (see handlePromptContext); full history is rebuilt across sections
+        // rather than duplicated per request.
+        messages.push(...msg.request.messages.filter((m) => m.role === "user"));
+        break;
+      case isToplevelLine(msg):
+        assistantLines.push(msg.line);
+        break;
+      case isCodeBegin(msg):
+        assistantLines.push("```" + msg.lang);
+        break;
+      case isCodeLine(msg):
+        assistantLines.push(msg.line);
+        break;
+      case isCodeEnd(msg):
+        assistantLines.push("```");
+        break;
     }
   }
   flushAssistant();

--- a/vibes.diy/api/tests/reconstruct-messages.test.ts
+++ b/vibes.diy/api/tests/reconstruct-messages.test.ts
@@ -127,4 +127,37 @@ describe("reconstructConversationMessages", () => {
   it("handles empty input", () => {
     expect(reconstructConversationMessages([])).toEqual([]);
   });
+
+  it("keeps one assistant turn when messages span a section boundary", () => {
+    // Simulates handlePromptContext splitting a single assistant response across
+    // two chatSections rows at the blockChunks boundary. injectSystemPrompt now
+    // concats both sections' messages before calling reconstruct, so the code
+    // block must stay paired into a single assistant message.
+    const section1: PromptAndBlockMsgs[] = [
+      makePromptReq("long request", 0),
+      makeToplevelLine("Working on it:", 1),
+      makeCodeBegin("jsx", 2),
+      makeCodeLine("line-a", "jsx", 3),
+    ];
+    const section2: PromptAndBlockMsgs[] = [
+      makeCodeLine("line-b", "jsx", 4),
+      makeCodeEnd("jsx", 5),
+      makeToplevelLine("Done.", 6),
+    ];
+    const result = reconstructConversationMessages([...section1, ...section2]);
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("assistant");
+    const text = result[1].content[0].text;
+    expect(text).toBe("Working on it:\n```jsx\nline-a\nline-b\n```\nDone.");
+    const fenceCount = (text.match(/```/g) ?? []).length;
+    expect(fenceCount).toBe(2);
+  });
+
+  it("produces no user message when input contains only assistant blocks", () => {
+    // Backs the injectSystemPrompt guard that rejects histories with no user turn.
+    const msgs = [makeToplevelLine("orphan assistant line", 0)];
+    const result = reconstructConversationMessages(msgs);
+    expect(result.some((m) => m.role === "user")).toBe(false);
+  });
 });

--- a/vibes.diy/api/tests/reconstruct-messages.test.ts
+++ b/vibes.diy/api/tests/reconstruct-messages.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { reconstructConversationMessages } from "@vibes.diy/api-svc";
+import type { PromptAndBlockMsgs } from "@vibes.diy/api-types";
+
+const base = {
+  blockId: "b1",
+  streamId: "s1",
+  blockNr: 0,
+  timestamp: new Date(),
+};
+
+function makePromptReq(text: string, seq: number): PromptAndBlockMsgs {
+  return {
+    type: "prompt.req",
+    chatId: "test-chat",
+    seq,
+    streamId: "s1",
+    timestamp: new Date(),
+    request: {
+      messages: [{ role: "user", content: [{ type: "text", text }] }],
+    },
+  } as unknown as PromptAndBlockMsgs;
+}
+
+function makeToplevelLine(line: string, seq: number): PromptAndBlockMsgs {
+  return {
+    type: "block.toplevel.line",
+    sectionId: "sec1",
+    ...base,
+    seq,
+    lineNr: 0,
+    line,
+  } as unknown as PromptAndBlockMsgs;
+}
+
+function makeCodeBegin(lang: string, seq: number): PromptAndBlockMsgs {
+  return {
+    type: "block.code.begin",
+    sectionId: "sec1",
+    ...base,
+    seq,
+    lang,
+  } as unknown as PromptAndBlockMsgs;
+}
+
+function makeCodeLine(line: string, lang: string, seq: number): PromptAndBlockMsgs {
+  return {
+    type: "block.code.line",
+    sectionId: "sec1",
+    ...base,
+    seq,
+    lang,
+    lineNr: 0,
+    line,
+  } as unknown as PromptAndBlockMsgs;
+}
+
+function makeCodeEnd(lang: string, seq: number): PromptAndBlockMsgs {
+  return {
+    type: "block.code.end",
+    sectionId: "sec1",
+    ...base,
+    seq,
+    lang,
+    stats: { lines: 0, bytes: 0 },
+  } as unknown as PromptAndBlockMsgs;
+}
+
+describe("reconstructConversationMessages", () => {
+  it("returns user messages only when no assistant blocks exist", () => {
+    const msgs = [makePromptReq("hello", 0)];
+    const result = reconstructConversationMessages(msgs);
+    expect(result).toEqual([{ role: "user", content: [{ type: "text", text: "hello" }] }]);
+  });
+
+  it("reconstructs assistant text from toplevel lines", () => {
+    const msgs = [makePromptReq("hello", 0), makeToplevelLine("Hi there!", 1), makeToplevelLine("How can I help?", 2)];
+    const result = reconstructConversationMessages(msgs);
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "Hi there!\nHow can I help?" }] },
+    ]);
+  });
+
+  it("reconstructs assistant code blocks", () => {
+    const msgs = [
+      makePromptReq("make an app", 0),
+      makeToplevelLine("Here is the code:", 1),
+      makeCodeBegin("jsx", 2),
+      makeCodeLine("function App() {", "jsx", 3),
+      makeCodeLine("  return <div>Hello</div>;", "jsx", 4),
+      makeCodeLine("}", "jsx", 5),
+      makeCodeEnd("jsx", 6),
+    ];
+    const result = reconstructConversationMessages(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ role: "user", content: [{ type: "text", text: "make an app" }] });
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content[0].text).toBe("Here is the code:\n```jsx\nfunction App() {\n  return <div>Hello</div>;\n}\n```");
+  });
+
+  it("preserves multi-turn conversation order", () => {
+    const msgs = [
+      // Turn 1
+      makePromptReq("build a todo app", 0),
+      makeToplevelLine("Sure, here it is:", 1),
+      makeCodeBegin("jsx", 2),
+      makeCodeLine("function App() { return <div>Todo</div>; }", "jsx", 3),
+      makeCodeEnd("jsx", 4),
+      // Turn 2
+      makePromptReq("add a button", 5),
+      makeToplevelLine("Done:", 6),
+      makeCodeBegin("jsx", 7),
+      makeCodeLine("function App() { return <div>Todo<button>Add</button></div>; }", "jsx", 8),
+      makeCodeEnd("jsx", 9),
+    ];
+    const result = reconstructConversationMessages(msgs);
+    expect(result).toHaveLength(4);
+    expect(result[0]).toEqual({ role: "user", content: [{ type: "text", text: "build a todo app" }] });
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].content[0].text).toContain("```jsx");
+    expect(result[2]).toEqual({ role: "user", content: [{ type: "text", text: "add a button" }] });
+    expect(result[3].role).toBe("assistant");
+    expect(result[3].content[0].text).toContain("button");
+  });
+
+  it("handles empty input", () => {
+    expect(reconstructConversationMessages([])).toEqual([]);
+  });
+});

--- a/vibes.diy/pkg/vite.config.ts
+++ b/vibes.diy/pkg/vite.config.ts
@@ -100,8 +100,8 @@ function setupSqlPlugin() {
       const isPg = process.env.DB_FLAVOUR === "pg" && !!process.env.NEON_DATABASE_URL;
 
       const schemaFile = isPg
-        ? join(import.meta.dirname, "node_modules/@vibes.diy/api-svc/sql/vibes-diy-api-schema-pg.ts")
-        : join(import.meta.dirname, "node_modules/@vibes.diy/api-svc/sql/vibes-diy-api-schema-sqlite.ts");
+        ? join(import.meta.dirname, "node_modules/@vibes.diy/api-sql/vibes-diy-api-schema-pg.ts")
+        : join(import.meta.dirname, "node_modules/@vibes.diy/api-sql/vibes-diy-api-schema-sqlite.ts");
       const hashFile = join(import.meta.dirname, "dist", isPg ? ".neon-schema-hash" : ".sqlite-schema-hash");
 
       const currentHash = await schemaHash(schemaFile);


### PR DESCRIPTION
## Summary
- Reconstructs assistant messages from stored block messages so follow-up LLM calls have full conversation context (not just user messages)
- Strengthens the database name stability instruction in the system prompt to prevent data loss on edits
- Adds tests for the conversation message reconstruction logic

## Context
Reverted from mabels/vibes-diy-api to reduce merge conflict surface with Meno's branch. Re-landing as a separate PR so it doesn't get lost — should be merged after Meno's integration work lands.

## Test plan
- [ ] `pnpm check` passes
- [ ] Verify multi-turn conversations preserve assistant context
- [ ] Confirm database names remain stable across edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)