### PR TITLE
Revert RAG merge — IDE misconfiguration

### DIFF
--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -388,6 +388,8 @@ async function injectSystemPrompt(
   const conversationMessages = reconstructConversationMessages(allSectionMsgs);
   const systemPrompt = await exception2Result(async () =>
     makeBaseSystemPrompt(await resolveEffectiveModel({ model }, {}), {
+      dependenciesUserOverride: true,
+      dependencies: ["fireproof", "callai", "img-vibes", "web-audio"],
       fetch: async (url: RequestInfo | URL, _init?: RequestInit) => {
         console.log("Fetching asset for system prompt from URL:", url.toString(), vctx.params.pkgRepos.workspace);
         const uri = URI.from(url);
@@ -403,31 +405,18 @@ async function injectSystemPrompt(
         if (rRes.isErr()) {
           console.error("Failed to fetch asset for system prompt from URL:", url.toString(), "with error:", rRes.Err());
           return new Response(JSON.stringify({ error: rRes.Err() }), { status: 500 });
+          // return Result.Err(rRes);
         }
-        return new Response(rRes.Ok());
+        const res = new Response(rRes.Ok());
+        // res.clone().text().then((text) => {
+        //   console.log("Fetched asset for system prompt from URL:", url.toString(), "with content:", text);
+        // })
+        return res;
+        //   return Result.Ok(await new Response(rRes.Ok()).text());
       },
       callAi: {
-        ModuleAndOptionsSelection: async (msgs: ChatMessage[]) => {
-          try {
-            const res = await vctx.llmRequest({
-              model: "openai/gpt-4o",
-              messages: msgs,
-              stream: false,
-              max_tokens: 200,
-              headers: vctx.params.llm.headers,
-            });
-            if (!res.ok) {
-              return Result.Err(`RAG decision LLM call failed: ${res.status} ${res.statusText}`);
-            }
-            const body = (await res.json()) as { choices?: { message?: { content?: string } }[] };
-            const content = body.choices?.[0]?.message?.content;
-            if (!content) {
-              return Result.Err("RAG decision LLM returned no content");
-            }
-            return Result.Ok(content);
-          } catch (e) {
-            return Result.Err(`RAG decision LLM call error: ${e}`);
-          }
+        ModuleAndOptionsSelection: async (_msgs: ChatMessage[]) => {
+          return Result.Err(`Module and options selection is not supported in system prompts at this time`);
         },
       },
     })


### PR DESCRIPTION
## Summary

IDE misconfiguration merged #1369 to main before the self-review comments on the `callAi.ModuleAndOptionsSelection` block were addressed (hardcoded model instead of config, raw `llmRequest` instead of callAI v2 schema, naming of the `callAi` key).

Reverting here so #1369 can be reworked against a clean main. The RAG commit is preserved on branch `jchris/title-on-rag-enable` and the PR will re-open once this revert lands.

## Test plan

- [ ] Merge this revert
- [ ] Confirm #1369 re-opens
- [ ] Rework #1369 to use config-driven model + callAI v2 schema, re-request review

🤖 Generated with [Claude Code](https://claude.com/claude-code)