### PR TITLE
feat: ImgVibes img2img support

### DIFF
--- a/prompts/pkg/llms/img-vibes.md
+++ b/prompts/pkg/llms/img-vibes.md
@@ -21,16 +21,27 @@ import { ImgVibes } from "img-vibes";
 
 function MyComponent() {
   const [file, setFile] = useState(null);
+  const [transformKey, setTransformKey] = useState(0);
+
+  const handleTransform = () => {
+    setTransformKey((k) => k + 1);
+  };
+
   return (
     <div>
       <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files[0])} />
-      {file && <ImgVibes prompt="Make it look like a watercolor painting" inputImage={file} />}
+      {file && (
+        <>
+          <button onClick={handleTransform}>Transform</button>
+          <ImgVibes key={transformKey} prompt="Make it look like a watercolor painting" inputImage={file} />
+        </>
+      )}
     </div>
   );
 }
 ```
 
-The input image is automatically resized (max 1024px) and compressed as JPEG before sending.
+Use `key={counter}` to force a fresh generation when the user re-triggers with the same prompt/file. The input image is automatically resized (max 1024px) and compressed as JPEG before sending.
 
 3. **With an \_id prop** - Loads a specific image from the database:
 

--- a/prompts/pkg/llms/img-vibes.md
+++ b/prompts/pkg/llms/img-vibes.md
@@ -24,7 +24,7 @@ function MyComponent() {
   return (
     <div>
       <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files[0])} />
-      {file && <ImgVibes prompt="Make it look like a watercolor painting" inputImage={file} />}
+      {file && <ImgVibes prompt="Make it look like a watercolor painting" images={[file]} />}
     </div>
   );
 }
@@ -110,7 +110,7 @@ ImgVibes supports custom styling through CSS variables or custom class names:
 #### Props
 
 - `prompt`: Text prompt for image generation (required unless `_id` is provided)
-- `inputImage`: A `File` object for img2img editing/transformation (optional)
+- `images`: Array of `File` objects for img2img editing/transformation (uses first image, optional)
 - `_id`: Document ID to load a specific image instead of generating a new one
 - `database`: Database name or instance to use for storing images (default: `'ImgVibes'`)
 - `className`: CSS class name for the image element (optional)

--- a/prompts/pkg/llms/img-vibes.md
+++ b/prompts/pkg/llms/img-vibes.md
@@ -21,27 +21,16 @@ import { ImgVibes } from "img-vibes";
 
 function MyComponent() {
   const [file, setFile] = useState(null);
-  const [transformKey, setTransformKey] = useState(0);
-
-  const handleTransform = () => {
-    setTransformKey((k) => k + 1);
-  };
-
   return (
     <div>
       <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files[0])} />
-      {file && (
-        <>
-          <button onClick={handleTransform}>Transform</button>
-          <ImgVibes key={transformKey} prompt="Make it look like a watercolor painting" inputImage={file} />
-        </>
-      )}
+      {file && <ImgVibes prompt="Make it look like a watercolor painting" inputImage={file} />}
     </div>
   );
 }
 ```
 
-Use `key={counter}` to force a fresh generation when the user re-triggers with the same prompt/file. The input image is automatically resized (max 1024px) and compressed as JPEG before sending.
+The input image is automatically resized (max 1024px) and compressed as JPEG before sending.
 
 3. **With an \_id prop** - Loads a specific image from the database:
 

--- a/prompts/pkg/llms/img-vibes.md
+++ b/prompts/pkg/llms/img-vibes.md
@@ -2,61 +2,53 @@
 
 ## Basic Usage
 
-The ImgVibes component can be used in three ways:
+The ImgVibes component can be used in several ways:
 
-1. **With no props** - Shows a form UI for users to enter a prompt and/or upload images:
+1. **With a prompt prop** - Immediately generates an image (cached across reloads):
 
 ```jsx
 import { ImgVibes } from "img-vibes";
 
 function MyComponent() {
-  return <ImgVibes />; // Shows built-in form for prompt entry and image upload
+  return <ImgVibes prompt="A sunset over mountains" />;
 }
 ```
 
