### PR TITLE
Auto-allow database sharing for same-vibe DBs

### DIFF
--- a/vibes.diy/pkg/app/hooks/useShareableDB.ts
+++ b/vibes.diy/pkg/app/hooks/useShareableDB.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth, useClerk } from "@clerk/react";
+import { useParams } from "react-router";
 import { useVibesDiy } from "../vibes-diy-provider.js";
 import { isUserSettingSharing, type UserSettingSharing } from "@vibes.diy/api-types";
 import type { ResOkVibeRegisterFPDb } from "@vibes.diy/vibe-types";
@@ -18,6 +19,7 @@ export function useShareableDB() {
   const { srvVibeSandbox, vibeDiyApi } = useVibesDiy();
   const { isSignedIn, isLoaded } = useAuth();
   const clerk = useClerk();
+  const { userSlug: routeUserSlug, appSlug: routeAppSlug } = useParams<{ userSlug: string; appSlug: string }>();
 
   const [pendingDbRef, setPendingDbRef] = useState<ReturnType<typeof srvVibeSandbox.shareableDBs.get> | null>(null);
   const pendingDbRefRef = useRef<ReturnType<typeof srvVibeSandbox.shareableDBs.get> | null>(null);
@@ -39,13 +41,29 @@ export function useShareableDB() {
     });
   }, [srvVibeSandbox]);
 
+  // Auto-allow same-vibe DB registrations without prompting
+  const isSameVibe = pendingDbRef
+    ? pendingDbRef.data.appSlug === routeAppSlug && pendingDbRef.data.userSlug === routeUserSlug
+    : false;
+
   // Compute sharingState whenever pendingDbRef or auth status changes
   useEffect(() => {
-    // console.log(`Computing sharing state for pendingDbRef:`, pendingDbRef, isLoaded, isSignedIn);
     if (!pendingDbRef) {
       setSharingState(null);
       return;
     }
+
+    // Same-vibe DB: auto-allow without user prompt or settings check
+    if (isSameVibe) {
+      const v = pendingDbRefRef.current;
+      if (v) {
+        srvVibeSandbox.shareableDBs.set(v.key, { ...v, attachAction: "attach" });
+      }
+      setSharingState("allowed");
+      return;
+    }
+
+    // Cross-vibe DB: require authentication and explicit consent
     if (!isLoaded) {
       setSharingState("waiting");
       return;
@@ -78,7 +96,7 @@ export function useShareableDB() {
         setSharingState("ask");
       }
     });
-  }, [pendingDbRef, isLoaded, isSignedIn, vibeDiyApi]);
+  }, [pendingDbRef, isLoaded, isSignedIn, vibeDiyApi, isSameVibe]);
 
   // Auto-clear "allowed"/"denied" — existing grant, no dialog needed
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Skip the "Allow Database Sharing" modal when a vibe registers its own database (same appSlug + userSlug as the current route)
- Preserve the full consent flow (modal, user settings grants, login prompt) for cross-vibe DB requests only
- No cross-vibe DB access exists today, so the modal effectively never shows

## Test plan
- [ ] Open a vibe that uses Fireproof — confirm no sharing modal appears
- [ ] Verify database sync still works (cloud attach happens automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)