### PR TITLE
fix: restore applicationChats table lookup in getResChatFromMode

### DIFF
--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -386,19 +386,32 @@ async function getResChatFromMode(
   req: ReqWithVerifiedAuth<ReqPromptChatSection>,
   orig: ReqPromptChatSection
 ): Promise<Result<ResChat>> {
-  // let resChat!: ResChat;
-  // if (isReqCreationPromptChatSection(orig) || isReqPromptApplicationChatSection(orig) || isReqPromptImageChatSection(orig)) {
-  const iResChat = await vctx.sql.db
-    .select()
-    .from(vctx.sql.tables.chatContexts)
-    .where(
-      and(
-        eq(vctx.sql.tables.chatContexts.userId, req._auth.verifiedAuth.claims.userId),
-        eq(vctx.sql.tables.chatContexts.chatId, req.chatId)
+  let iResChat;
+  if (isReqPromptApplicationChatSection(orig)) {
+    iResChat = await vctx.sql.db
+      .select()
+      .from(vctx.sql.tables.applicationChats)
+      .where(
+        and(
+          eq(vctx.sql.tables.applicationChats.userId, req._auth.verifiedAuth.claims.userId),
+          eq(vctx.sql.tables.applicationChats.chatId, req.chatId)
+        )
       )
-    )
-    .limit(1)
-    .then((r) => r[0]);
+      .limit(1)
+      .then((r) => r[0]);
+  } else {
+    iResChat = await vctx.sql.db
+      .select()
+      .from(vctx.sql.tables.chatContexts)
+      .where(
+        and(
+          eq(vctx.sql.tables.chatContexts.userId, req._auth.verifiedAuth.claims.userId),
+          eq(vctx.sql.tables.chatContexts.chatId, req.chatId)
+        )
+      )
+      .limit(1)
+      .then((r) => r[0]);
+  }
   if (!iResChat) {
     if (isReqCreationPromptChatSection(orig)) {
       return Result.Err(`Creation Chat ID ${req.chatId} not found`);
@@ -409,7 +422,6 @@ async function getResChatFromMode(
     }
   }
   const resChat = { ...iResChat, mode: orig.mode };
-  // }
   return Result.Ok(resChat);
 }
 


### PR DESCRIPTION
## Summary
- Branch the DB lookup in `getResChatFromMode()`: query `applicationChats` for app-mode, `chatContexts` for creation/image modes
- Restores app-mode chat lookup that regressed in 28bfde4b when all modes were collapsed onto `chatContexts`

## Context
Extracted from the closed PR #1318. The other two fixes from that branch (prompt.block-end emission, CLI fsId lookup) already merged via #1332 and related. This is the remaining unmerged piece.

Kept on its own branch because the `applicationChats` table is likely to be restructured as part of Meno's ongoing file-system refactor (the `wip:` 28bfde4b lineage — new `PromptStyle`, `fs-set` / `fs-update` modes, commented-out `refFsId` merge semantics). Draft so we can either land it quickly or discard cleanly when the schema changes arrive.

## Test plan
- [x] `pnpm --filter ... test` for the API package passes (86 files, 591 tests)
- [ ] Manual: open an app-mode chat and confirm the prompt lookup no longer errors with "Application Chat ID ... not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)