### PR TITLE
fix: validate JSON input in handlePut() with arktype (#1317)

### DIFF
--- a/vibes.diy/stable-entry/package.json
+++ b/vibes.diy/stable-entry/package.json
@@ -7,10 +7,12 @@
     "dev": "echo 'dev mode is broken due to some resolve issues' ; vite",
     "deploy": "core-cli tsc && vite build && wrangler deploy --keep-vars",
     "pack": "echo core-cli build --doPack",
-    "publish": "echo core-cli build"
+    "publish": "echo core-cli build",
+    "test": "vitest --run --config vitest.config.ts"
   },
   "dependencies": {
     "@adviser/cement": "^0.5.34",
+    "arktype": "^2.2.0",
     "@cloudflare/workers-types": "^4.20260402.1",
     "@tanstack/react-table": "^8.21.3",
     "@vibes.diy/base": "workspace:*",
@@ -25,6 +27,7 @@
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^5.2.0",
     "vite": "^7.3.1",
+    "vitest": "~4.1.2",
     "wrangler": "^4.81.0"
   }
 }

--- a/vibes.diy/stable-entry/spa-api.test.ts
+++ b/vibes.diy/stable-entry/spa-api.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { handleSpaApi } from "./spa-api.js";
+
+describe("handleSpaApi", () => {
+  describe("handlePut", () => {
+    it("returns 400 when body is missing path field", async () => {
+      const request = new Request("https://example.com/__vibes-spa-api__", {
+        method: "PUT",
+        body: JSON.stringify({ key: "some-key" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await handleSpaApi(request, {} as any);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when body is missing key field", async () => {
+      const request = new Request("https://example.com/__vibes-spa-api__", {
+        method: "PUT",
+        body: JSON.stringify({ path: "/some/path" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await handleSpaApi(request, {} as any);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when body is empty object", async () => {
+      const request = new Request("https://example.com/__vibes-spa-api__", {
+        method: "PUT",
+        body: JSON.stringify({}),
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await handleSpaApi(request, {} as any);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 303 redirect when body is valid", async () => {
+      const request = new Request("https://example.com/__vibes-spa-api__", {
+        method: "PUT",
+        body: JSON.stringify({ path: "/some/path", key: "some-key" }),
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await handleSpaApi(request, {} as any);
+      expect(response.status).toBe(303);
+    });
+  });
+});

--- a/vibes.diy/stable-entry/spa-api.test.ts
+++ b/vibes.diy/stable-entry/spa-api.test.ts
@@ -3,6 +3,16 @@ import { handleSpaApi } from "./spa-api.js";
 
 describe("handleSpaApi", () => {
   describe("handlePut", () => {
+    it("returns 400 when body is not valid JSON", async () => {
+      const request = new Request("https://example.com/__vibes-spa-api__", {
+        method: "PUT",
+        body: "not json",
+        headers: { "Content-Type": "application/json" },
+      });
+      const response = await handleSpaApi(request, {} as any);
+      expect(response.status).toBe(400);
+    });
+
     it("returns 400 when body is missing path field", async () => {
       const request = new Request("https://example.com/__vibes-spa-api__", {
         method: "PUT",
@@ -44,3 +54,4 @@ describe("handleSpaApi", () => {
     });
   });
 });
+

--- a/vibes.diy/stable-entry/spa-api.ts
+++ b/vibes.diy/stable-entry/spa-api.ts
@@ -46,7 +46,13 @@ export function updateRoutingCookie(routingGroups: Record<string, string>, path:
 }
 
 async function handlePut(request: Request, env: Env, origin: string): Promise<Response> {
-  const body = type({ path: "string", key: "string" })(await request.json());
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid JSON body" }), { status: 400 });
+  }
+  const body = type({ path: "string", key: "string" })(rawBody);
   if (body instanceof type.errors) {
     return new Response(JSON.stringify({ error: body.summary }), { status: 400 });
   }
@@ -70,3 +76,4 @@ export async function handleSpaApi(request: Request, env: Env): Promise<Response
   if (request.method === "PUT") return handlePut(request, env, origin);
   return new Response("Method not allowed", { status: 405 });
 }
+

--- a/vibes.diy/stable-entry/spa-api.ts
+++ b/vibes.diy/stable-entry/spa-api.ts
@@ -1,5 +1,6 @@
 import { parse as parseCookies, serialize as serializeCookie } from "cookie";
 import { exception2Result } from "@adviser/cement";
+import { type } from "arktype";
 import type { Env, ApiResponse } from "./types.js";
 import { getBackendConfig, ROUTING_COOKIE, API_PATH } from "./types.js";
 
@@ -45,7 +46,11 @@ export function updateRoutingCookie(routingGroups: Record<string, string>, path:
 }
 
 async function handlePut(request: Request, env: Env, origin: string): Promise<Response> {
-  const { path, key } = (await request.json()) as { path: string; key: string };
+  const body = type({ path: "string", key: "string" })(await request.json());
+  if (body instanceof type.errors) {
+    return new Response(JSON.stringify({ error: body.summary }), { status: 400 });
+  }
+  const { path, key } = body;
   const routingGroups = parseRoutingCookie(request.headers.get("cookie") ?? "");
   const cookieHeader = updateRoutingCookie(routingGroups, path, key);
 

--- a/vibes.diy/stable-entry/vitest.config.ts
+++ b/vibes.diy/stable-entry/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Adds runtime validation to handlePut() in spa-api.ts using arktype.
Previously, malformed JSON or missing fields would throw an uncaught exception.
Now returns 400 with error details on invalid input.

Adds vitest config and tests covering missing fields and valid input.

Closes #1317