### PR TITLE
Hide auto-join toggle until published, auto-open on first publish

### DIFF
--- a/vibes.diy/pkg/app/components/ResultPreview/ShareModal.tsx
+++ b/vibes.diy/pkg/app/components/ResultPreview/ShareModal.tsx
@@ -81,6 +81,38 @@ export function ShareModal({ modal }: ShareModalProps) {
             >
               {modal.isPublishing ? "Updating..." : modal.isUpToDate ? "Up to date" : "Update"}
             </Button>
+
+            {/* Divider */}
+            <hr className="my-3 border-gray-200 dark:border-gray-700" />
+
+            {/* Auto-join toggle */}
+            <div className="flex cursor-pointer items-center justify-between gap-3">
+              <div>
+                <p id="auto-join-label" className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  Open access
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {modal.autoJoinEnabled ? "Anyone with the link gets access" : "New users must be approved"}
+                </p>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-labelledby="auto-join-label"
+                aria-checked={modal.autoJoinEnabled}
+                disabled={modal.isTogglingAutoJoin}
+                onClick={() => void modal.handleToggleAutoJoin()}
+                className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-black transition-colors ${
+                  modal.autoJoinEnabled ? "bg-blue-500" : "bg-gray-300 dark:bg-gray-600"
+                } ${modal.isTogglingAutoJoin ? "opacity-50" : ""}`}
+              >
+                <span
+                  className={`pointer-events-none inline-block h-5 w-5 rounded-full border border-black bg-white shadow transition-transform ${
+                    modal.autoJoinEnabled ? "translate-x-5" : "translate-x-0"
+                  }`}
+                />
+              </button>
+            </div>
           </div>
         ) : (
           <div className="space-y-2">
@@ -100,38 +132,6 @@ export function ShareModal({ modal }: ShareModalProps) {
             ) : null}
           </div>
         )}
-
-        {/* Divider */}
-        <hr className="my-3 border-gray-200 dark:border-gray-700" />
-
-        {/* Auto-join toggle */}
-        <div className="flex cursor-pointer items-center justify-between gap-3">
-          <div>
-            <p id="auto-join-label" className="text-sm font-medium text-gray-900 dark:text-gray-100">
-              Open access
-            </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              {modal.autoJoinEnabled ? "Anyone with the link gets access" : "New users must be approved"}
-            </p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-labelledby="auto-join-label"
-            aria-checked={modal.autoJoinEnabled}
-            disabled={modal.isTogglingAutoJoin}
-            onClick={() => void modal.handleToggleAutoJoin()}
-            className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-black transition-colors ${
-              modal.autoJoinEnabled ? "bg-blue-500" : "bg-gray-300 dark:bg-gray-600"
-            } ${modal.isTogglingAutoJoin ? "opacity-50" : ""}`}
-          >
-            <span
-              className={`pointer-events-none inline-block h-5 w-5 rounded-full border border-black bg-white shadow transition-transform ${
-                modal.autoJoinEnabled ? "translate-x-5" : "translate-x-0"
-              }`}
-            />
-          </button>
-        </div>
       </div>
     </div>,
     document.body

