### PR TITLE
Prompt pre-allocation: LLM-driven title/slug + skills on first prompt

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1044,6 +1044,9 @@ importers:
       arktype:
         specifier: ^2.2.0
         version: 2.2.0
+      call-ai:
+        specifier: workspace:*
+        version: link:../../../call-ai/pkg
       cookie:
         specifier: ^1.1.1
         version: 1.1.1
@@ -3205,67 +3208,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -3651,48 +3666,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.121.0':
     resolution: {integrity: sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.121.0':
     resolution: {integrity: sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.121.0':
     resolution: {integrity: sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.121.0':
     resolution: {integrity: sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.121.0':
     resolution: {integrity: sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.121.0':
     resolution: {integrity: sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.121.0':
     resolution: {integrity: sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.121.0':
     resolution: {integrity: sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==}
@@ -3768,41 +3791,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -4119,36 +4150,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
@@ -4222,66 +4259,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -4481,24 +4531,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -4892,41 +4946,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -7073,6 +7135,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -7110,24 +7173,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -41,6 +41,27 @@ export async function getDefaultSkills(): Promise<string[]> {
   return ["fireproof", "callai", "img-vibes", "web-audio"];
 }
 
+/**
+ * Builds the user-message body for the pre-allocation LLM call. Includes the
+ * skill catalog (name + one-line description per entry) so the model can pick
+ * valid skill names, plus the user's raw prompt. Invalid names returned by the
+ * model are filtered out at read time (`makeBaseSystemPrompt` → catalog guard),
+ * so name-misses fail silently.
+ */
+export async function makePreAllocUserMessage(userPrompt: string): Promise<string> {
+  const catalog = await getLlmCatalog();
+  const catalogText = catalog.map((l) => `- ${l.name}: ${l.description}`).join("\n");
+  return [
+    "Pick skills from this catalog that fit the user's app request, and propose 3 title/slug pairs for naming.",
+    "",
+    "Skill catalog:",
+    catalogText,
+    "",
+    "User request:",
+    userPrompt,
+  ].join("\n");
+}
+
 export interface SystemPromptResult {
   systemPrompt: string;
   skills: string[];

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -43,13 +43,13 @@ export async function resolveEffectiveModel(
   return defaultCodingModel();
 }
 
-export async function getDefaultDependencies(): Promise<string[]> {
+export async function getDefaultSkills(): Promise<string[]> {
   return ["fireproof", "callai", "img-vibes", "web-audio"];
 }
 
 export interface SystemPromptResult {
   systemPrompt: string;
-  dependencies: string[];
+  skills: string[];
   demoData: boolean;
   model: string;
 }
@@ -308,7 +308,7 @@ export async function makeBaseSystemPrompt(
       includeDemoData
     );
 
-    if (selectedNames.length === 0) selectedNames = [...(await getDefaultDependencies())];
+    if (selectedNames.length === 0) selectedNames = [...(await getDefaultSkills())];
   }
   if (typeof sessionDoc?.demoDataOverride === "boolean") {
     includeDemoData = sessionDoc.demoDataOverride;
@@ -428,7 +428,7 @@ export async function makeBaseSystemPrompt(
 
   return {
     systemPrompt,
-    dependencies: selectedNames,
+    skills: selectedNames,
     demoData: includeDemoData,
     model,
   };

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -1,18 +1,12 @@
-// import { callAI, type Message, type CallAIOptions, Mocks } from "call-ai";
-
-import type { HistoryMessage, UserSettings } from "./settings.js";
-import { exception2Result, loadAsset, Result, KeyedResolvOnce } from "@adviser/cement";
+import type { UserSettings } from "./settings.js";
+import { loadAsset, KeyedResolvOnce } from "@adviser/cement";
 import { getLlmCatalog, getLlmCatalogNames, LlmCatalogEntry } from "./json-docs.js";
 
 // import { getTexts } from "./txt-docs.js";
 import { defaultStylePrompt } from "./style-prompts.js";
-import { ChatMessage } from "@vibes.diy/call-ai-v2";
 
 // Single source of truth for the default coding model used across the repo.
 export const DEFAULT_CODING_MODEL = "anthropic/claude-opus-4.5" as const;
-
-// Model used for RAG decisions (module selection)
-const RAG_DECISION_MODEL = "openai/gpt-4o" as const;
 
 async function defaultCodingModel() {
   return DEFAULT_CODING_MODEL;
@@ -82,164 +76,6 @@ export interface SystemPromptResult {
 //   );
 // });
 
-async function detectModulesInHistory(history: HistoryMessage[], _opts: LlmSelectionOptions): Promise<Set<string>> {
-  const detected = new Set<string>();
-  if (!Array.isArray(history)) return detected;
-  for (const msg of history) {
-    const content = msg?.content || "";
-    if (!content || typeof content !== "string") continue;
-    // for (const { name, named, def, namespace } of await llmImportRegexes()) {
-    //   if (named.test(content) || def.test(content) || namespace.test(content)) {
-    //     detected.add(name);
-    //   }
-    // }
-  }
-  return detected;
-}
-
-interface LlmSelectionDecisions {
-  selected: string[];
-  demoData: boolean;
-}
-
-interface LlmSelectionOptions {
-  readonly appMode?: "test" | "production";
-  // readonly callAiEndpoint?: CoerceURI;
-  fetch?: typeof fetch;
-
-  readonly callAi: {
-    ModuleAndOptionsSelection(msgs: ChatMessage[]): Promise<Result<string>>;
-  };
-
-  // readonly getAuthToken?: () => Promise<string>;
-  // readonly mock?: Mocks;
-}
-
-// type LlmSelectionWithoutGetTextUrl = Omit<LlmSelectionOptions, "getTextUrl" | "callAiEndpoint"> & {
-//   readonly fallBackUrl: CoerceURI;
-//   // readonly callAiEndpoint?: CoerceURI;
-// };
-
-// async function sleepReject<T>(ms: number) {
-//   return new Promise<T>((_, rj) => setTimeout(rj, ms));
-// }
-
-// move this to the other file along with referenced types
-async function selectLlmsAndOptions(
-  model: string,
-  userPrompt: string,
-  history: HistoryMessage[],
-  iopts: LlmSelectionOptions
-): Promise<LlmSelectionDecisions> {
-  const opts = {
-    ...iopts,
-    mode: iopts.appMode === "test" ? "test" : "production",
-  };
-  // const opts: LlmSelectionWithoutGetTextUrl = {
-  //   appMode: "production",
-  //   ...iopts,
-  //   callAiEndpoint: iopts.callAiEndpoint ? iopts.callAiEndpoint : undefined,
-  //   // fallBackUrl: URI.from(iopts.fallBackUrl ?? "https://esm.sh/use-vibes@0.18.9/prompt-catalog/llms").toString(),
-  //   // getAuthToken: iopts.getAuthToken,
-  // };
-  const llmsCatalog = await getLlmCatalog();
-  const catalog = llmsCatalog.map((l) => ({
-    name: l.name,
-    description: l.description || "",
-  }));
-  const payload = {
-    catalog,
-    userPrompt: userPrompt || "",
-    history: history || [],
-  };
-
-  const messages: ChatMessage[] = [
-    {
-      role: "system",
-      content: [
-        {
-          type: "text",
-          text: `You select which library modules from a catalog should 
-         be included AND whether to include a demo-data button. 
-         First analyze if the user prompt describes specific 
-         look & feel requirements. For demo data: include it 
-         only when asked for. Read the JSON payload and return 
-         JSON with properties: 
-         "selected" (array of catalog "name" strings) and "demoData" (boolean). 
-         Only choose modules from the catalog. Include any 
-         libraries already used in history. Respond with JSON only.`,
-        },
-      ],
-    },
-    { role: "user", content: [{ type: "text", text: JSON.stringify(payload) }] },
-  ];
-
-  // const options: CallAIOptions = {
-  //   chatUrl: opts.callAiEndpoint ? opts.callAiEndpoint.toString().replace(/\/+$/, "") : undefined,
-  //   apiKey: (await opts.getAuthToken?.()) || "",
-  //   model,
-  //   schema: {
-  //     name: "module_and_options_selection",
-  //     properties: {
-  //       selected: { type: "array", items: { type: "string" } },
-  //       demoData: { type: "boolean" },
-  //     },
-  //   },
-  //   max_tokens: 2000,
-  //   headers: {
-  //     "HTTP-Referer": "https://vibes.diy",
-  //     "X-Title": "Vibes DIY",
-  //   },
-  //   mock: opts.mock,
-  // };
-
-  const rRaw = await opts.callAi.ModuleAndOptionsSelection(messages);
-  if (rRaw.isErr()) {
-    console.warn("Module/options selection call failed:", rRaw.Err());
-    return { selected: [], demoData: true };
-  }
-
-  // try {
-  // const withTimeout = <T>(p: Promise<T>, ms = 4000): Promise<T> =>
-  //   Promise.race([
-  //     sleepReject<T>(ms).then((val) => {
-  //       console.warn("Module/options selection: API call timed out after", ms, "ms");
-  //       return val;
-  //     }),
-  //     p
-  //       .then((val) => {
-  //         return val;
-  //       })
-  //       .catch((err) => {
-  //         console.warn("Module/options selection: API call failed with error:", err);
-  //         throw err;
-  //       }),
-  //   ]);
-
-  // const raw = (await withTimeout((options.mock?.callAI || callAI)(messages, options))) as string;
-
-  // if (raw === undefined || raw === null) {
-  //   console.warn("Module/options selection: call-ai returned undefined with schema present");
-  //   console.warn("This is a known issue in the prompts package environment");
-  //   return { selected: [], demoData: true };
-  // }
-
-  const rParsed = exception2Result(() => JSON.parse(rRaw.Ok()) ?? {});
-  if (rParsed.isErr()) {
-    console.warn("Module/options selection: Failed to parse JSON response:", rRaw.Ok());
-    return { selected: [], demoData: true };
-  }
-  const parsed = rParsed.Ok();
-  const selected = Array.isArray(parsed?.selected) ? parsed.selected.filter((v: unknown) => typeof v === "string") : [];
-  const demoData = typeof parsed?.demoData === "boolean" ? parsed.demoData : true;
-
-  return { selected, demoData };
-  // } catch (err) {
-  //   console.warn("Module/options selection call failed:", err);
-  //   return { selected: [], demoData: true };
-  // }
-}
-
 export function generateImportStatements(llms: LlmCatalogEntry[]) {
   const seen = new Set<string>();
   return llms
@@ -269,50 +105,26 @@ export function generateImportStatements(llms: LlmCatalogEntry[]) {
 
 const keyedLoadAsset = new KeyedResolvOnce();
 
-// move this function to its own file along with generateImportStatements and selectLlmsAndOptions, and rexport from here
+export interface MakeBaseSystemPromptOptions {
+  fetch?: typeof fetch;
+}
+
 export async function makeBaseSystemPrompt(
   model: string,
-  sessionDoc: Partial<UserSettings> & LlmSelectionOptions
+  sessionDoc: Partial<UserSettings> & MakeBaseSystemPromptOptions
 ): Promise<SystemPromptResult> {
   const userPrompt = sessionDoc?.userPrompt || "";
-  const history: HistoryMessage[] = Array.isArray(sessionDoc?.history) ? sessionDoc.history : [];
-  const useOverride = !!sessionDoc?.dependenciesUserOverride;
-
-  let selectedNames: string[] = [];
-  let includeDemoData = true;
-
   const llmsCatalog = await getLlmCatalog();
   const llmsCatalogNames = await getLlmCatalogNames();
 
-  if (useOverride) {
-    selectedNames = (sessionDoc.dependencies ?? [])
-      .filter((v): v is string => typeof v === "string")
-      .filter((name) => llmsCatalogNames.has(name));
-    console.log("[makeBaseSystemPrompt] user override dependencies:", selectedNames);
-  } else {
-    const decisions = await selectLlmsAndOptions(RAG_DECISION_MODEL, userPrompt, history, sessionDoc);
-    includeDemoData = decisions.demoData;
-
-    const detected = await detectModulesInHistory(history, sessionDoc);
-    const finalNames = new Set<string>([...decisions.selected, ...detected]);
-    selectedNames = Array.from(finalNames);
-
-    console.log(
-      "[makeBaseSystemPrompt] RAG selected:",
-      decisions.selected,
-      "detected:",
-      [...detected],
-      "final:",
-      selectedNames,
-      "demoData:",
-      includeDemoData
-    );
-
-    if (selectedNames.length === 0) selectedNames = [...(await getDefaultSkills())];
+  const rawSkills = Array.isArray(sessionDoc?.skills) ? sessionDoc.skills : undefined;
+  let selectedNames = rawSkills
+    ? rawSkills.filter((v): v is string => typeof v === "string").filter((name) => llmsCatalogNames.has(name))
+    : [];
+  if (selectedNames.length === 0) {
+    selectedNames = [...(await getDefaultSkills())];
   }
-  if (typeof sessionDoc?.demoDataOverride === "boolean") {
-    includeDemoData = sessionDoc.demoDataOverride;
-  }
+  const includeDemoData = sessionDoc?.demoData === true;
 
   const chosenLlms = llmsCatalog.filter((l) => selectedNames.includes(l.name));
   console.log(

--- a/prompts/pkg/prompts.ts
+++ b/prompts/pkg/prompts.ts
@@ -1,6 +1,7 @@
 import type { UserSettings } from "./settings.js";
 import { loadAsset, KeyedResolvOnce } from "@adviser/cement";
 import { getLlmCatalog, getLlmCatalogNames, LlmCatalogEntry } from "./json-docs.js";
+import { type } from "arktype";
 
 // import { getTexts } from "./txt-docs.js";
 import { defaultStylePrompt } from "./style-prompts.js";
@@ -61,6 +62,40 @@ export async function makePreAllocUserMessage(userPrompt: string): Promise<strin
     userPrompt,
   ].join("\n");
 }
+
+/**
+ * callAI schema for the pre-allocation call — the two halves of the pre-alloc
+ * contract (user message + schema) live together here so descriptions stay in
+ * sync with the message composition above.
+ */
+export const preAllocSchema = {
+  name: "pre_alloc",
+  properties: {
+    skills: {
+      type: "array",
+      description: "Selected skill names from the catalog above, appropriate for the app described by the user prompt. Only use names present in the catalog.",
+      items: { type: "string" },
+    },
+    pairs: {
+      type: "array",
+      description: "Exactly 3 title/slug pairs ranked by fit. Title in Title Case, 1-4 words. Slug in kebab-case derived from title.",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          slug: { type: "string" },
+        },
+      },
+    },
+  },
+} as const;
+
+/** arktype validator for parsed pre-alloc responses. Matches preAllocSchema. */
+export const preAllocParsed = type({
+  skills: type("string").array(),
+  pairs: type({ title: "string", slug: "string" }).array(),
+});
+export type PreAllocParsed = typeof preAllocParsed.infer;
 
 export interface SystemPromptResult {
   systemPrompt: string;

--- a/prompts/pkg/settings.ts
+++ b/prompts/pkg/settings.ts
@@ -1,8 +1,3 @@
-export interface HistoryMessage {
-  role: "user" | "assistant" | "system";
-  content: string;
-}
-
 /**
  * User settings for the application
  */
@@ -22,11 +17,9 @@ export interface UserSettings {
   /** Whether to show the per‑chat model picker in the chat UI */
   showModelPickerInChat?: boolean; // default false
 
-  history?: HistoryMessage[];
+  /** Pre-resolved skill names chosen for this app (from pre-allocation). */
+  skills?: string[];
 
-  dependenciesUserOverride?: boolean;
-
-  dependencies?: string[];
-
-  demoDataOverride?: boolean;
+  /** Whether to include a demo-data button. Default false. */
+  demoData?: boolean;
 }

--- a/prompts/tests/prompt-builder.test.ts
+++ b/prompts/tests/prompt-builder.test.ts
@@ -84,17 +84,6 @@ let orderedLlms: LlmCatalogEntry[];
 
 const opts = {
   fetchText: mockFetchText,
-  callAi: {
-    ModuleAndOptionsSelection: vi.fn().mockResolvedValue(
-      Result.Ok(
-        JSON.stringify({
-          selected: knownModuleNames,
-          instructionalText: true,
-          demoData: true,
-        })
-      )
-    ),
-  },
 };
 
 beforeAll(async () => {
@@ -262,50 +251,31 @@ describe("prompt builder (real implementation)", () => {
     expect(result.systemPrompt).toContain("hello");
   });
 
-  it("makeBaseSystemPrompt: honors explicit dependencies only when override=true", async () => {
-    // await preloadLlmsText();
+  it("makeBaseSystemPrompt: honors explicit skills", async () => {
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
-      dependencies: ["fireproof"],
-      dependenciesUserOverride: true,
+      skills: ["fireproof"],
     });
     expect(result.systemPrompt).toContain("<useFireproof-docs>");
     expect(result.systemPrompt).not.toContain("<callAI-docs>");
   });
 
-  it("makeBaseSystemPrompt: includes demo-data guidance when selector enables it (test mode)", async () => {
-    // await preloadLlmsText();
+  it("makeBaseSystemPrompt: demoData=false (default) hides demo-data guidance", async () => {
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
       stylePrompt: undefined,
       userPrompt: undefined,
-      history: [],
-    });
-    expect(result.systemPrompt).toMatch(/include a Demo Data button/i);
-    expect(result.systemPrompt).not.toMatch(/vivid description of the app's purpose/i);
-  });
-
-  it("makeBaseSystemPrompt: respects demoDataOverride=false to disable demo data", async () => {
-    // await preloadLlmsText();
-    const result = await makeBaseSystemPrompt("test-model", {
-      ...opts,
-      stylePrompt: undefined,
-      userPrompt: undefined,
-      history: [],
-      demoDataOverride: false,
     });
     expect(result.systemPrompt).not.toMatch(/include a Demo Data button/i);
     expect(result.systemPrompt).not.toMatch(/vivid description of the app's purpose/i);
   });
 
-  it("makeBaseSystemPrompt: respects demoDataOverride=true to force demo data", async () => {
-    // await preloadLlmsText();
+  it("makeBaseSystemPrompt: demoData=true enables demo-data guidance", async () => {
     const result = await makeBaseSystemPrompt("test-model", {
       ...opts,
       stylePrompt: undefined,
       userPrompt: undefined,
-      history: [],
-      demoDataOverride: true,
+      demoData: true,
     });
     expect(result.systemPrompt).toMatch(/include a Demo Data button/i);
     expect(result.systemPrompt).not.toMatch(/vivid description of the app's purpose/i);

--- a/prompts/tests/prompts-dependencies.integration.test.ts
+++ b/prompts/tests/prompts-dependencies.integration.test.ts
@@ -40,56 +40,38 @@ beforeEach(() => {
 
 const opts = {
   fetchText: mockFetchText,
-  callAi: {
-    ModuleAndOptionsSelection: vi.fn().mockResolvedValue(
-      Result.Ok(
-        JSON.stringify({
-          choices: [{ message: { content: "Mocked response" } }],
-        })
-      )
-    ),
-  },
 };
 
-describe("makeBaseSystemPrompt dependency selection", () => {
-  it("when override is false/absent, uses schema-driven selection (test mode => all); includes core libs", async () => {
-    // await preloadLlmsText();
+describe("makeBaseSystemPrompt skill selection", () => {
+  it("no skills provided: uses defaults (fireproof + callai + ...) ", async () => {
     const result = await mod.makeBaseSystemPrompt("anthropic/claude-sonnet-4.5", {
       ...opts,
       _id: "user_settings",
     });
-    // Should include at least the core libs
     expect(result.systemPrompt).toMatch(/<useFireproof-docs>/);
     expect(result.systemPrompt).toMatch(/<callAI-docs>/);
-    // Should include corresponding import lines
     expect(result.systemPrompt).toMatch(/import\s+\{\s*useFireproof\s*\}\s+from\s+"use-fireproof"/);
     expect(result.systemPrompt).toMatch(/import\s+\{\s*callAI\s*\}\s+from\s+"call-ai"/);
   });
 
-  it("honors explicit dependencies only when override=true", async () => {
-    // await preloadLlmsText();
+  it("honors explicit skills", async () => {
     const result = await mod.makeBaseSystemPrompt("anthropic/claude-sonnet-4.5", {
       _id: "user_settings",
-      dependencies: ["fireproof"],
-      dependenciesUserOverride: true,
+      skills: ["fireproof"],
       ...opts,
     });
     expect(result.systemPrompt).toMatch(/<useFireproof-docs>/);
     expect(result.systemPrompt).not.toMatch(/<callAI-docs>/);
-    // Import statements reflect chosen modules only
     expect(result.systemPrompt).toMatch(/import\s+\{\s*useFireproof\s*\}\s+from\s+"use-fireproof"/);
     expect(result.systemPrompt).not.toMatch(/from\s+"call-ai"/);
   });
 
-  it("ignores explicit dependencies when override=false (still schema-driven)", async () => {
-    // await preloadLlmsText();
+  it("empty skills array falls back to defaults", async () => {
     const result = await mod.makeBaseSystemPrompt("anthropic/claude-sonnet-4.5", {
       _id: "user_settings",
-      dependencies: ["fireproof"],
-      dependenciesUserOverride: false,
+      skills: [],
       ...opts,
     });
-    // Should include at least both core libs
     expect(result.systemPrompt).toMatch(/<useFireproof-docs>/);
     expect(result.systemPrompt).toMatch(/<callAI-docs>/);
   });

--- a/prompts/tests/prompts.test.ts
+++ b/prompts/tests/prompts.test.ts
@@ -1,5 +1,4 @@
 import { vi, describe, it, expect, beforeEach } from "vitest";
-import { Result } from "@adviser/cement";
 import { makeBaseSystemPrompt } from "@vibes.diy/prompts";
 
 // We need to mock the module properly, not test the real implementation yet
@@ -8,8 +7,8 @@ vi.mock("@vibes.diy/prompts", async () => {
   return {
     makeBaseSystemPrompt: vi.fn().mockResolvedValue({
       systemPrompt: "mocked system prompt",
-      dependencies: ["fireproof", "callai"],
-      demoData: true,
+      skills: ["fireproof", "callai"],
+      demoData: false,
       model: "test-model",
     }),
   };
@@ -17,9 +16,7 @@ vi.mock("@vibes.diy/prompts", async () => {
 
 describe("Prompts Utility", () => {
   const opts = {
-    callAi: {
-      ModuleAndOptionsSelection: vi.fn().mockResolvedValue(Result.Ok("{}")),
-    },
+    skills: ["fireproof", "callai"],
   };
   beforeEach(() => {
     vi.clearAllMocks();

--- a/prompts/tests/settings-prompt.test.ts
+++ b/prompts/tests/settings-prompt.test.ts
@@ -77,7 +77,7 @@ import { callAI } from "call-ai"
 
       return {
         systemPrompt,
-        dependencies: ["fireproof", "callai"],
+        skills: ["fireproof", "callai"],
         demoData: true,
         model,
       };
@@ -97,7 +97,7 @@ describe("Settings and Prompt Integration", () => {
   it("generates a base system prompt with default values when no settings provided", async () => {
     const model = "test-model";
     const result = await makeBaseSystemPrompt(model, {
-      callAi: { ModuleAndOptionsSelection: vi.fn() },
+
     });
 
     // Check that the prompt includes the default style
@@ -112,7 +112,7 @@ describe("Settings and Prompt Integration", () => {
     const settingsDoc = {
       _id: "user_settings",
       stylePrompt: "synthwave (80s digital aesthetic)",
-      callAi: { ModuleAndOptionsSelection: vi.fn() },
+
     };
 
     const result = await makeBaseSystemPrompt(model, settingsDoc);
@@ -128,7 +128,7 @@ describe("Settings and Prompt Integration", () => {
     const settingsDoc = {
       _id: "user_settings",
       userPrompt: userPromptText,
-      callAi: { ModuleAndOptionsSelection: vi.fn() },
+
     };
 
     const result = await makeBaseSystemPrompt(model, settingsDoc);
@@ -145,7 +145,7 @@ describe("Settings and Prompt Integration", () => {
       _id: "user_settings",
       stylePrompt: stylePromptText,
       userPrompt: userPromptText,
-      callAi: { ModuleAndOptionsSelection: vi.fn() },
+
     };
 
     const result = await makeBaseSystemPrompt(model, settingsDoc);
@@ -160,7 +160,7 @@ describe("Settings and Prompt Integration", () => {
     const model = "test-model";
     const settingsDoc = {
       _id: "user_settings",
-      callAi: { ModuleAndOptionsSelection: vi.fn() },
+
     };
 
     const result = await makeBaseSystemPrompt(model, settingsDoc);
@@ -172,7 +172,7 @@ describe("Settings and Prompt Integration", () => {
   it("includes LLM documentation in the prompt", async () => {
     const model = "test-model";
     const result = await makeBaseSystemPrompt(model, {
-      callAi: { ModuleAndOptionsSelection: vi.fn() },
+
     });
 
     // Check that the LLM documentation is included

--- a/use-vibes/base/hooks/vibes-gen/use-vibes.ts
+++ b/use-vibes/base/hooks/vibes-gen/use-vibes.ts
@@ -123,10 +123,10 @@ export function useVibes(
         } catch (error) {
           // Fallback to a simple but functional system prompt
           result = {
-            systemPrompt: `You are a React component generator. Generate a complete React component based on the user's prompt. 
+            systemPrompt: `You are a React component generator. Generate a complete React component based on the user's prompt.
 Use Fireproof for data persistence. Begin the component with the import statements.
 Return only the JSX code with a default export. Use modern React patterns with hooks if needed.`,
-            dependencies: options.dependencies || ["useFireproof"],
+            skills: options.dependencies || ["useFireproof"],
             demoData: false,
             model: options.model || "anthropic/claude-sonnet-4.5",
           };
@@ -134,8 +134,8 @@ Return only the JSX code with a default export. Use modern React patterns with h
 
         const systemPrompt = result.systemPrompt;
         const metadata = {
-          dependencies: result.dependencies,
-          aiSelectedDependencies: result.dependencies,
+          dependencies: result.skills,
+          aiSelectedDependencies: result.skills,
           demoData: result.demoData,
           model: result.model,
           timestamp: Date.now(),

--- a/use-vibes/base/hooks/vibes-gen/use-vibes.ts
+++ b/use-vibes/base/hooks/vibes-gen/use-vibes.ts
@@ -109,16 +109,8 @@ export function useVibes(
         try {
           result = await makeBaseSystemPrompt(options.model || "anthropic/claude-sonnet-4.5", {
             userPrompt: prompt,
-            history: [],
-            callAi: {
-              ModuleAndOptionsSelection: () => {
-                throw new Error("ModuleAndOptionsSelection not implemented in Cycle 1");
-              },
-            },
-            // fallBackUrl: "https://esm.sh/@vibes.diy/prompts/llms",
-            // Pass through any user overrides
-            dependencies: options.dependencies,
-            dependenciesUserOverride: !!options.dependencies,
+            skills: options.dependencies,
+            demoData: false,
           });
         } catch (error) {
           // Fallback to a simple but functional system prompt

--- a/vibes-diy/cli/cmds/system-cmd.ts
+++ b/vibes-diy/cli/cmds/system-cmd.ts
@@ -43,13 +43,8 @@ export const systemEvento: EventoHandler<WrapCmdTSMsg<unknown>, ReqSystem, ResSy
   handle: async (ctx: HandleTriggerCtx<WrapCmdTSMsg<unknown>, ReqSystem, ResSystem>): Promise<Result<EventoResultType>> => {
     const rPrompt = await exception2Result(() =>
       makeBaseSystemPrompt("cli", {
-        dependenciesUserOverride: true,
-        dependencies: ["fireproof", "callai", "img-vibes", "web-audio"],
-        callAi: {
-          ModuleAndOptionsSelection() {
-            return Promise.resolve(Result.Err("ModuleAndOptionsSelection is not used by CLI"));
-          },
-        },
+        skills: ["fireproof", "callai", "img-vibes", "web-audio"],
+        demoData: false,
       })
     );
     if (rPrompt.isErr()) {

--- a/vibes.diy/api/svc/create-handler.ts
+++ b/vibes.diy/api/svc/create-handler.ts
@@ -200,6 +200,8 @@ export async function createAppContext<T extends VibesSqlite>(
       // }) as LLMDefault,
       enforced: LLMEnforced({}) as LLMEnforced,
       headers: LLMHeaders({}) as LLMHeaders,
+      url: envVals.LLM_BACKEND_URL,
+      apiKey: envVals.LLM_BACKEND_API_KEY,
     },
     assetCacheUrl: "https://asset-cache.vibes.app/{assetId}",
     // importMapProps: {

--- a/vibes.diy/api/svc/intern/ensure-chat-id.ts
+++ b/vibes.diy/api/svc/intern/ensure-chat-id.ts
@@ -2,7 +2,8 @@ import { and, eq } from "drizzle-orm/sql/expressions";
 import { VibesApiSQLCtx } from "../types.js";
 import { exception2Result, Result } from "@adviser/cement";
 import { ensureUserSlug, ensureAppSlug, getDefaultUserSlug, persistDefaultUserSlug } from "./ensure-slug-binding.js";
-import { ReqOpenChat, ReqWithVerifiedAuth } from "@vibes.diy/api-types";
+import { preAllocate } from "./pre-allocate.js";
+import { ActiveEntry, ActiveSkills, ActiveTitle, EvtAppSetting, MsgBase, ReqOpenChat, ReqWithVerifiedAuth } from "@vibes.diy/api-types";
 
 interface EnsureChatIdPResult {
   appSlug: string;
@@ -80,11 +81,28 @@ export async function ensureChatId(
     }
 
     if (!chatId) {
-      const resApp = await ensureAppSlug(ctx, { userId, userSlug, appSlug: req.appSlug });
+      // Pre-allocation: when the caller passed a prompt and no appSlug, run one
+      // LLM call to pick {skills, pairs: [{title, slug}] × 3}. Feed pairs to
+      // ensureAppSlug so the URL slug reflects the prompt; persist the chosen
+      // pair's title and the skill list into app_settings below.
+      let preferredPairs: { title: string; slug: string }[] | undefined;
+      let preAllocSkills: string[] | undefined;
+      if (req.prompt && !req.appSlug) {
+        const rPre = await preAllocate(ctx, { prompt: req.prompt });
+        if (rPre.isOk()) {
+          preferredPairs = rPre.Ok().pairs;
+          preAllocSkills = rPre.Ok().skills;
+        } else {
+          console.warn("preAllocate failed; falling through to random-words:", rPre.Err());
+        }
+      }
+
+      const resApp = await ensureAppSlug(ctx, { userId, userSlug, appSlug: req.appSlug, preferredPairs });
       if (resApp.isErr()) {
         return Result.Err(`Failed to ensure appSlug: ${resApp.Err().message}`);
       }
       appSlug = resApp.Ok().appSlug;
+      const chosenTitle = resApp.Ok().chosenTitle;
       chatId = ctx.sthis.nextId(12).str;
       await ctx.sql.db.insert(ctx.sql.tables.chatContexts).values({
         chatId,
@@ -93,7 +111,54 @@ export async function ensureChatId(
         userSlug,
         created: new Date().toISOString(),
       });
+
+      if (chosenTitle || preAllocSkills) {
+        await writePreAllocActiveEntries(ctx, {
+          userId,
+          userSlug,
+          appSlug,
+          title: chosenTitle,
+          skills: preAllocSkills,
+        });
+      }
     }
   }
   return Result.Ok({ appSlug, userSlug, chatId });
+}
+
+async function writePreAllocActiveEntries(
+  ctx: VibesApiSQLCtx,
+  { userId, userSlug, appSlug, title, skills }: { userId: string; userSlug: string; appSlug: string; title?: string; skills?: string[] }
+): Promise<void> {
+  const now = new Date().toISOString();
+  const entries: ActiveEntry[] = [];
+  if (title) {
+    entries.push({ type: "active.title", title } satisfies ActiveTitle);
+  }
+  if (skills) {
+    entries.push({ type: "active.skills", skills } satisfies ActiveSkills);
+  }
+  if (entries.length === 0) return;
+  await exception2Result(() =>
+    ctx.sql.db.insert(ctx.sql.tables.appSettings).values({
+      userId,
+      userSlug,
+      appSlug,
+      settings: entries,
+      updated: now,
+      created: now,
+    })
+  );
+  await ctx.postQueue({
+    payload: {
+      type: "vibes.diy.evt-app-setting",
+      userSlug,
+      appSlug,
+      settings: entries,
+    },
+    tid: "queue-event",
+    src: "ensureChatId",
+    dst: "vibes-service",
+    ttl: 1,
+  } satisfies MsgBase<EvtAppSetting>);
 }

--- a/vibes.diy/api/svc/intern/ensure-chat-id.ts
+++ b/vibes.diy/api/svc/intern/ensure-chat-id.ts
@@ -1,6 +1,7 @@
 import { and, eq } from "drizzle-orm/sql/expressions";
 import { VibesApiSQLCtx } from "../types.js";
 import { exception2Result, Result } from "@adviser/cement";
+import { ensureLogger } from "@fireproof/core-runtime";
 import { ensureUserSlug, ensureAppSlug, getDefaultUserSlug, persistDefaultUserSlug } from "./ensure-slug-binding.js";
 import { preAllocate } from "./pre-allocate.js";
 import { ActiveEntry, ActiveSkills, ActiveTitle, EvtAppSetting, MsgBase, ReqOpenChat, ReqWithVerifiedAuth } from "@vibes.diy/api-types";
@@ -135,11 +136,11 @@ async function writePreAllocActiveEntries(
   if (title) {
     entries.push({ type: "active.title", title } satisfies ActiveTitle);
   }
-  if (skills) {
+  if (skills && skills.length > 0) {
     entries.push({ type: "active.skills", skills } satisfies ActiveSkills);
   }
   if (entries.length === 0) return;
-  await exception2Result(() =>
+  const rIns = await exception2Result(() =>
     ctx.sql.db.insert(ctx.sql.tables.appSettings).values({
       userId,
       userSlug,
@@ -149,6 +150,13 @@ async function writePreAllocActiveEntries(
       created: now,
     })
   );
+  if (rIns.isErr()) {
+    ensureLogger(ctx.sthis, "writePreAllocActiveEntries")
+      .Error()
+      .Any({ err: rIns.Err(), userSlug, appSlug })
+      .Msg("appSettings insert failed; skipping evt-app-setting");
+    return;
+  }
   await ctx.postQueue({
     payload: {
       type: "vibes.diy.evt-app-setting",

--- a/vibes.diy/api/svc/intern/ensure-slug-binding.ts
+++ b/vibes.diy/api/svc/intern/ensure-slug-binding.ts
@@ -175,13 +175,35 @@ async function writeAppSlugBinding(
 
 export async function ensureAppSlug(
   ctx: VibesApiSQLCtx,
-  binding: (OptAppSlugUserSlug | AppSlugUserSlug) & { userId: string }
-): Promise<Result<AppSlugBinding>> {
-  return exception2Result(async (): Promise<Result<AppSlugBinding>> => {
+  binding: (OptAppSlugUserSlug | AppSlugUserSlug) & {
+    userId: string;
+    preferredPairs?: { title: string; slug: string }[];
+  }
+): Promise<Result<AppSlugBinding & { chosenTitle?: string }>> {
+  return exception2Result(async (): Promise<Result<AppSlugBinding & { chosenTitle?: string }>> => {
     let appSlug: string | undefined = undefined;
+    let chosenTitle: string | undefined = undefined;
     if (!binding.appSlug) {
+      // Walk LLM-provided preferred pairs first; each supplies its own title.
+      for (const pair of binding.preferredPairs ?? []) {
+        const sanitized = toRFC2822_32ByteLength(pair.slug);
+        if (!sanitized) continue;
+        const existing = await ctx.sql.db
+          .select()
+          .from(ctx.sql.tables.appSlugBinding)
+          .where(eq(ctx.sql.tables.appSlugBinding.appSlug, sanitized))
+          .limit(1)
+          .then((r) => r[0]);
+        if (!existing) {
+          appSlug = sanitized;
+          chosenTitle = pair.title;
+          break;
+        }
+      }
+      // Fall through to random-words for remaining attempts (5 total).
+      const randomAttempts = Math.max(0, 5 - (binding.preferredPairs?.length ?? 0));
       // should be a transaction but CF - oh well
-      for (let attempts = 0; attempts < 5; attempts++) {
+      for (let attempts = 0; !appSlug && attempts < randomAttempts; attempts++) {
         const tryAppSlug = generate({
           exactly: 1,
           wordsPerString: 3,
@@ -205,7 +227,9 @@ export async function ensureAppSlug(
       if (!appSlug) {
         return Result.Err("could not generate unique appSlug after 5 attempts");
       }
-      return writeAppSlugBinding(ctx, binding.userId, binding.userSlug, appSlug);
+      const rWrite = await writeAppSlugBinding(ctx, binding.userId, binding.userSlug, appSlug);
+      if (rWrite.isErr()) return rWrite;
+      return Result.Ok({ ...rWrite.Ok(), chosenTitle });
     } else {
       const sanitizedAppSlug = toRFC2822_32ByteLength(binding.appSlug);
       const existing = await ctx.sql.db

--- a/vibes.diy/api/svc/intern/pre-allocate.ts
+++ b/vibes.diy/api/svc/intern/pre-allocate.ts
@@ -36,6 +36,8 @@ const preAllocSchema = {
   },
 };
 
+const PRE_ALLOC_TIMEOUT_MS = 8000;
+
 /**
  * Pre-allocation LLM call: takes the user's initial prompt and asks one
  * structured call for {skills, pairs}. The caller hands pairs to
@@ -45,6 +47,10 @@ const preAllocSchema = {
  * Model: resolved via loadModels → `preSelected: ["app"]` entry in
  * models.json (currently openai/gpt-5.4-mini). No user/app overrides;
  * pre-alloc stays deterministic across users.
+ *
+ * Timeout: racing against PRE_ALLOC_TIMEOUT_MS. On timeout or any error
+ * the caller (ensureChatId) falls through to random-words slug + default
+ * skills — the user sees a random slug instead of blocking.
  */
 export async function preAllocate(vctx: VibesApiSQLCtx, { prompt }: { prompt: string }): Promise<Result<PreAllocateResult>> {
   const rModels = await loadModels(vctx);
@@ -52,13 +58,19 @@ export async function preAllocate(vctx: VibesApiSQLCtx, { prompt }: { prompt: st
   const appDefault = rModels.Ok().models.find((m) => m.preSelected?.includes("app"));
   if (!appDefault) return Result.Err("no preSelected app model in catalog");
 
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`pre-alloc LLM call timed out after ${PRE_ALLOC_TIMEOUT_MS}ms`)), PRE_ALLOC_TIMEOUT_MS)
+  );
   const rCall = await exception2Result(() =>
-    callAI(prompt, {
-      model: appDefault.id,
-      endpoint: vctx.params.llm.url,
-      apiKey: vctx.params.llm.apiKey,
-      schema: preAllocSchema,
-    })
+    Promise.race([
+      callAI(prompt, {
+        model: appDefault.id,
+        endpoint: vctx.params.llm.url,
+        apiKey: vctx.params.llm.apiKey,
+        schema: preAllocSchema,
+      }),
+      timeout,
+    ])
   );
   if (rCall.isErr()) return Result.Err(rCall);
   const raw = rCall.Ok();

--- a/vibes.diy/api/svc/intern/pre-allocate.ts
+++ b/vibes.diy/api/svc/intern/pre-allocate.ts
@@ -1,6 +1,7 @@
 import { Result, exception2Result } from "@adviser/cement";
 import { callAI } from "call-ai";
 import { type } from "arktype";
+import { makePreAllocUserMessage } from "@vibes.diy/prompts";
 import { VibesApiSQLCtx } from "../types.js";
 import { loadModels } from "../public/list-models.js";
 
@@ -19,7 +20,7 @@ const preAllocSchema = {
   properties: {
     skills: {
       type: "array",
-      description: "Selected capability names from the catalog, appropriate for the app described by the prompt.",
+      description: "Selected skill names from the catalog above, appropriate for the app described by the user prompt. Only use names present in the catalog.",
       items: { type: "string" },
     },
     pairs: {
@@ -58,12 +59,14 @@ export async function preAllocate(vctx: VibesApiSQLCtx, { prompt }: { prompt: st
   const appDefault = rModels.Ok().models.find((m) => m.preSelected?.includes("app"));
   if (!appDefault) return Result.Err("no preSelected app model in catalog");
 
+  const userMessage = await makePreAllocUserMessage(prompt);
+
   const timeout = new Promise<never>((_, reject) =>
     setTimeout(() => reject(new Error(`pre-alloc LLM call timed out after ${PRE_ALLOC_TIMEOUT_MS}ms`)), PRE_ALLOC_TIMEOUT_MS)
   );
   const rCall = await exception2Result(() =>
     Promise.race([
-      callAI(prompt, {
+      callAI(userMessage, {
         model: appDefault.id,
         endpoint: vctx.params.llm.url,
         apiKey: vctx.params.llm.apiKey,

--- a/vibes.diy/api/svc/intern/pre-allocate.ts
+++ b/vibes.diy/api/svc/intern/pre-allocate.ts
@@ -1,7 +1,8 @@
 import { Result, exception2Result } from "@adviser/cement";
 import { callAI } from "call-ai";
 import { type } from "arktype";
-import { makePreAllocUserMessage, preAllocParsed, preAllocSchema } from "@vibes.diy/prompts";
+import { ensureLogger } from "@fireproof/core-runtime";
+import { getLlmCatalogNames, makePreAllocUserMessage, preAllocParsed, preAllocSchema } from "@vibes.diy/prompts";
 import { VibesApiSQLCtx } from "../types.js";
 import { loadModels } from "../public/list-models.js";
 
@@ -64,8 +65,18 @@ export async function preAllocate(vctx: VibesApiSQLCtx, { prompt }: { prompt: st
   if (validated.pairs.length === 0) {
     return Result.Err("pre-alloc returned zero title/slug pairs");
   }
+
+  const catalogNames = await getLlmCatalogNames();
+  const validSkills = validated.skills.filter((s) => catalogNames.has(s));
+  if (validated.skills.length > 0 && validSkills.length === 0) {
+    ensureLogger(vctx.sthis, "preAllocate")
+      .Warn()
+      .Any({ rawSkills: validated.skills })
+      .Msg("all pre-alloc skills missed catalog");
+  }
+
   return Result.Ok({
-    skills: validated.skills,
+    skills: validSkills,
     pairs: validated.pairs.slice(0, 3),
   });
 }

--- a/vibes.diy/api/svc/intern/pre-allocate.ts
+++ b/vibes.diy/api/svc/intern/pre-allocate.ts
@@ -1,0 +1,83 @@
+import { Result, exception2Result } from "@adviser/cement";
+import { callAI } from "call-ai";
+import { type } from "arktype";
+import { VibesApiSQLCtx } from "../types.js";
+import { loadModels } from "../public/list-models.js";
+
+export interface PreAllocateResult {
+  skills: string[];
+  pairs: { title: string; slug: string }[];
+}
+
+const preAllocParsed = type({
+  skills: type("string").array(),
+  pairs: type({ title: "string", slug: "string" }).array(),
+});
+
+const preAllocSchema = {
+  name: "pre_alloc",
+  properties: {
+    skills: {
+      type: "array",
+      description: "Selected capability names from the catalog, appropriate for the app described by the prompt.",
+      items: { type: "string" },
+    },
+    pairs: {
+      type: "array",
+      description: "Exactly 3 title/slug pairs ranked by fit. Title in Title Case, 1-4 words. Slug in kebab-case derived from title.",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          slug: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Pre-allocation LLM call: takes the user's initial prompt and asks one
+ * structured call for {skills, pairs}. The caller hands pairs to
+ * ensureAppSlug as preferredPairs, and persists the chosen title + skills
+ * into app_settings.
+ *
+ * Model: resolved via loadModels → `preSelected: ["app"]` entry in
+ * models.json (currently openai/gpt-5.4-mini). No user/app overrides;
+ * pre-alloc stays deterministic across users.
+ */
+export async function preAllocate(vctx: VibesApiSQLCtx, { prompt }: { prompt: string }): Promise<Result<PreAllocateResult>> {
+  const rModels = await loadModels(vctx);
+  if (rModels.isErr()) return Result.Err(rModels);
+  const appDefault = rModels.Ok().models.find((m) => m.preSelected?.includes("app"));
+  if (!appDefault) return Result.Err("no preSelected app model in catalog");
+
+  const rCall = await exception2Result(() =>
+    callAI(prompt, {
+      model: appDefault.id,
+      endpoint: vctx.params.llm.url,
+      apiKey: vctx.params.llm.apiKey,
+      schema: preAllocSchema,
+    })
+  );
+  if (rCall.isErr()) return Result.Err(rCall);
+  const raw = rCall.Ok();
+  if (typeof raw !== "string") {
+    return Result.Err("pre-alloc callAI returned non-string (streaming not requested)");
+  }
+
+  const rParsed = exception2Result(() => JSON.parse(raw) as unknown);
+  if (rParsed.isErr()) return Result.Err(`pre-alloc JSON parse failed: ${rParsed.Err()}`);
+
+  const validated = preAllocParsed(rParsed.Ok());
+  if (validated instanceof type.errors) {
+    return Result.Err(`pre-alloc schema validation failed: ${validated.summary}`);
+  }
+  if (validated.pairs.length === 0) {
+    return Result.Err("pre-alloc returned zero title/slug pairs");
+  }
+  return Result.Ok({
+    skills: validated.skills,
+    pairs: validated.pairs.slice(0, 3),
+  });
+}

--- a/vibes.diy/api/svc/intern/pre-allocate.ts
+++ b/vibes.diy/api/svc/intern/pre-allocate.ts
@@ -67,12 +67,16 @@ export async function preAllocate(vctx: VibesApiSQLCtx, { prompt }: { prompt: st
   }
 
   const catalogNames = await getLlmCatalogNames();
-  const validSkills = validated.skills.filter((s) => catalogNames.has(s));
-  if (validated.skills.length > 0 && validSkills.length === 0) {
+  const validSkills: string[] = [];
+  const droppedSkills: string[] = [];
+  for (const s of validated.skills) {
+    (catalogNames.has(s) ? validSkills : droppedSkills).push(s);
+  }
+  if (droppedSkills.length > 0) {
     ensureLogger(vctx.sthis, "preAllocate")
       .Warn()
-      .Any({ rawSkills: validated.skills })
-      .Msg("all pre-alloc skills missed catalog");
+      .Any({ droppedSkills, validSkills })
+      .Msg("pre-alloc skills missed catalog");
   }
 
   return Result.Ok({

--- a/vibes.diy/api/svc/intern/pre-allocate.ts
+++ b/vibes.diy/api/svc/intern/pre-allocate.ts
@@ -1,7 +1,7 @@
 import { Result, exception2Result } from "@adviser/cement";
 import { callAI } from "call-ai";
 import { type } from "arktype";
-import { makePreAllocUserMessage } from "@vibes.diy/prompts";
+import { makePreAllocUserMessage, preAllocParsed, preAllocSchema } from "@vibes.diy/prompts";
 import { VibesApiSQLCtx } from "../types.js";
 import { loadModels } from "../public/list-models.js";
 
@@ -9,33 +9,6 @@ export interface PreAllocateResult {
   skills: string[];
   pairs: { title: string; slug: string }[];
 }
-
-const preAllocParsed = type({
-  skills: type("string").array(),
-  pairs: type({ title: "string", slug: "string" }).array(),
-});
-
-const preAllocSchema = {
-  name: "pre_alloc",
-  properties: {
-    skills: {
-      type: "array",
-      description: "Selected skill names from the catalog above, appropriate for the app described by the user prompt. Only use names present in the catalog.",
-      items: { type: "string" },
-    },
-    pairs: {
-      type: "array",
-      description: "Exactly 3 title/slug pairs ranked by fit. Title in Title Case, 1-4 words. Slug in kebab-case derived from title.",
-      items: {
-        type: "object",
-        properties: {
-          title: { type: "string" },
-          slug: { type: "string" },
-        },
-      },
-    },
-  },
-};
 
 const PRE_ALLOC_TIMEOUT_MS = 8000;
 

--- a/vibes.diy/api/svc/package.json
+++ b/vibes.diy/api/svc/package.json
@@ -34,6 +34,7 @@
     "@vibes.diy/vibe-db-explorer": "workspace:*",
     "acorn": "^8.15.0",
     "arktype": "^2.2.0",
+    "call-ai": "workspace:*",
     "cookie": "^1.1.1",
     "drizzle-orm": "^0.45.2",
     "jose": "^6.2.2",

--- a/vibes.diy/api/svc/public/ensure-app-settings.ts
+++ b/vibes.diy/api/svc/public/ensure-app-settings.ts
@@ -4,6 +4,7 @@ import {
   parseArrayWarning,
   ActiveEnv,
   ActiveModelSetting,
+  ActiveSkills,
   ActiveTitle,
   AppSettings,
   EnablePublicAccess,
@@ -13,7 +14,9 @@ import {
   isActiveModelSettingApp,
   isActiveModelSettingChat,
   isActiveModelSettingImg,
+  isActiveSkills,
   isReqEnsureAppSettingsImg,
+  isReqEnsureAppSettingsSkills,
   isActiveTitle,
   isEnablePublicAccess,
   isEnableRequest,
@@ -80,6 +83,9 @@ export function buildEnsureEntryResult(entries: ActiveEntry[]): AppSettings {
         break;
       case isActiveTitle(e):
         result.entry.settings.title = e.title;
+        break;
+      case isActiveSkills(e):
+        result.entry.settings.skills = e.skills;
         break;
       case isActiveModelSettingChat(e):
         result.entry.settings.chat = e.param;
@@ -245,6 +251,19 @@ export async function ensureAppSettings(
             type: "active.title",
             title: req.title,
           }) satisfies ActiveTitle
+      );
+      break;
+    case isReqEnsureAppSettingsSkills(req):
+      [res.settings, res.error] = await sqlUpsert(
+        vctx,
+        res,
+        settings,
+        isActiveSkills,
+        () =>
+          ({
+            type: "active.skills",
+            skills: req.skills,
+          }) satisfies ActiveSkills
       );
       break;
     case isReqEnsureAppSettingsApp(req):

--- a/vibes.diy/api/svc/public/prompt-chat-section.ts
+++ b/vibes.diy/api/svc/public/prompt-chat-section.ts
@@ -42,6 +42,8 @@ import {
   parseArray,
   vibeFile,
   isVibeCodeBlock,
+  ActiveEntry,
+  isActiveSkills,
 } from "@vibes.diy/api-types";
 import { ensureLogger } from "@fireproof/core-runtime";
 import { type } from "arktype";
@@ -359,6 +361,31 @@ export function reconstructConversationMessages(sectionMsgs: PromptAndBlockMsgs[
   return messages;
 }
 
+async function loadActiveSkills(vctx: VibesApiSQLCtx, chatId: string): Promise<string[] | undefined> {
+  const rChat = await exception2Result(() =>
+    vctx.sql.db
+      .select({ appSlug: vctx.sql.tables.chatContexts.appSlug, userSlug: vctx.sql.tables.chatContexts.userSlug })
+      .from(vctx.sql.tables.chatContexts)
+      .where(eq(vctx.sql.tables.chatContexts.chatId, chatId))
+      .limit(1)
+      .then((r) => r[0])
+  );
+  if (rChat.isErr() || !rChat.Ok()) return undefined;
+  const { appSlug, userSlug } = rChat.Ok();
+  const rApp = await exception2Result(() =>
+    vctx.sql.db
+      .select({ settings: vctx.sql.tables.appSettings.settings })
+      .from(vctx.sql.tables.appSettings)
+      .where(and(eq(vctx.sql.tables.appSettings.appSlug, appSlug), eq(vctx.sql.tables.appSettings.userSlug, userSlug)))
+      .limit(1)
+      .then((r) => r[0])
+  );
+  if (rApp.isErr() || !rApp.Ok()) return undefined;
+  const entries = (rApp.Ok().settings ?? []) as ActiveEntry[];
+  const skillsEntry = entries.find(isActiveSkills);
+  return skillsEntry?.skills;
+}
+
 async function injectSystemPrompt(
   vctx: VibesApiSQLCtx,
   chatId: string,
@@ -386,10 +413,16 @@ async function injectSystemPrompt(
     allSectionMsgs.push(...sectionMsgs);
   }
   const conversationMessages = reconstructConversationMessages(allSectionMsgs);
+
+  // Resolve the app's ActiveSkills from app_settings. Pre-allocation seeds this
+  // on new chats; legacy rows without it fall back to makeBaseSystemPrompt's
+  // getDefaultSkills().
+  const skills = await loadActiveSkills(vctx, chatId);
+
   const systemPrompt = await exception2Result(async () =>
     makeBaseSystemPrompt(await resolveEffectiveModel({ model }, {}), {
-      dependenciesUserOverride: true,
-      dependencies: ["fireproof", "callai", "img-vibes", "web-audio"],
+      skills,
+      demoData: false,
       fetch: async (url: RequestInfo | URL, _init?: RequestInit) => {
         console.log("Fetching asset for system prompt from URL:", url.toString(), vctx.params.pkgRepos.workspace);
         const uri = URI.from(url);
@@ -405,19 +438,8 @@ async function injectSystemPrompt(
         if (rRes.isErr()) {
           console.error("Failed to fetch asset for system prompt from URL:", url.toString(), "with error:", rRes.Err());
           return new Response(JSON.stringify({ error: rRes.Err() }), { status: 500 });
-          // return Result.Err(rRes);
         }
-        const res = new Response(rRes.Ok());
-        // res.clone().text().then((text) => {
-        //   console.log("Fetched asset for system prompt from URL:", url.toString(), "with content:", text);
-        // })
-        return res;
-        //   return Result.Ok(await new Response(rRes.Ok()).text());
-      },
-      callAi: {
-        ModuleAndOptionsSelection: async (_msgs: ChatMessage[]) => {
-          return Result.Err(`Module and options selection is not supported in system prompts at this time`);
-        },
+        return new Response(rRes.Ok());
       },
     })
   );

--- a/vibes.diy/api/types/chat.ts
+++ b/vibes.diy/api/types/chat.ts
@@ -34,6 +34,7 @@ export const reqOpenChat = type({
   "appSlug?": "string",
   "userSlug?": "string",
   "chatId?": "string",
+  "prompt?": "string", // when present with no appSlug, triggers pre-allocation (LLM-driven title+slug+skills)
   mode: PromptStyle,
 });
 

--- a/vibes.diy/api/types/invite.ts
+++ b/vibes.diy/api/types/invite.ts
@@ -291,6 +291,15 @@ export function isActiveTitle(obj: unknown): obj is ActiveTitle {
   return !(ActiveTitle(obj) instanceof type.errors);
 }
 
+export const ActiveSkills = type({
+  type: "'active.skills'",
+  skills: type("string").array(),
+});
+export type ActiveSkills = typeof ActiveSkills.infer;
+export function isActiveSkills(obj: unknown): obj is ActiveSkills {
+  return !(ActiveSkills(obj) instanceof type.errors);
+}
+
 export const ActiveModelSettingBase = type({
   type: "'active.model'",
   param: AIParams,
@@ -344,6 +353,7 @@ export const ActiveEntry = EnablePublicAccess.or(ActiveRequest)
   .or(ActiveInvite)
   .or(EnableRequest)
   .or(ActiveTitle)
+  .or(ActiveSkills)
   .or(ActiveModelSetting)
   .or(ActiveEnv);
 

--- a/vibes.diy/api/types/settings.ts
+++ b/vibes.diy/api/types/settings.ts
@@ -119,6 +119,15 @@ export function isReqEnsureAppSettingsTitle(obj: unknown): obj is ReqEnsureAppSe
   return !(reqEnsureAppSettingsTitle(obj) instanceof type.errors);
 }
 
+export const reqEnsureAppSettingsSkills = type({
+  skills: type("string").array(),
+}).and(reqEnsureAppSettingsBase);
+
+export type ReqEnsureAppSettingsSkills = typeof reqEnsureAppSettingsSkills.infer;
+export function isReqEnsureAppSettingsSkills(obj: unknown): obj is ReqEnsureAppSettingsSkills {
+  return !(reqEnsureAppSettingsSkills(obj) instanceof type.errors);
+}
+
 export const reqEnsureAppSettingsApp = type({
   app: AIParams.partial(),
 }).and(reqEnsureAppSettingsBase);
@@ -160,6 +169,7 @@ export type ReqEnsureAppSettings =
   | ReqPublicAccess
   | ReqRequest
   | ReqEnsureAppSettingsTitle
+  | ReqEnsureAppSettingsSkills
   | ReqEnsureAppSettingsApp
   | ReqEnsureAppSettingsChat
   | ReqEnsureAppSettingsImg
@@ -170,6 +180,7 @@ export function isReqEnsureAppSettings(obj: unknown): obj is ReqEnsureAppSetting
   return (
     // isReqEnsureAppSettingsAcl(obj) ||
     isReqEnsureAppSettingsTitle(obj) ||
+    isReqEnsureAppSettingsSkills(obj) ||
     isReqEnsureAppSettingsApp(obj) ||
     isReqEnsureAppSettingsChat(obj) ||
     isReqEnsureAppSettingsImg(obj) ||
@@ -183,6 +194,7 @@ export const AppSettings = type({
   entry: type({
     settings: {
       "title?": "string",
+      "skills?": type("string").array(),
       "app?": AIParams.partial(),
       "chat?": AIParams.partial(),
       "img?": AIParams.partial(),

--- a/vibes.diy/api/types/vibes-types.ts
+++ b/vibes.diy/api/types/vibes-types.ts
@@ -44,5 +44,7 @@ export type VibesFPApiParameters = Pick<FPApiParameters, "cloudPublicKeys" | "cl
     // default: LLMDefault;
     enforced: LLMEnforced;
     headers: LLMHeaders;
+    url: string;
+    apiKey: string;
   };
 };

--- a/vibes.diy/pkg/app/routes/chat/prompt.tsx
+++ b/vibes.diy/pkg/app/routes/chat/prompt.tsx
@@ -28,11 +28,9 @@ export default function ChatPrompt() {
           console.error("tokenClaims:", rClaims.Err());
           return Promise.reject();
         }
-        // const { params } = rClaims.Ok().claims;
-        // HERE we need to look in the userSettings
         return vibeDiyApi.openChat({
-          // userSlug: params.name ?? params.nick ?? params.email.replace(/@[^@]+$/, ""),
           mode: "chat",
+          prompt,
         });
       })
       .then((rChat) => {


### PR DESCRIPTION
## Summary

Replaces the random-words-then-hardcoded-skills bootstrap with a single LLM-driven pre-allocation phase that runs inside `openChat` when the home-form prompt is present. One structured `callAI` returns `{skills, pairs: [{title, slug}] × 3}`; the slug allocator walks those pairs first (falling back to `random-words` on collision/failure), and the chosen title + skills are persisted as `active.*` entries in `app_settings`. Subsequent turns read `active.skills` from app_settings instead of recomputing — no per-turn RAG call, user-editable via the existing settings UI.

Plan doc: [notes/pre-alloc-plan.md](../blob/jchris/pre-alloc-skills/notes/pre-alloc-plan.md) (local reference at `/Users/jchris/.claude/plans/mutable-munching-bumblebee.md`).

## Shape

```
prompt64 → openChat({mode, prompt}) ──► preAllocate (callAI, schema)
                                         │
                                         ├─► ensureAppSlug(preferredPairs)  ─► chatContexts INSERT
                                         └─► UPSERT app_settings w/ ActiveTitle + ActiveSkills
                                                                 │
                                                                 ▼
                                                          first codegen turn
                                                          reads active.skills
                                                          no LLM call here
```

**Model:** resolved via `loadModels` → the `preSelected: ["app"]` entry (`openai/gpt-5.4-mini`). No user/app override applied; pre-alloc is deterministic across users.

**Timeout:** 8s `Promise.race` around the callAI. On timeout or any error, `ensureChatId` falls through to random-words slug + default skills — no user-visible hang.

**Failure modes all degrade gracefully:**
- LLM down → random-words slug, default skills.
- Malformed JSON → same.
- All 3 suggested slugs collide → random-words, no `active.*` written.
- CLI push (no `prompt`) → existing random-words path unchanged.

## Commits (6, small-review-friendly)

1. `refactor(prompts): rename dependencies → skills` — `SystemPromptResult.dependencies` → `.skills`, `getDefaultDependencies` → `getDefaultSkills`. Catalog items are skills, not npm deps.
2. `feat(types): add ActiveSkills, reqEnsureAppSettingsSkills, optional prompt on reqOpenChat` — new arktype + union + request shape.
3. `feat(svc): extend ensureAppSlug to accept preferredPairs (title+slug)` — walks LLM pairs first, returns `chosenTitle` alongside the binding.
4. `feat(svc): add preAllocate helper; thread into ensureChatId` — one callAI call with schema, 8s timeout, upserts `ActiveTitle` + `ActiveSkills` after the chatContexts INSERT. New `call-ai` workspace dep on `api-svc`; `vctx.params.llm` grows `url` + `apiKey`.
5. `feat(svc): route ActiveSkills through ensureAppSettings read/write` — `buildEnsureEntryResult` surfaces `settings.entry.settings.skills`; new `reqEnsureAppSettingsSkills` upsert branch.
6. `feat: skills/demoData flow through app_settings; prompt.tsx pre-allocates` — `makeBaseSystemPrompt` signature takes `{skills, demoData, fetch}` directly; `selectLlmsAndOptions` / `RAG_DECISION_MODEL` / `LlmSelectionOptions` / `LlmSelectionDecisions` / `detectModulesInHistory` deleted; `HistoryMessage` + `UserSettings.history` / `dependenciesUserOverride` / `demoDataOverride` removed as dead code. Client `prompt.tsx` passes `prompt` to `openChat`. Callers (CLI `system-cmd`, `use-vibes` hook) updated.

## Known tradeoff (documented in the plan)

Prompt crosses the wire twice — once as `openChat({prompt})` for pre-alloc, once as `chat.prompt({messages: [prompt]})` for codegen. Kept simple for v1: pre-alloc is a pure addition on top of the existing openChat/prompt/stream pipeline. Future improvement: server carries prompt through and auto-fires first stream message from inside openChat.

## Verification

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `vibes.diy/api/tests` — 73 pass, 1 skipped
- [ ] End-to-end manual: new chat from home form → URL reflects prompt; chat header shows generated title; no LLM call during streaming; second prompt skips pre-alloc.
- [ ] Simulate `LLM_BACKEND_URL` outage → random-words fallback, no error surfaced.
- [ ] CLI push unchanged (no prompt, no pre-alloc).

## Non-goals (follow-ups tracked in `notes/whats-next.md`)

- `demoData` user-settings toggle (future `userSettingItem` variant).
- Icon generation.
- WS push of `active.*` changes.
- UI editor for `active.skills`.
- CLI `--prompt` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)