-2. **With a prompt prop** - Immediately generates an image (no form shown):
+2. **With an input image** - Edits or transforms an uploaded image:
 
 ```jsx
 import { ImgVibes } from "img-vibes";
 
 function MyComponent() {
-  return <ImgVibes prompt="A sunset over mountains" />; // Direct generation, no form
-}
-```
-
-3. **With images prop** - Edits or combines images with AI (no form shown):
-
-```jsx
-import { ImgVibes } from "img-vibes";
-
-function MyComponent() {
-  const [files, setFiles] = useState([]);
+  const [file, setFile] = useState(null);
   return (
-    <ImgVibes
-      prompt="Create a gift basket with these items"
-      images={files} // Array of File objects
-    />
+    <div>
+      <input type="file" accept="image/*" onChange={(e) => setFile(e.target.files[0])} />
+      {file && <ImgVibes prompt="Make it look like a watercolor painting" inputImage={file} />}
+    </div>
   );
 }
 ```
 
-4. **With an \_id prop** - Loads a specific image from the database (no form shown):
+The input image is automatically resized (max 1024px) and compressed as JPEG before sending.
 
-If there is no image generated for the document yet, but it has a `prompt` field, it will generate a new image with the prompt. If there an images is stored, at doc.\_files.original, it will use that as the base image.
+3. **With an \_id prop** - Loads a specific image from the database:
 
 ```jsx
 import { ImgVibes } from "img-vibes";
 
 function MyComponent() {
-  return <ImgVibes _id="my-image-id" />; // Loads specific image by ID
+  return <ImgVibes _id="my-image-id" database={database} />;
 }
 ```
 
-## List by ID
+If the document has a `prompt` field but no generated image yet, it will generate one automatically.
 
-Images and prompts are tracked in a Fireproof database with a `type` of `image`. If a database is not provided, it uses `"ImgVibes"` as the database name.
+## Gallery Pattern
 
-Display stored images by their ID. Ensure you do this, so users can find the images they created.
+Images and prompts are tracked in a Fireproof database with a `type` of `image`. If a database is not provided, it uses `"ImgVibes"` as the default.
+
+Display stored images by their ID using `useLiveQuery`:
 
 ```jsx
 import { useFireproof } from "use-fireproof";
@@ -71,7 +63,7 @@ function MyComponent() {
 
   return (
     <div>
-      <ImgVibes database={database} />
+      <ImgVibes database={database} prompt="A colorful landscape" />
       {imageDocuments.length > 0 && (
         <div className="history">
           <h3>Previously Generated Images</h3>
@@ -89,6 +81,13 @@ function MyComponent() {
 }
 ```
 
+## Caching and Versions
+
+- Same prompt generates a deterministic `_id` (hash-based), so results are cached across reloads
+- Each image has a **regenerate** button that creates a new version
+- Use **prev/next** controls to navigate between versions
+- Set `showControls={false}` to hide the regen and version navigation buttons
+
 ## Styling
 
 ImgVibes supports custom styling through CSS variables or custom class names:
@@ -105,23 +104,16 @@ ImgVibes supports custom styling through CSS variables or custom class names:
 <ImgVibes
   prompt="A landscape"
   className="my-custom-image"