--- a/vibes.diy/pkg/app/components/ResultPreview/useShareModal.ts
+++ b/vibes.diy/pkg/app/components/ResultPreview/useShareModal.ts
@@ -120,6 +120,7 @@ export function useShareModal({ userSlug, appSlug, fsId, vibeDiyApi }: UseShareM
 
   const handlePublish = useCallback(async () => {
     if (!canPublish || !settingsLoaded) return;
+    const isInitialPublish = !isPublished;
     setIsPublishing(true);
     setPublishError(undefined);
 
@@ -153,12 +154,16 @@ export function useShareModal({ userSlug, appSlug, fsId, vibeDiyApi }: UseShareM
       setPublishedUrl(url);
       setProductionFsId(fsId);
       setIsPublished(true);
+
+      if (isInitialPublish) {
+        window.open(url, "_blank");
+      }
     } catch {
       setPublishError("Failed to publish. Please try again.");
     } finally {
       setIsPublishing(false);
     }
-  }, [canPublish, settingsLoaded, fsId, appSlug, userSlug, vibeDiyApi, autoJoinEnabled]);
+  }, [canPublish, settingsLoaded, isPublished, fsId, appSlug, userSlug, vibeDiyApi, autoJoinEnabled]);
 
   const handleToggleAutoJoin = useCallback(async () => {
     setIsTogglingAutoJoin(true);

--- a/vibes.diy/tests/app/ShareModal.test.tsx
+++ b/vibes.diy/tests/app/ShareModal.test.tsx
@@ -130,15 +130,27 @@ describe("ShareModal", () => {
     expect(screen.getByText(/Generate some code first/)).toBeInTheDocument();
   });
 
-  it("shows auto-join toggle", () => {
-    const modal = createMockModal();
-    render(<ShareModal modal={modal} />);
+  it("shows auto-join toggle only when published", () => {
+    const unpublished = createMockModal();
+    render(<ShareModal modal={unpublished} />);
+    expect(screen.queryByText("Open access")).not.toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    cleanup();
+
+    const published = createMockModal({
+      isPublished: true,
+      publishedUrl: "https://vibes.diy/vibe/testuser/testapp/",
+    });
+    render(<ShareModal modal={published} />);
     expect(screen.getByText("Open access")).toBeInTheDocument();
     expect(screen.getByRole("switch")).toBeInTheDocument();
   });
 
   it("calls handleToggleAutoJoin when clicking toggle", async () => {
-    const modal = createMockModal();
+    const modal = createMockModal({
+      isPublished: true,
+      publishedUrl: "https://vibes.diy/vibe/testuser/testapp/",
+    });
     render(<ShareModal modal={modal} />);
 
     await act(async () => {
@@ -149,7 +161,11 @@ describe("ShareModal", () => {
   });
 
   it("shows auto-join enabled state", () => {
-    const modal = createMockModal({ autoJoinEnabled: true });
+    const modal = createMockModal({
+      isPublished: true,
+      publishedUrl: "https://vibes.diy/vibe/testuser/testapp/",
+      autoJoinEnabled: true,
+    });
     render(<ShareModal modal={modal} />);
 
     expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
@@ -157,7 +173,11 @@ describe("ShareModal", () => {
   });
 
   it("shows auto-join disabled state", () => {
-    const modal = createMockModal({ autoJoinEnabled: false });
+    const modal = createMockModal({
+      isPublished: true,
+      publishedUrl: "https://vibes.diy/vibe/testuser/testapp/",
+      autoJoinEnabled: false,
+    });
     render(<ShareModal modal={modal} />);
 
     expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
@@ -207,7 +227,10 @@ describe("ShareModal", () => {
   });
 
   it("auto-join switch has accessible name via aria-labelledby", () => {
-    const modal = createMockModal();
+    const modal = createMockModal({
+      isPublished: true,
+      publishedUrl: "https://vibes.diy/vibe/testuser/testapp/",
+    });
     render(<ShareModal modal={modal} />);
 
     const toggle = screen.getByRole("switch");


### PR DESCRIPTION
## Summary
- Move the "Open access" auto-join toggle and divider inside the `isPublished` branch so they only appear after the app has a published URL — pre-publish view now shows just the Publish button
- Auto-open the published URL in a new tab on initial publish (not on subsequent Update clicks)
- Update tests to reflect the new conditional visibility

## Test plan
- [x] `pnpm check` passes (ShareModal tests green; 6 pre-existing api-test failures unrelated)
- [ ] Manually verify pre-publish modal shows only "Publish" button, no toggle
- [ ] Publish an app and confirm URL opens in new tab
- [ ] Re-open modal after publish and confirm auto-join toggle is visible
- [ ] Click "Update" and confirm no new tab opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)