### PR TITLE
wip: enable RAG decision call for title generation (rework)

### DIFF
--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -388,8 +388,6 @@ async function injectSystemPrompt(
   const conversationMessages = reconstructConversationMessages(allSectionMsgs);
   const systemPrompt = await exception2Result(async () =>
     makeBaseSystemPrompt(await resolveEffectiveModel({ model }, {}), {
-      dependenciesUserOverride: true,
-      dependencies: ["fireproof", "callai", "img-vibes", "web-audio"],
       fetch: async (url: RequestInfo | URL, _init?: RequestInit) => {
         console.log("Fetching asset for system prompt from URL:", url.toString(), vctx.params.pkgRepos.workspace);
         const uri = URI.from(url);
@@ -405,18 +403,31 @@ async function injectSystemPrompt(
         if (rRes.isErr()) {
           console.error("Failed to fetch asset for system prompt from URL:", url.toString(), "with error:", rRes.Err());
           return new Response(JSON.stringify({ error: rRes.Err() }), { status: 500 });
-          // return Result.Err(rRes);
         }
-        const res = new Response(rRes.Ok());
-        // res.clone().text().then((text) => {
-        //   console.log("Fetched asset for system prompt from URL:", url.toString(), "with content:", text);
-        // })
-        return res;
-        //   return Result.Ok(await new Response(rRes.Ok()).text());
+        return new Response(rRes.Ok());
       },
       callAi: {
-        ModuleAndOptionsSelection: async (_msgs: ChatMessage[]) => {
-          return Result.Err(`Module and options selection is not supported in system prompts at this time`);
+        ModuleAndOptionsSelection: async (msgs: ChatMessage[]) => {
+          try {
+            const res = await vctx.llmRequest({
+              model: "openai/gpt-4o",
+              messages: msgs,
+              stream: false,
+              max_tokens: 200,
+              headers: vctx.params.llm.headers,
+            });
+            if (!res.ok) {
+              return Result.Err(`RAG decision LLM call failed: ${res.status} ${res.statusText}`);
+            }
+            const body = (await res.json()) as { choices?: { message?: { content?: string } }[] };
+            const content = body.choices?.[0]?.message?.content;
+            if (!content) {
+              return Result.Err("RAG decision LLM returned no content");
+            }
+            return Result.Ok(content);
+          } catch (e) {
+            return Result.Err(`RAG decision LLM call error: ${e}`);
+          }
         },
       },
     })


### PR DESCRIPTION
## Summary

Rework of #1369 (which was prematurely merged via IDE misconfig and reverted in #1392). Same 22/-11 diff in `vibes.diy/api/svc/public/prompt-chat-section.ts`, opened here so the self-review items can be addressed before merging.

Enables the `selectLlmsAndOptions` RAG decision call server-side — previously hardcoded to skip with `dependenciesUserOverride: true`.

## Outstanding self-review (must fix before merge)

From #1369 comments on [prompt-chat-section.ts:409-413](https://github.com/VibesDIY/vibes.diy/blob/jchris/rag-enable-rework/vibes.diy/api/svc/public/prompt-chat-section.ts#L409-L413):

1. **L413** — model `"openai/gpt-4o"` is hardcoded. Use the existing config (likely `RAG_DECISION_MODEL`, per #431/#432).
2. **L409** — `callAi` key name is unclear in this context; rename or document.
3. **L412** — use callAI v2 schema instead of raw `vctx.llmRequest`. This also fixes the structured-output blocker (gpt-4o wraps JSON in markdown fences) via `response_format: { type: "json_object" }`.

## Known blocker (from original PR)

gpt-4o response is fenced JSON, parser fails, falls back to defaults gracefully. Fixed by adopting callAI v2 above.

## Next steps (once RAG works reliably)

1. Extend `selectLlmsAndOptions` to also return `title` and `iconPrompt` fields (see [notes/whats-next.md](https://github.com/VibesDIY/vibes.diy/blob/main/notes/whats-next.md)).
2. Queue handler writes `ActiveTitle` / `ActiveIcon` into `app_settings`.
3. WS push via `evt-app-setting` instead of 3s client poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)