-  classes={{
-    root: 'custom-container',
-    image: 'custom-img',
-    overlay: 'custom-overlay'
-  }}
 />
 ```
 
 #### Props
 
 - `prompt`: Text prompt for image generation (required unless `_id` is provided)
+- `inputImage`: A `File` object for img2img editing/transformation (optional)
 - `_id`: Document ID to load a specific image instead of generating a new one
-- `database`: Database name or instance to use for storing images (default: `'ImgVibes'`)- `options` (object, optional): Configuration options for image generation
-  - `model` (string, optional): Model to use for image generation, defaults to 'gpt-image-1'
-  - `size` (string, optional): Size of the generated image (Must be one of 1024x1024, 1536x1024 (landscape), 1024x1536 (portrait), or 'auto' (default value) for gpt-image-1, and one of 256x256, 512x512, or 1024x1024 for dall-e-2.)
-  - `quality` (string, optional): Quality of the generated image (high, medium and low are only supported for gpt-image-1. dall-e-2 only supports standard quality. Defaults to auto.)
-  - `debug` (boolean, optional): Enable debug logging, defaults to false
-- `onLoad`: Callback when image load completes successfully
-- `onError`: Callback when image load fails, receives the error as parameter
-- `className`: CSS class name for the image element (optional)- `classes`: Object containing custom CSS classes for styling component parts (see Styling section)
+- `database`: Database name or instance to use for storing images (default: `'ImgVibes'`)
+- `className`: CSS class name for the image element (optional)
+- `alt`: Alt text for the image element (optional)
+- `style`: Inline styles for the image element (optional)
+- `showControls`: Toggle regenerate and version navigation buttons (default: `true`)

--- a/use-vibes/types/img-vibes-types.ts
+++ b/use-vibes/types/img-vibes-types.ts
@@ -34,6 +34,7 @@ export interface UseImgVibesOptions {
   readonly database: string | Database;
   readonly generationId: string;
   readonly skip: boolean;
+  readonly inputImage?: File;
 }
 
 export interface UseImgVibesResult {

--- a/vibes.diy/api/impl/index.ts
+++ b/vibes.diy/api/impl/index.ts
@@ -668,7 +668,7 @@ class LLMChatImpl implements LLMChat {
     }
   }
 
-  async prompt(msg: LLMRequest): Promise<Result<ResPromptChatSection, VibesDiyError>> {
+  async prompt(msg: LLMRequest, opts?: { inputImageBase64?: string }): Promise<Result<ResPromptChatSection, VibesDiyError>> {
     const mode = this.res.mode;
     if (!isPromptLLMStyle(mode)) {
       return Result.Err({
@@ -685,6 +685,7 @@ class LLMChatImpl implements LLMChat {
         chatId: this.res.chatId,
         outerTid: this.tid, //leaking but necessary streaming
         prompt: msg,
+        ...(mode === "img" && opts?.inputImageBase64 ? { inputImageBase64: opts.inputImageBase64 } : {}),
       },
       {
         resMatch: isResPromptChatSection,

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -20,6 +20,7 @@ import {
   isReqPromptFSChatSection,
   isReqPromptFSUpdateChatSection,
   isReqPromptImageChatSection,
+  reqPromptImageChatSection,
   isReqPromptLLMChatSection,
   LLMHeaders,
   type PromptStyle,
@@ -624,7 +625,7 @@ async function handleProdiaImageRequest({
   scope: Scope;
   ctx: HandleTriggerCtx<W3CWebSocketEvent, MsgBase<ReqWithVerifiedAuth<ReqPromptChatSection>>, never | VibesDiyError>;
   vctx: VibesApiSQLCtx;
-  req: ReqWithVerifiedAuth<ReqPromptLLMChatSection>;
+  req: ReqWithVerifiedAuth<typeof reqPromptImageChatSection.infer>;
   promptId: string;
   blockSeq: number;
 }): Promise<Result<number>> {
@@ -633,21 +634,14 @@ async function handleProdiaImageRequest({
     return Result.Err("PRODIA_TOKEN not configured");
   }
 
-  // Extract prompt text and optional input image from the last user message
+  // Extract prompt text from the last user message
   const userMessages = req.prompt.messages.filter((m) => m.role === "user");
   const lastUserMsg = userMessages[userMessages.length - 1];
-  let promptText = "";
-  let inputImageDataUrl: string | undefined;
-  for (const part of lastUserMsg?.content ?? []) {
-    if (part.text.startsWith("__img2img__:")) {
-      inputImageDataUrl = part.text.slice("__img2img__:".length);
-    } else if (!promptText) {
-      promptText = part.text;
-    }
-  }
+  const promptText = lastUserMsg?.content?.[0]?.text ?? "";
   if (!promptText) {
     return Result.Err("No prompt text found in user messages");
   }
+  const inputImageDataUrl = req.inputImageBase64;
 
   // Emit prompt.req
   await scope
@@ -1179,7 +1173,7 @@ export const promptChatSection: EventoHandler<W3CWebSocketEvent, MsgBase<ReqProm
             scope,
             ctx,
             vctx,
-            req: req as ReqWithVerifiedAuth<ReqPromptLLMChatSection>,
+            req: orig as ReqWithVerifiedAuth<typeof reqPromptImageChatSection.infer>,
             promptId,
             blockSeq,
           });

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -678,7 +678,7 @@ async function handleProdiaImageRequest({
     const formData = new FormData();
     formData.append(
       "job",
-      new Blob([JSON.stringify({ type: "inference.flux-2.klein.img2img.v1", config: { prompt: promptText } })], {
+      new Blob([JSON.stringify({ type: "inference.flux-2.klein.9b.img2img.v1", config: { prompt: promptText } })], {
         type: "application/json",
       }),
       "job.json"

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -633,10 +633,18 @@ async function handleProdiaImageRequest({
     return Result.Err("PRODIA_TOKEN not configured");
   }
 
-  // Extract prompt text from the last user message
+  // Extract prompt text and optional input image from the last user message
   const userMessages = req.prompt.messages.filter((m) => m.role === "user");
   const lastUserMsg = userMessages[userMessages.length - 1];
-  const promptText = lastUserMsg?.content?.[0]?.text ?? "";
+  let promptText = "";
+  let inputImageDataUrl: string | undefined;
+  for (const part of lastUserMsg?.content ?? []) {
+    if (part.text.startsWith("__img2img__:")) {
+      inputImageDataUrl = part.text.slice("__img2img__:".length);
+    } else if (!promptText) {
+      promptText = part.text;
+    }
+  }
   if (!promptText) {
     return Result.Err("No prompt text found in user messages");
   }
@@ -664,19 +672,46 @@ async function handleProdiaImageRequest({
     })
     .do();
 
-  // Call Prodia API
-  const prodiaRes = await fetch("https://inference.prodia.com/v2/job", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${prodiaToken}`,
-      Accept: "image/png",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      type: "inference.flux-2.klein.9b.txt2img.v1",
-      config: { prompt: promptText },
-    }),
-  });
+  // Call Prodia API (img2img if input image provided, otherwise txt2img)
+  let prodiaRes: Response;
+  if (inputImageDataUrl) {
+    const base64Data = inputImageDataUrl.split(",")[1];
+    const binaryString = atob(base64Data);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    const formData = new FormData();
+    formData.append(
+      "job",
+      new Blob([JSON.stringify({ type: "inference.flux-2.klein.img2img.v1", config: { prompt: promptText } })], {
+        type: "application/json",
+      }),
+      "job.json"
+    );
+    formData.append("input", new Blob([bytes], { type: "image/jpeg" }), "input.jpg");
+    prodiaRes = await fetch("https://inference.prodia.com/v2/job", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${prodiaToken}`,
+        Accept: "image/png",
+      },
+      body: formData,
+    });
+  } else {
+    prodiaRes = await fetch("https://inference.prodia.com/v2/job", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${prodiaToken}`,
+        Accept: "image/png",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "inference.flux-2.klein.9b.txt2img.v1",
+        config: { prompt: promptText },
+      }),
+    });
+  }
 
   if (!prodiaRes.ok) {
     const errorText = await prodiaRes.text().catch(() => "");

--- a/vibes.diy/api/types/chat.ts
+++ b/vibes.diy/api/types/chat.ts
@@ -86,6 +86,7 @@ export const reqPromptImageChatSection = type({
   chatId: "string",
   outerTid: "string", // this is used to emit events to the current chat session
   prompt: LLMRequest,
+  "inputImageBase64?": "string",
 });
 
 export function isReqPromptImageChatSection(obj: unknown): obj is typeof reqPromptImageChatSection.infer {

--- a/vibes.diy/api/types/vibes-diy-api.ts
+++ b/vibes.diy/api/types/vibes-diy-api.ts
@@ -72,7 +72,7 @@ export type LLMChatEntry = typeof LLMChatEntry.infer;
 export type OnResponseTypes = ResError | SectionEvent;
 
 export interface LLMChat extends LLMChatEntry {
-  prompt(req: LLMRequest): Promise<Result<ResPromptChatSection, VibesDiyError>>;
+  prompt(req: LLMRequest, opts?: { inputImageBase64?: string }): Promise<Result<ResPromptChatSection, VibesDiyError>>;
   promptFS(req: FSUpdate | VibeFile[]): Promise<Result<ResPromptChatSection, VibesDiyError>>;
 
   readonly sectionStream: ReadableStream<OnResponseTypes>;

--- a/vibes.diy/base/components/ImgVibes.tsx
+++ b/vibes.diy/base/components/ImgVibes.tsx
@@ -5,7 +5,7 @@ import { useImgVibes } from "../hooks/img-vibes/use-img-vibes.js";
 export interface ImgVibesProps {
   prompt?: string;
   _id?: string;
-  inputImage?: File;
+  images?: File[];
   database?: string | Database;
   className?: string;
   alt?: string;
@@ -22,8 +22,9 @@ function promptToId(prompt: string): string {
   return `img-${(hash >>> 0).toString(36)}`;
 }
 
-export function ImgVibes({ prompt, _id: propId, inputImage, database, className, alt, style, showControls = true }: ImgVibesProps) {
-  const imageKey = inputImage ? `${inputImage.name}-${inputImage.lastModified}` : "";
+export function ImgVibes({ prompt, _id: propId, images, database, className, alt, style, showControls = true }: ImgVibesProps) {
+  const inputImage = images?.[0];
+  const imageKey = inputImage ? `${inputImage.name}-${inputImage.size}-${inputImage.lastModified}` : "";
   const stableId = useMemo(() => propId ?? (prompt ? promptToId(prompt + imageKey) : undefined), [propId, prompt, imageKey]);
   const [generationId, setGenerationId] = useState<string | undefined>(undefined);
   const [versionIndex, setVersionIndex] = useState<number | null>(null);

--- a/vibes.diy/base/components/ImgVibes.tsx
+++ b/vibes.diy/base/components/ImgVibes.tsx
@@ -5,6 +5,7 @@ import { useImgVibes } from "../hooks/img-vibes/use-img-vibes.js";
 export interface ImgVibesProps {
   prompt?: string;
   _id?: string;
+  inputImage?: File;
   database?: string | Database;
   className?: string;
   alt?: string;
@@ -21,7 +22,7 @@ function promptToId(prompt: string): string {
   return `img-${(hash >>> 0).toString(36)}`;
 }
 
-export function ImgVibes({ prompt, _id: propId, database, className, alt, style, showControls = true }: ImgVibesProps) {
+export function ImgVibes({ prompt, _id: propId, inputImage, database, className, alt, style, showControls = true }: ImgVibesProps) {
   const stableId = useMemo(() => propId ?? (prompt ? promptToId(prompt) : undefined), [propId, prompt]);
   const [generationId, setGenerationId] = useState<string | undefined>(undefined);
   const [versionIndex, setVersionIndex] = useState<number | null>(null);
@@ -32,6 +33,7 @@ export function ImgVibes({ prompt, _id: propId, database, className, alt, style,
     database,
     skip: !prompt && !stableId,
     generationId,
+    inputImage,
   });
 
   const versions = document?.versions ?? [];

--- a/vibes.diy/base/components/ImgVibes.tsx
+++ b/vibes.diy/base/components/ImgVibes.tsx
@@ -23,7 +23,8 @@ function promptToId(prompt: string): string {
 }
 
 export function ImgVibes({ prompt, _id: propId, inputImage, database, className, alt, style, showControls = true }: ImgVibesProps) {
-  const stableId = useMemo(() => propId ?? (prompt ? promptToId(prompt) : undefined), [propId, prompt]);
+  const imageKey = inputImage ? `${inputImage.name}-${inputImage.lastModified}` : "";
+  const stableId = useMemo(() => propId ?? (prompt ? promptToId(prompt + imageKey) : undefined), [propId, prompt, imageKey]);
   const [generationId, setGenerationId] = useState<string | undefined>(undefined);
   const [versionIndex, setVersionIndex] = useState<number | null>(null);
 

--- a/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
+++ b/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
@@ -10,6 +10,7 @@ export function useImgVibes({
   database = "ImgVibes",
   skip = false,
   generationId,
+  inputImage,
 }: Partial<UseImgVibesOptions>): UseImgVibesResult {
   const [assetUrl, setAssetUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -69,7 +70,7 @@ export function useImgVibes({
       setError(null);
 
       try {
-        const urls = await imgVibes(promptText);
+        const urls = await imgVibes(promptText, inputImage);
         const imageUrl = urls[0];
         if (!imageUrl) throw new Error("No image URL received from service");
 
@@ -111,7 +112,7 @@ export function useImgVibes({
     }
 
     run();
-  }, [_id, prompt, generationId, skip, db]);
+  }, [_id, prompt, generationId, skip, db, inputImage]);
 
   return { assetUrl, loading, progress, error, document };
 }

--- a/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
+++ b/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
@@ -42,8 +42,8 @@ export function useImgVibes({
         // Doc doesn't exist yet
       }
 
-      // Cache hit: doc exists with versions, and this isn't a regen request
-      if (existingDoc?.versions?.length && !isRegen) {
+      // Cache hit: doc exists with versions, and this isn't a regen request or img2img
+      if (existingDoc?.versions?.length && !isRegen && !inputImage) {
         const ver = existingDoc.versions[existingDoc.currentVersion ?? 0];
         if (ver?.assetUrl) {
           setDocument(existingDoc);

--- a/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
+++ b/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
@@ -26,7 +26,7 @@ export function useImgVibes({
   useEffect(() => {
     if (skip || !_id) return;
 
-    const genKey = `${_id}-${generationId ?? ""}`;
+    const genKey = `${_id}-${generationId ?? ""}-${inputImage?.name ?? ""}${inputImage?.lastModified ?? ""}`;
     if (currentGenRef.current === genKey) return;
     currentGenRef.current = genKey;
 

--- a/vibes.diy/vibe/runtime/img-vibes.tsx
+++ b/vibes.diy/vibe/runtime/img-vibes.tsx
@@ -1,14 +1,19 @@
 import { VibeSandboxApi } from "./register-dependencies.js";
 import { isResErrorImgVibes } from "@vibes.diy/vibe-types";
+import { resizeImageToBase64 } from "./resize-image.js";
 
 // Re-export ImgVibes component from @vibes.diy/base so sandbox apps can import { ImgVibes } from "use-vibes"
 export { ImgVibes, useImgVibes } from "@vibes.diy/base";
 
-export let imgVibes: (prompt: string) => Promise<string[]>;
+export let imgVibes: (prompt: string, inputImage?: File) => Promise<string[]>;
 
 export function registerImgVibes(vibeApi: VibeSandboxApi): void {
-  imgVibes = async (prompt: string): Promise<string[]> => {
-    const rResult = await vibeApi.imgVibes(prompt);
+  imgVibes = async (prompt: string, inputImage?: File): Promise<string[]> => {
+    let inputImageBase64: string | undefined;
+    if (inputImage) {
+      inputImageBase64 = await resizeImageToBase64(inputImage);
+    }
+    const rResult = await vibeApi.imgVibes(prompt, inputImageBase64);
     if (rResult.isErr()) {
       throw rResult.Err();
     }

--- a/vibes.diy/vibe/runtime/register-dependencies.ts
+++ b/vibes.diy/vibe/runtime/register-dependencies.ts
@@ -97,11 +97,12 @@ export class VibeSandboxApi {
     );
   }
 
-  imgVibes(prompt: string): Promise<Result<ResImgVibes>> {
+  imgVibes(prompt: string, inputImageBase64?: string): Promise<Result<ResImgVibes>> {
     return this.request<ReqImgVibes, ResImgVibes>(
       {
         type: "vibe.req.imgVibes",
         prompt,
+        ...(inputImageBase64 ? { inputImageBase64 } : {}),
         ...this.svc.vibeApp,
       },
       { wait: isResImgVibes, timeout: 120000 }

--- a/vibes.diy/vibe/runtime/resize-image.ts
+++ b/vibes.diy/vibe/runtime/resize-image.ts
@@ -1,0 +1,20 @@
+export async function resizeImageToBase64(file: File, maxDim = 1024, quality = 0.85): Promise<string> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+  const scale = Math.min(1, maxDim / Math.max(width, height));
+  const w = Math.round(width * scale);
+  const h = Math.round(height * scale);
+
+  const canvas = new OffscreenCanvas(w, h);
+  const ctx = canvas.getContext("2d")!;
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close();
+
+  const blob = await canvas.convertToBlob({ type: "image/jpeg", quality });
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}

--- a/vibes.diy/vibe/runtime/resize-image.ts
+++ b/vibes.diy/vibe/runtime/resize-image.ts
@@ -6,7 +6,8 @@ export async function resizeImageToBase64(file: File, maxDim = 1024, quality = 0
   const h = Math.round(height * scale);
 
   const canvas = new OffscreenCanvas(w, h);
-  const ctx = canvas.getContext("2d")!;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Failed to get 2d context from OffscreenCanvas");
   ctx.drawImage(bitmap, 0, 0, w, h);
   bitmap.close();
 

--- a/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
+++ b/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
@@ -398,18 +398,12 @@ function vibeImageGen(sandbox: vibesDiySrvSandbox): EventoHandler {
                 message: err?.message ?? String(err),
               } satisfies ResErrorImgVibes);
             });
+          const content: Array<{ type: "text"; text: string }> = [{ type: "text", text: ctx.validated.prompt }];
+          if (ctx.validated.inputImageBase64) {
+            content.push({ type: "text", text: `__img2img__:${ctx.validated.inputImageBase64}` });
+          }
           const rPrompt = await rChat.Ok().prompt({
-            messages: [
-              {
-                role: "user",
-                content: [
-                  {
-                    type: "text",
-                    text: ctx.validated.prompt,
-                  },
-                ],
-              },
-            ],
+            messages: [{ role: "user", content }],
           });
           if (rPrompt.isErr()) {
             return ctx.send.send(ctx, {

--- a/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
+++ b/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
@@ -398,13 +398,12 @@ function vibeImageGen(sandbox: vibesDiySrvSandbox): EventoHandler {
                 message: err?.message ?? String(err),
               } satisfies ResErrorImgVibes);
             });
-          const content: Array<{ type: "text"; text: string }> = [{ type: "text", text: ctx.validated.prompt }];
-          if (ctx.validated.inputImageBase64) {
-            content.push({ type: "text", text: `__img2img__:${ctx.validated.inputImageBase64}` });
-          }
-          const rPrompt = await rChat.Ok().prompt({
-            messages: [{ role: "user", content }],
-          });
+          const rPrompt = await rChat
+            .Ok()
+            .prompt(
+              { messages: [{ role: "user", content: [{ type: "text", text: ctx.validated.prompt }] }] },
+              ctx.validated.inputImageBase64 ? { inputImageBase64: ctx.validated.inputImageBase64 } : undefined
+            );
           if (rPrompt.isErr()) {
             return ctx.send.send(ctx, {
               tid: ctx.validated.tid,

--- a/vibes.diy/vibe/types/index.ts
+++ b/vibes.diy/vibe/types/index.ts
@@ -221,6 +221,7 @@ export const ReqImgVibes = type({
   userSlug: "string",
   appSlug: "string",
   prompt: "string",
+  "inputImageBase64?": "string",
 }).and(Base);
 
 export type ReqImgVibes = typeof ReqImgVibes.infer;


### PR DESCRIPTION
## Summary
- Add `inputImage` prop to `<ImgVibes>` for image editing/transformation via Prodia img2img API
- Client-side resize (max 1024px JPEG) keeps data under WebSocket limits
- Type-safe `inputImageBase64` field on `reqPromptImageChatSection` (img-mode only) — no tagged text smuggling
- Server conditionally uses multipart Prodia img2img when input image present, falls back to txt2img
- Updated `img-vibes.md` prompt doc to match current component API (removed nonexistent props)

## Test plan
- [ ] `<ImgVibes prompt="a cat" />` — txt2img still works, cached on reload
- [ ] `<ImgVibes prompt="watercolor" inputImage={file} />` — img2img via Prodia multipart
- [ ] Verify Prodia img2img model name `inference.flux-2.klein.img2img.v1` works (may need adjustment)
- [ ] Regen works on img2img results
- [ ] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)