### PR TITLE
fix(api): reject slugs owned by another user

### DIFF
--- a/vibes.diy/api/svc/index.ts
+++ b/vibes.diy/api/svc/index.ts
@@ -12,3 +12,4 @@ export * from "./peers/r2-to-s3api.js";
 export * from "./intern/application-settings.js";
 export * from "./public/prompt-chat-section.js";
 export * from "./noop-cache.js";
+export * from "./intern/ensure-slug-binding.js";

--- a/vibes.diy/api/svc/intern/ensure-slug-binding.ts
+++ b/vibes.diy/api/svc/intern/ensure-slug-binding.ts
@@ -34,27 +34,41 @@ export async function writeUserSlugBinding(
     if (existing.length >= ctx.params.maxUserSlugPerUserId) {
       return Result.Err("maximum userSlug bindings reached for this userId");
     }
-    if (existing.find((e) => e.userSlug === userSlug)) {
+    const owned = existing.find((e) => e.userSlug === userSlug);
+    if (owned) {
       return Result.Ok({
         type: "vibes.diy-user-slug-binding",
         userId,
-        userSlug: existing[0].userSlug,
-        tenant: existing[0].tenant,
+        userSlug: owned.userSlug,
+        tenant: owned.tenant,
       });
     }
     const tenant = ctx.sthis.nextId(12).str;
-    await ctx.sql.db.insert(ctx.sql.tables.userSlugBinding).values({
-      userId,
-      tenant,
-      userSlug,
-      created: new Date().toISOString(),
-    });
-    // .onConflictDoNothing();
+    await ctx.sql.db
+      .insert(ctx.sql.tables.userSlugBinding)
+      .values({
+        userId,
+        tenant,
+        userSlug,
+        created: new Date().toISOString(),
+      })
+      .onConflictDoNothing();
+    // Post-insert verification: confirm our userId owns the row.
+    // If another user won the race, the insert was a no-op and we reject.
+    const owner = await ctx.sql.db
+      .select()
+      .from(ctx.sql.tables.userSlugBinding)
+      .where(eq(ctx.sql.tables.userSlugBinding.userSlug, userSlug))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!owner || owner.userId !== userId) {
+      return Result.Err(`userSlug "${userSlug}" is owned by another user`);
+    }
     return Result.Ok({
       type: "vibes.diy-user-slug-binding",
       userId,
       userSlug,
-      tenant,
+      tenant: owner.tenant,
     });
   });
 }

