### PR TITLE
fix: editor code save persistence and navigation

### DIFF
--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -15,6 +15,7 @@ import {
   InMsgBase,
   isReqCreationPromptChatSection,
   isReqPromptApplicationChatSection,
+  isPromptFSStyle,
   isReqPromptFSChatSection,
   isReqPromptFSUpdateChatSection,
   isReqPromptImageChatSection,
@@ -199,7 +200,7 @@ export async function handlePromptContext({
       }
     }
   }
-  if (code.length > 0 && resChat.mode === "chat") {
+  if (code.length > 0 && (resChat.mode === "chat" || isPromptFSStyle(resChat.mode))) {
     // here is where the music plays
     const rFs = await ensureAppSlugItem(vctx, {
       type: "vibes.diy.req-ensure-app-slug",
@@ -793,7 +794,8 @@ export async function handleFSPrompt({
               timestamp: new Date(),
               lang: file.lang,
               blockNr,
-            } as CodeEndMsg,
+              stats: { lines: file.content.split("\n").length, bytes },
+            } satisfies CodeEndMsg,
           ];
         }),
       ];
@@ -820,6 +822,21 @@ export async function handleFSPrompt({
         timestamp: new Date(),
       } satisfies BlockEndMsg;
       collectedMsgs.push(value);
+
+      // Emit code blocks to WebSocket so the client can display them
+      for (const msg of collectedMsgs) {
+        if (!isBlockEnd(msg)) {
+          await appendBlockEvent({
+            ctx,
+            vctx,
+            req,
+            promptId,
+            blockSeq: blockSeq++,
+            evt: msg,
+            emitMode: "emit-only",
+          });
+        }
+      }
 
       return handleEndMsg({
         collectedMsgs,

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -151,6 +151,7 @@ export async function handlePromptContext({
   value,
   collectedMsgs: iCollectedMsgs,
   blockChunks = 100,
+  fileSystem,
 }: {
   vctx: VibesApiSQLCtx;
   req: ReqWithVerifiedAuth<ReqPromptChatSection>;
@@ -160,6 +161,7 @@ export async function handlePromptContext({
   value: BlockEndMsg;
   collectedMsgs: PromptAndBlockMsgs[];
   blockChunks?: number;
+  fileSystem?: VibeFile[];
 }): Promise<Result<{ blockSeq: number; fsRef: Option<FileSystemRef> }>> {
   let fsRef: Option<FileSystemRef> = Option.None();
   const code: CodeBlocks[] = [];
@@ -202,13 +204,9 @@ export async function handlePromptContext({
   }
   if (code.length > 0 && (resChat.mode === "chat" || isPromptFSStyle(resChat.mode))) {
     // here is where the music plays
-    const rFs = await ensureAppSlugItem(vctx, {
-      type: "vibes.diy.req-ensure-app-slug",
-      mode: "dev",
-      // chatId: req.chatId,
-      appSlug: resChat.appSlug,
-      userSlug: resChat.userSlug,
-      fileSystem: code.reduce((acc, block, idx) => {
+    const resolvedFileSystem =
+      fileSystem ??
+      code.reduce((acc, block, idx) => {
         if (block.end) {
           const content = block.lines.map((l) => l.line).join("\n");
           // console.log("Code to add to file system:", content, block.begin.lang);
@@ -233,7 +231,14 @@ export async function handlePromptContext({
           });
         }
         return acc;
-      }, [] as VibeFile[]),
+      }, [] as VibeFile[]);
+    const rFs = await ensureAppSlugItem(vctx, {
+      type: "vibes.diy.req-ensure-app-slug",
+      mode: "dev",
+      // chatId: req.chatId,
+      appSlug: resChat.appSlug,
+      userSlug: resChat.userSlug,
+      fileSystem: resolvedFileSystem,
       auth: req.auth,
       _auth: req._auth,
     });
@@ -552,6 +557,7 @@ async function handleEndMsg({
   promptId,
   value,
   blockSeq,
+  fileSystem,
 }: {
   collectedMsgs: PromptAndBlockMsgs[];
   vctx: VibesApiSQLCtx;
@@ -561,8 +567,9 @@ async function handleEndMsg({
   promptId: string;
   value: BlockEndMsg;
   blockSeq: number;
+  fileSystem?: VibeFile[];
 }): Promise<Result<number>> {
-  const r = await handlePromptContext({ vctx, req, promptId, resChat, value, blockSeq, collectedMsgs });
+  const r = await handlePromptContext({ vctx, req, promptId, resChat, value, blockSeq, collectedMsgs, fileSystem });
   if (r.isErr()) {
     return Result.Err(r);
   }
@@ -847,6 +854,7 @@ export async function handleFSPrompt({
         promptId,
         value,
         blockSeq,
+        fileSystem,
       });
     })
     .do();

--- a/vibes.diy/pkg/app/components/MessageList.tsx
+++ b/vibes.diy/pkg/app/components/MessageList.tsx
@@ -299,6 +299,7 @@ function MessageList({
     let collectedMsg: LineMsg[] = [];
     let codeBegin: CodeBeginMsg;
     let toplevelBegin: ToplevelBeginMsg;
+    let hasPromptReq = false;
     // let traceBlockId: BlockEndMsg | undefined
     const nprompt = fixCurrentStreaming(promptBlock);
     // if (promptBlock.msgs.length !== nprompt.msgs.length) {
@@ -323,6 +324,7 @@ function MessageList({
           acc.push(<PromptErrorMsg key={`error-${msg.streamId}`} msg={msg} onRetry={onRetry} />);
           break;
         case isPromptReq(msg):
+          hasPromptReq = true;
           acc.push(<Prompt key={`prompt-${msg.streamId}`} msg={msg} />);
           break;
 
@@ -330,7 +332,13 @@ function MessageList({
           blockMsgs.splice(0, blockMsgs.length);
           break;
         case isBlockEnd(msg):
-          // console.log(`Completed a Chat --- need to register the clicks`, msg);
+          if (!hasPromptReq && blockMsgs.some((b) => b.type === "Code")) {
+            acc.push(
+              <div key={`edited-${msg.blockId}`} className="mx-4 text-sm italic text-gray-400 dark:text-gray-500">
+                User edited code
+              </div>
+            );
+          }
           blockMsgs.forEach((block, idx) => {
             // console.log(">>>>>", block.type, block.begin.sectionId, block.lines.length)
             if (block.type === "Code") {

--- a/vibes.diy/pkg/app/components/mine/PromptsTab.tsx
+++ b/vibes.diy/pkg/app/components/mine/PromptsTab.tsx
@@ -43,7 +43,9 @@ export function PromptsTab({ isLoading, chatDetails, screenshots, onToggleMode }
         const isToggling = toggling === p.fsId;
         return (
           <div key={i} className="rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 p-3">
-            <p className="mb-2 text-sm text-gray-800 dark:text-gray-200">{p.prompt}</p>
+            <p className="mb-2 text-sm text-gray-800 dark:text-gray-200">
+              {p.prompt || <span className="italic text-gray-400 dark:text-gray-500">User edited code</span>}
+            </p>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <a

--- a/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
+++ b/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
@@ -20,7 +20,7 @@ import SessionSidebar from "../../components/SessionSidebar.js";
 import ChatInput, { ChatInputRef } from "../../components/ChatInput.js";
 import { isMobileViewport, useViewState } from "../../utils/ViewState.js";
 import type { ViewType } from "@vibes.diy/prompts";
-import { isCodeBegin } from "@vibes.diy/call-ai-v2";
+import { isCodeBegin, isBlockEnd } from "@vibes.diy/call-ai-v2";
 import { calcEntryPointUrl } from "@vibes.diy/api-pkg";
 import ChatHeaderContent from "../../components/ChatHeaderContent.js";
 import ChatInterface from "../../components/ChatInterface.js";
@@ -334,6 +334,8 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
     // }
   }, []);
 
+  const pendingSavePromptIdRef = useRef<string | null>(null);
+
   const handleOnCodeSave = useCallback(() => {
     console.log(`Saving code changes...`, editorState);
     if (!chat) return;
@@ -356,9 +358,29 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
           setEditorState(editorState); // restore unsaved state
         } else {
           toast.success(`Code changes saved`);
+          pendingSavePromptIdRef.current = r.Ok().promptId;
+          console.log(`[CodeSave] waiting for block.end with promptId: ${r.Ok().promptId}`);
         }
       });
   }, [editorState, chat]);
+
+  // Navigate to new fsId after save by watching promptState for the block.end matching the save's promptId
+  useEffect(() => {
+    if (!pendingSavePromptIdRef.current) return;
+    const targetPromptId = pendingSavePromptIdRef.current;
+    for (const block of [...promptState.blocks].reverse()) {
+      for (const msg of block.msgs) {
+        if (isBlockEnd(msg) && msg.streamId === targetPromptId && msg.fsRef) {
+          pendingSavePromptIdRef.current = null;
+          const sp = new URLSearchParams(searchParams);
+          if (!sp.has("view")) sp.set("view", "preview");
+          console.log(`[CodeSave] navigating to new fsId: ${msg.fsRef.fsId} (promptId: ${targetPromptId})`);
+          navigate({ pathname: `/chat/${userSlug}/${appSlug}/${msg.fsRef.fsId}`, search: sp.toString() }, { replace: true });
+          return;
+        }
+      }
+    }
+  }, [promptState.blocks, searchParams, navigate, userSlug, appSlug, fsId]);
 
   useEffect(() => {
     if (inConstruction) return;

--- a/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
+++ b/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
@@ -382,6 +382,11 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
     }
   }, [promptState.blocks, searchParams, navigate, userSlug, appSlug, fsId]);
 
+  // Clear pending save when switching chats
+  useEffect(() => {
+    pendingSavePromptIdRef.current = null;
+  }, [userSlug, appSlug]);
+
   useEffect(() => {
     if (inConstruction) return;
     if (isMobileViewport()) {


### PR DESCRIPTION
## Summary
- **Server: persist filesystem for fs-set/fs-update modes** — `handlePromptContext` only called `ensureAppSlugItem` when `resChat.mode === "chat"`, but editor saves use `fs-set` mode. Added `isPromptFSStyle` check.
- **Server: emit code blocks to WebSocket during FS prompts** — code blocks were only stored in DB but never sent to the client, so the editor couldn't display saved code after navigation.
- **Server: add missing `stats` field to `CodeEndMsg`** — `as CodeEndMsg` cast hid the missing field, causing `isCodeEnd` validation to fail and the editor to show `complete=false`. Changed to `satisfies`.
- **Client: navigate to correct fsId after save** — `getAppByFsId` without fsId returns the production entry, not the dev save. Now matches `block.end.streamId` to the save's `promptId` to find the exact fsId.
- **Client: show "User edited code" label** — FS saves have no `prompt.req`, so chat history and /vibes/mine showed empty text. Now detects promptless blocks and shows a label.

## Test plan
- [ ] Edit code in editor, click Save — toast appears, URL updates to new fsId
- [ ] Edit code again after save — Save button reappears
- [ ] Navigate away and back — saved code persists
- [ ] Check /vibes/mine — FS save entries show "User edited code" instead of blank
- [ ] Check chat history — "User edited code" label appears before promptless code blocks
- [ ] Normal LLM chat flow still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)