--- a/vibes.diy/api/svc/intern/ensure-slug-binding.ts
+++ b/vibes.diy/api/svc/intern/ensure-slug-binding.ts
@@ -31,9 +31,6 @@ export async function writeUserSlugBinding(
       .select()
       .from(ctx.sql.tables.userSlugBinding)
       .where(eq(ctx.sql.tables.userSlugBinding.userId, userId));
-    if (existing.length >= ctx.params.maxUserSlugPerUserId) {
-      return Result.Err("maximum userSlug bindings reached for this userId");
-    }
     const owned = existing.find((e) => e.userSlug === userSlug);
     if (owned) {
       return Result.Ok({
@@ -42,6 +39,9 @@ export async function writeUserSlugBinding(
         userSlug: owned.userSlug,
         tenant: owned.tenant,
       });
+    }
+    if (existing.length >= ctx.params.maxUserSlugPerUserId) {
+      return Result.Err("maximum userSlug bindings reached for this userId");
     }
     const tenant = ctx.sthis.nextId(12).str;
     await ctx.sql.db

--- a/vibes.diy/api/tests/slug-ownership.test.ts
+++ b/vibes.diy/api/tests/slug-ownership.test.ts
@@ -56,6 +56,26 @@ describe("slug ownership", () => {
     expect(rB2.Ok().tenant).toBe(rB.Ok().tenant);
   });
 
+  it("should return existing binding even at max quota", async () => {
+    const userId = "quota-user";
+    const slug = `quota-${sthis.nextId(8).str}`;
+
+    // Create the binding first
+    const r1 = await writeUserSlugBinding(vibesCtx, userId, slug);
+    expect(r1.isOk()).toBe(true);
+
+    // Temporarily lower the max to simulate being at quota
+    const original = vibesCtx.params.maxUserSlugPerUserId;
+    vibesCtx.params.maxUserSlugPerUserId = 1;
+
+    // Idempotent call should still succeed — owned slug, not a new one
+    const r2 = await writeUserSlugBinding(vibesCtx, userId, slug);
+    expect(r2.isOk()).toBe(true);
+    expect(r2.Ok().tenant).toBe(r1.Ok().tenant);
+
+    vibesCtx.params.maxUserSlugPerUserId = original;
+  });
+
   it("should handle concurrent claims to the same slug", async () => {
     const slug = `concurrent-${sthis.nextId(8).str}`;
 

--- a/vibes.diy/api/tests/slug-ownership.test.ts
+++ b/vibes.diy/api/tests/slug-ownership.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { ensureSuperThis } from "@fireproof/core-runtime";
+import { createTestDeviceCA } from "@fireproof/core-device-id";
+import { writeUserSlugBinding, VibesApiSQLCtx } from "@vibes.diy/api-svc";
+import { eq } from "drizzle-orm/sql/expressions";
+import { createVibeDiyTestCtx } from "./vibe-diy-test-ctx.js";
+
+describe("slug ownership", () => {
+  const sthis = ensureSuperThis();
+  let vibesCtx: VibesApiSQLCtx;
+
+  beforeAll(async () => {
+    const deviceCA = await createTestDeviceCA(sthis);
+    const appCtx = await createVibeDiyTestCtx(sthis, deviceCA);
+    vibesCtx = appCtx.vibesCtx;
+  });
+
+  it("should reject userSlug owned by another user", async () => {
+    const userA = "user-slug-owner-A";
+    const userB = "user-slug-thief-B";
+    const slug = `ownership-${sthis.nextId(8).str}`;
+
+    // User A creates a binding
+    const rA = await writeUserSlugBinding(vibesCtx, userA, slug);
+    expect(rA.isOk()).toBe(true);
+    expect(rA.Ok().userSlug).toBe(slug);
+
+    // Verify row exists for user A
+    const rows = await vibesCtx.sql.db
+      .select()
+      .from(vibesCtx.sql.tables.userSlugBinding)
+      .where(eq(vibesCtx.sql.tables.userSlugBinding.userSlug, slug));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(userA);
+
+    // User B tries to use the same userSlug — should fail
+    const rB = await writeUserSlugBinding(vibesCtx, userB, slug);
+    expect(rB.isErr()).toBe(true);
+  });
+
+  it("should return the correct binding when user has multiple slugs", async () => {
+    const userId = "multi-slug-user";
+    const slugA = `multi-a-${sthis.nextId(8).str}`;
+    const slugB = `multi-b-${sthis.nextId(8).str}`;
+
+    const rA = await writeUserSlugBinding(vibesCtx, userId, slugA);
+    expect(rA.isOk()).toBe(true);
+
+    const rB = await writeUserSlugBinding(vibesCtx, userId, slugB);
+    expect(rB.isOk()).toBe(true);
+
+    // Request slugB again — should return slugB's tenant, not slugA's
+    const rB2 = await writeUserSlugBinding(vibesCtx, userId, slugB);
+    expect(rB2.isOk()).toBe(true);
+    expect(rB2.Ok().userSlug).toBe(slugB);
+    expect(rB2.Ok().tenant).toBe(rB.Ok().tenant);
+  });
+
+  it("should handle concurrent claims to the same slug", async () => {
+    const slug = `concurrent-${sthis.nextId(8).str}`;
+
+    const [r1, r2] = await Promise.all([
+      writeUserSlugBinding(vibesCtx, "racer-1", slug),
+      writeUserSlugBinding(vibesCtx, "racer-2", slug),
+    ]);
+
+    // Exactly one succeeds, one fails
+    const successes = [r1.isOk(), r2.isOk()].filter(Boolean);
+    expect(successes).toHaveLength(1);
+
+    // Only one row exists
+    const rows = await vibesCtx.sql.db
+      .select()
+      .from(vibesCtx.sql.tables.userSlugBinding)
+      .where(eq(vibesCtx.sql.tables.userSlugBinding.userSlug, slug));
+    expect(rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix wrong-row bug in `writeUserSlugBinding` — was returning `existing[0]` instead of matched entry when user has multiple slugs
- Add cross-user uniqueness check using `onConflictDoNothing` + post-insert ownership verify (race-safe, no try/catch)
- Add `slug-ownership.test.ts` with 3 tests: cross-user rejection, multi-slug correctness, concurrent race

Closes #1179, supersedes #1181 and #1303

## Test plan
- [x] `pnpm test slug-ownership` — all 3 tests pass
- [x] `pnpm check` — 82 test files passed, 2 skipped (pre-existing)
- [ ] Verify on Neon with real user data after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)