### PR TITLE
App-icon generation: evt-new-fs-id handler + /vibes-icon endpoint

### DIFF
--- a/vibes.diy/api/queue/handlers/evt-icon-gen.ts
+++ b/vibes.diy/api/queue/handlers/evt-icon-gen.ts
@@ -1,0 +1,135 @@
+import { EventoHandler, EventoResult, EventoResultType, HandleTriggerCtx, Option, Result, exception2Result, uint8array2stream } from "@adviser/cement";
+import {
+  ActiveEntry,
+  ActiveIcon,
+  EvtIconRepair,
+  EvtNewFsId,
+  MsgBase,
+  isActiveIcon,
+  isActiveTitle,
+  isEvtIconRepair,
+  isEvtNewFsId,
+  msgBase,
+  parseArrayWarning,
+} from "@vibes.diy/api-types";
+import { createSQLPeer } from "@vibes.diy/api-sql";
+import { ensureStorage } from "@vibes.diy/api-pkg";
+import { ensureLogger } from "@fireproof/core-runtime";
+import { type } from "arktype";
+import { and, eq } from "drizzle-orm/sql/expressions";
+import { QueueCtx } from "../queue-ctx.js";
+import { generateIcon } from "../intern/generate-icon.js";
+
+type IconEvt = EvtNewFsId | EvtIconRepair;
+
+export const evtIconGenEvento: EventoHandler<unknown, MsgBase<IconEvt>, void> = {
+  hash: "evt-icon-gen",
+  validate: async (ctx) => {
+    const msg = msgBase(ctx.enRequest);
+    if (msg instanceof type.errors) {
+      return Result.Ok(Option.None());
+    }
+    if (!isEvtNewFsId(msg.payload) && !isEvtIconRepair(msg.payload)) {
+      return Result.Ok(Option.None());
+    }
+    return Result.Ok(Option.Some(msg as MsgBase<IconEvt>));
+  },
+  handle: async (ctx: HandleTriggerCtx<unknown, MsgBase<IconEvt>, void>): Promise<Result<EventoResultType>> => {
+    const qctx = ctx.ctx.getOrThrow<QueueCtx>("queueCtx");
+    const { userSlug, appSlug } = ctx.validated.payload;
+    const logger = ensureLogger(qctx.sthis, "evtIconGen");
+
+    const rUserId = await resolveUserId(qctx, userSlug);
+    if (rUserId.isErr()) {
+      logger.Warn().Any({ userSlug, err: rUserId.Err() }).Msg("skip icon-gen: userId not found for userSlug");
+      return Result.Ok(EventoResult.Continue);
+    }
+    const userId = rUserId.Ok();
+
+    const rRow = await exception2Result(() =>
+      qctx.sql.db
+        .select()
+        .from(qctx.sql.tables.appSettings)
+        .where(
+          and(
+            eq(qctx.sql.tables.appSettings.userId, userId),
+            eq(qctx.sql.tables.appSettings.userSlug, userSlug),
+            eq(qctx.sql.tables.appSettings.appSlug, appSlug)
+          )
+        )
+        .limit(1)
+        .then((r) => r[0])
+    );
+    if (rRow.isErr()) return Result.Err(`appSettings read failed: ${rRow.Err()}`);
+    const row = rRow.Ok();
+
+    const { filtered: entries } = parseArrayWarning((row?.settings as unknown[]) ?? [], ActiveEntry);
+    if (entries.find(isActiveIcon)) {
+      return Result.Ok(EventoResult.Continue);
+    }
+
+    const titleEntry = entries.find(isActiveTitle);
+    const category = titleEntry?.title ?? appSlug;
+
+    const rGen = await generateIcon({
+      category,
+      llmUrl: qctx.params.vibes.env.LLM_BACKEND_URL,
+      llmApiKey: qctx.params.vibes.env.LLM_BACKEND_API_KEY,
+    });
+    if (rGen.isErr()) {
+      logger.Error().Any({ err: rGen.Err(), userSlug, appSlug, category }).Msg("icon-gen failed");
+      return Result.Err(rGen.Err());
+    }
+    const { bytes, mime } = rGen.Ok();
+
+    const [storageResult] = await ensureStorage(createSQLPeer(qctx.storageSystems.sql)).ensure(uint8array2stream(bytes));
+    if (!storageResult || storageResult.isErr()) {
+      return Result.Err(`icon-gen storage.ensure failed: ${storageResult?.Err()}`);
+    }
+    const cid = storageResult.Ok().getURL;
+
+    const iconEntry: ActiveIcon = { type: "active.icon", cid, mime };
+    const nextEntries: ActiveEntry[] = [...entries.filter((e) => !isActiveIcon(e)), iconEntry];
+
+    const now = new Date().toISOString();
+    const rUp = await exception2Result(() =>
+      qctx.sql.db
+        .insert(qctx.sql.tables.appSettings)
+        .values({
+          userId,
+          userSlug,
+          appSlug,
+          settings: nextEntries,
+          updated: now,
+          created: row?.created ?? now,
+        })
+        .onConflictDoUpdate({
+          target: [qctx.sql.tables.appSettings.userId, qctx.sql.tables.appSettings.userSlug, qctx.sql.tables.appSettings.appSlug],
+          set: { settings: nextEntries, updated: now },
+        })
+    );
+    if (rUp.isErr()) {
+      logger.Error().Any({ err: rUp.Err(), userSlug, appSlug }).Msg("icon-gen appSettings upsert failed");
+      return Result.Err(`icon-gen upsert failed: ${rUp.Err()}`);
+    }
+
+    logger.Info().Any({ userSlug, appSlug, category, cid }).Msg("icon-gen complete");
+    return Result.Ok(EventoResult.Continue);
+  },
+};
+
+async function resolveUserId(qctx: QueueCtx, userSlug: string): Promise<Result<string>> {
+  const rBinding = await exception2Result(() =>
+    qctx.sql.db
+      .select({ userId: qctx.sql.tables.userSlugBinding.userId })
+      .from(qctx.sql.tables.userSlugBinding)
+      .where(eq(qctx.sql.tables.userSlugBinding.userSlug, userSlug))
+      .limit(1)
+      .then((r) => r[0])
+  );
+  if (rBinding.isErr()) return Result.Err(rBinding);
+  const row = rBinding.Ok();
+  if (!row) return Result.Err(`no userSlugBinding for ${userSlug}`);
+  return Result.Ok(row.userId);
+}
+

--- a/vibes.diy/api/queue/intern/generate-icon.ts
+++ b/vibes.diy/api/queue/intern/generate-icon.ts
@@ -1,0 +1,83 @@
+import { Result, exception2Result } from "@adviser/cement";
+
+/**
+ * Calls the LLM backend in image-modality mode and returns the decoded image bytes.
+ *
+ * Uses the same backend (LLM_BACKEND_URL) pre-alloc and codegen share, with
+ * model `openai/gpt-5-image-mini` and `modalities: ["text", "image"]`. The
+ * response's first `data:image/...;base64,...` URI is decoded into a Uint8Array.
+ */
+export async function generateIcon(args: {
+  category: string;
+  llmUrl: string;
+  llmApiKey: string;
+  model?: string;
+  fetch?: typeof fetch;
+}): Promise<Result<{ bytes: Uint8Array; mime: string }>> {
+  const prompt =
+    `Minimal black icon on a white background, enclosed in a circle, representing ${args.category}. ` +
+    `Use clear, text-free imagery to convey the category. Avoid letters or numbers.`;
+
+  const doFetch = args.fetch ?? fetch;
+  const rRes = await exception2Result(() =>
+    doFetch(args.llmUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${args.llmApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: args.model ?? "openai/gpt-5-image-mini",
+        modalities: ["text", "image"],
+        stream: false,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    })
+  );
+  if (rRes.isErr()) return Result.Err(rRes);
+  const res = rRes.Ok();
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    return Result.Err(`icon-gen LLM call failed: ${res.status} ${res.statusText}: ${body.slice(0, 200)}`);
+  }
+
+  const rJson = await exception2Result(() => res.json() as Promise<unknown>);
+  if (rJson.isErr()) return Result.Err(`icon-gen JSON parse failed: ${rJson.Err()}`);
+
+  const dataUrl = findFirstDataImageUrl(rJson.Ok());
+  if (!dataUrl) {
+    return Result.Err("icon-gen response did not contain a data:image/ URL");
+  }
+
+  const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
+  if (!match) return Result.Err("icon-gen data URL not in base64 form");
+  const mime = match[1];
+  const rBytes = exception2Result(() => Uint8Array.from(atob(match[2]), (c) => c.charCodeAt(0)));
+  if (rBytes.isErr()) return Result.Err(`icon-gen base64 decode failed: ${rBytes.Err()}`);
+
+  return Result.Ok({ bytes: rBytes.Ok(), mime });
+}
+
+// Walks arbitrary JSON looking for the first string that looks like
+// `data:image/...;base64,...`. Robust across the two shapes OpenRouter returns
+// for image responses: `choices[0].message.images[].image_url.url` and
+// `choices[0].message.content[].image_url.url`.
+function findFirstDataImageUrl(node: unknown): string | undefined {
+  if (typeof node === "string") {
+    return node.startsWith("data:image/") ? node : undefined;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      const hit = findFirstDataImageUrl(item);
+      if (hit) return hit;
+    }
+    return undefined;
+  }
+  if (node && typeof node === "object") {
+    for (const v of Object.values(node)) {
+      const hit = findFirstDataImageUrl(v);
+      if (hit) return hit;
+    }
+  }
+  return undefined;
+}

--- a/vibes.diy/api/queue/queue-ctx.ts
+++ b/vibes.diy/api/queue/queue-ctx.ts
@@ -17,6 +17,8 @@ export interface QueueCtxParams {
       VIBES_DIY_FROM_EMAIL: string;
       DB_FLAVOUR: string;
       NEON_DATABASE_URL?: string;
+      LLM_BACKEND_URL: string;
+      LLM_BACKEND_API_KEY: string;
     };
   };
 }

--- a/vibes.diy/api/queue/queue-evento.ts
+++ b/vibes.diy/api/queue/queue-evento.ts
@@ -3,12 +3,14 @@ import { evtNewFsIdEvento } from "./handlers/evt-new-fs-id.js";
 import { evtAppSettingEvento } from "./handlers/evt-app-setting.js";
 import { evtInviteGrantEvento } from "./handlers/evt-invite-grant.js";
 import { evtRequestGrantEvento } from "./handlers/evt-request-grant.js";
+import { evtIconGenEvento } from "./handlers/evt-icon-gen.js";
 import { MsgBaseEventoEnDecoder } from "@vibes.diy/api-pkg";
 
 export const vibesQueueEvento = Lazy(() => {
   const evento = new Evento(new MsgBaseEventoEnDecoder());
   evento.push(
     evtNewFsIdEvento,
+    evtIconGenEvento,
     evtAppSettingEvento,
     evtInviteGrantEvento,
     evtRequestGrantEvento,

--- a/vibes.diy/api/queue/worker.ts
+++ b/vibes.diy/api/queue/worker.ts
@@ -28,6 +28,8 @@ export default {
           VIBES_DIY_FROM_EMAIL: env.VIBES_DIY_FROM_EMAIL,
           DB_FLAVOUR: toDBFlavour(env.DB_FLAVOUR),
           NEON_DATABASE_URL: env.NEON_DATABASE_URL,
+          LLM_BACKEND_URL: env.LLM_BACKEND_URL,
+          LLM_BACKEND_API_KEY: env.LLM_BACKEND_API_KEY,
         },
       },
     });

--- a/vibes.diy/api/svc/public/ensure-app-settings.ts
+++ b/vibes.diy/api/svc/public/ensure-app-settings.ts
@@ -14,6 +14,7 @@ import {
   isActiveModelSettingApp,
   isActiveModelSettingChat,
   isActiveModelSettingImg,
+  isActiveIcon,
   isActiveSkills,
   isReqEnsureAppSettingsImg,
   isReqEnsureAppSettingsSkills,
@@ -86,6 +87,9 @@ export function buildEnsureEntryResult(entries: ActiveEntry[]): AppSettings {
         break;
       case isActiveSkills(e):
         result.entry.settings.skills = e.skills;
+        break;
+      case isActiveIcon(e):
+        result.entry.settings.icon = { cid: e.cid, mime: e.mime };
         break;
       case isActiveModelSettingChat(e):
         result.entry.settings.chat = e.param;

--- a/vibes.diy/api/svc/public/vibes-icon.ts
+++ b/vibes.diy/api/svc/public/vibes-icon.ts
@@ -1,0 +1,112 @@
+import {
+  EventoHandler,
+  EventoResult,
+  EventoResultType,
+  HandleTriggerCtx,
+  Option,
+  Result,
+  URI,
+  ValidateTriggerCtx,
+  exception2Result,
+} from "@adviser/cement";
+import {
+  ActiveEntry,
+  HttpResponseBodyType,
+  HttpResponseJsonType,
+  isActiveIcon,
+  isFetchErrResult,
+  isFetchNotFoundResult,
+  isFetchOkResult,
+  parseArrayWarning,
+} from "@vibes.diy/api-types";
+import { and, eq } from "drizzle-orm/sql/expressions";
+import { VibesApiSQLCtx } from "../types.js";
+
+interface ValidatedIconReq {
+  userSlug: string;
+  appSlug: string;
+}
+
+// Parses `/vibes-icon/:userSlug/:appSlug` — trailing slashes ignored.
+function parseIconPath(pathname: string): ValidatedIconReq | undefined {
+  const parts = pathname.split("/").filter((p) => p.length > 0);
+  if (parts.length !== 3 || parts[0] !== "vibes-icon") return undefined;
+  return { userSlug: parts[1], appSlug: parts[2] };
+}
+
+export const vibesIcon: EventoHandler<Request, ValidatedIconReq, unknown> = {
+  hash: "vibes-icon",
+  validate: (ctx: ValidateTriggerCtx<Request, ValidatedIconReq, unknown>) => {
+    const { request: req } = ctx;
+    if (!req) return Promise.resolve(Result.Ok(Option.None()));
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      return Promise.resolve(Result.Ok(Option.None()));
+    }
+    const url = URI.from(req.url);
+    const parsed = parseIconPath(url.pathname);
+    if (!parsed) return Promise.resolve(Result.Ok(Option.None()));
+    return Promise.resolve(Result.Ok(Option.Some(parsed)));
+  },
+  handle: async (ctx: HandleTriggerCtx<Request, ValidatedIconReq, unknown>): Promise<Result<EventoResultType>> => {
+    const vctx = ctx.ctx.getOrThrow<VibesApiSQLCtx>("vibesApiCtx");
+    const { userSlug, appSlug } = ctx.validated;
+
+    const rRow = await exception2Result(() =>
+      vctx.sql.db
+        .select({ settings: vctx.sql.tables.appSettings.settings })
+        .from(vctx.sql.tables.appSettings)
+        .where(
+          and(eq(vctx.sql.tables.appSettings.userSlug, userSlug), eq(vctx.sql.tables.appSettings.appSlug, appSlug))
+        )
+        .limit(1)
+        .then((r) => r[0])
+    );
+    if (rRow.isErr() || !rRow.Ok()) {
+      return notFound(ctx, userSlug, appSlug);
+    }
+
+    const { filtered: entries } = parseArrayWarning((rRow.Ok().settings as unknown[]) ?? [], ActiveEntry);
+    const iconEntry = entries.find(isActiveIcon);
+    if (!iconEntry) {
+      return notFound(ctx, userSlug, appSlug);
+    }
+
+    const rAsset = await vctx.storage.fetch(iconEntry.cid);
+    switch (true) {
+      case isFetchOkResult(rAsset):
+        await ctx.send.send(ctx, {
+          type: "http.Response.Body",
+          status: 200,
+          headers: {
+            "Content-Type": iconEntry.mime,
+            "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+          },
+          body: rAsset.data,
+        } satisfies HttpResponseBodyType);
+        break;
+      case isFetchNotFoundResult(rAsset):
+        return notFound(ctx, userSlug, appSlug);
+      case isFetchErrResult(rAsset):
+      default:
+        await ctx.send.send(ctx, {
+          type: "http.Response.JSON",
+          status: 500,
+          json: { type: "error", message: `Failed to fetch icon asset for ${userSlug}/${appSlug}` },
+        } satisfies HttpResponseJsonType);
+    }
+    return Result.Ok(EventoResult.Stop);
+  },
+};
+
+async function notFound(
+  ctx: HandleTriggerCtx<Request, ValidatedIconReq, unknown>,
+  userSlug: string,
+  appSlug: string
+): Promise<Result<EventoResultType>> {
+  await ctx.send.send(ctx, {
+    type: "http.Response.JSON",
+    status: 404,
+    json: { type: "error", message: `No icon for ${userSlug}/${appSlug}` },
+  } satisfies HttpResponseJsonType);
+  return Result.Ok(EventoResult.Stop);
+}

--- a/vibes.diy/api/svc/public/vibes-icon.ts
+++ b/vibes.diy/api/svc/public/vibes-icon.ts
@@ -22,6 +22,7 @@ import {
   parseArrayWarning,
 } from "@vibes.diy/api-types";
 import { and, eq } from "drizzle-orm/sql/expressions";
+import { ensureLogger } from "@fireproof/core-runtime";
 import { VibesApiSQLCtx } from "../types.js";
 
 interface ValidatedIconReq {
@@ -63,12 +64,14 @@ export const vibesIcon: EventoHandler<Request, ValidatedIconReq, unknown> = {
         .limit(1)
         .then((r) => r[0])
     );
-    if (rRow.isErr() || !rRow.Ok()) {
-      return notFound(vctx, ctx, userSlug, appSlug);
+    if (rRow.isErr()) {
+      ensureLogger(vctx.sthis, "vibesIcon").Error().Any({ err: rRow.Err(), userSlug, appSlug }).Msg("appSettings read failed");
+      return serverError(ctx, userSlug, appSlug);
     }
-
-    const { filtered: entries } = parseArrayWarning((rRow.Ok().settings as unknown[]) ?? [], ActiveEntry);
+    const row = rRow.Ok();
+    const entries = row ? parseArrayWarning((row.settings as unknown[]) ?? [], ActiveEntry).filtered : [];
     const iconEntry = entries.find(isActiveIcon);
+
     if (!iconEntry) {
       return notFound(vctx, ctx, userSlug, appSlug);
     }
@@ -85,20 +88,55 @@ export const vibesIcon: EventoHandler<Request, ValidatedIconReq, unknown> = {
           },
           body: rAsset.data,
         } satisfies HttpResponseBodyType);
-        break;
+        return Result.Ok(EventoResult.Stop);
       case isFetchNotFoundResult(rAsset):
+        // Stale ActiveIcon — underlying storage blob was deleted or never
+        // landed. Clear the entry so the next repair event regenerates
+        // instead of short-circuiting on the dangling cid.
+        await clearStaleIcon(vctx, userSlug, appSlug, entries, iconEntry.cid);
         return notFound(vctx, ctx, userSlug, appSlug);
       case isFetchErrResult(rAsset):
       default:
-        await ctx.send.send(ctx, {
-          type: "http.Response.JSON",
-          status: 500,
-          json: { type: "error", message: `Failed to fetch icon asset for ${userSlug}/${appSlug}` },
-        } satisfies HttpResponseJsonType);
+        ensureLogger(vctx.sthis, "vibesIcon").Error().Any({ userSlug, appSlug, cid: iconEntry.cid }).Msg("storage.fetch failed");
+        return serverError(ctx, userSlug, appSlug);
     }
-    return Result.Ok(EventoResult.Stop);
   },
 };
+
+async function isKnownApp(vctx: VibesApiSQLCtx, userSlug: string, appSlug: string): Promise<boolean> {
+  const rBinding = await exception2Result(() =>
+    vctx.sql.db
+      .select({ appSlug: vctx.sql.tables.appSlugBinding.appSlug })
+      .from(vctx.sql.tables.appSlugBinding)
+      .where(and(eq(vctx.sql.tables.appSlugBinding.userSlug, userSlug), eq(vctx.sql.tables.appSlugBinding.appSlug, appSlug)))
+      .limit(1)
+      .then((r) => r[0])
+  );
+  return rBinding.isOk() && rBinding.Ok() !== undefined;
+}
+
+async function clearStaleIcon(
+  vctx: VibesApiSQLCtx,
+  userSlug: string,
+  appSlug: string,
+  entries: ActiveEntry[],
+  staleCid: string
+): Promise<void> {
+  const remaining = entries.filter((e) => !isActiveIcon(e) || e.cid !== staleCid);
+  const now = new Date().toISOString();
+  const rUp = await exception2Result(() =>
+    vctx.sql.db
+      .update(vctx.sql.tables.appSettings)
+      .set({ settings: remaining, updated: now })
+      .where(and(eq(vctx.sql.tables.appSettings.userSlug, userSlug), eq(vctx.sql.tables.appSettings.appSlug, appSlug)))
+  );
+  if (rUp.isErr()) {
+    ensureLogger(vctx.sthis, "vibesIcon")
+      .Error()
+      .Any({ err: rUp.Err(), userSlug, appSlug, staleCid })
+      .Msg("failed to clear stale ActiveIcon");
+  }
+}
 
 async function notFound(
   vctx: VibesApiSQLCtx,
@@ -106,23 +144,38 @@ async function notFound(
   userSlug: string,
   appSlug: string
 ): Promise<Result<EventoResultType>> {
-  // Lazy hydration: enqueue a repair event so the icon gets generated on a
-  // future load. The handler dedupes if ActiveIcon already landed between
-  // this call and its turn on the queue.
-  void vctx
-    .postQueue({
-      payload: { type: "vibes.diy.evt-icon-repair", userSlug, appSlug },
-      tid: "queue-event",
-      src: "vibesIcon",
-      dst: "vibes-service",
-      ttl: 1,
-    } satisfies MsgBase<EvtIconRepair>)
-    .catch(() => undefined);
+  // Lazy hydration: only enqueue repair when the app actually exists. Without
+  // this gate, /vibes-icon is a public endpoint that any visitor can hit with
+  // arbitrary slugs — unbounded queue churn otherwise.
+  if (await isKnownApp(vctx, userSlug, appSlug)) {
+    void vctx
+      .postQueue({
+        payload: { type: "vibes.diy.evt-icon-repair", userSlug, appSlug },
+        tid: "queue-event",
+        src: "vibesIcon",
+        dst: "vibes-service",
+        ttl: 1,
+      } satisfies MsgBase<EvtIconRepair>)
+      .catch(() => undefined);
+  }
 
   await ctx.send.send(ctx, {
     type: "http.Response.JSON",
     status: 404,
     json: { type: "error", message: `No icon for ${userSlug}/${appSlug}` },
+  } satisfies HttpResponseJsonType);
+  return Result.Ok(EventoResult.Stop);
+}
+
+async function serverError(
+  ctx: HandleTriggerCtx<Request, ValidatedIconReq, unknown>,
+  userSlug: string,
+  appSlug: string
+): Promise<Result<EventoResultType>> {
+  await ctx.send.send(ctx, {
+    type: "http.Response.JSON",
+    status: 500,
+    json: { type: "error", message: `Failed to serve icon for ${userSlug}/${appSlug}` },
   } satisfies HttpResponseJsonType);
   return Result.Ok(EventoResult.Stop);
 }

--- a/vibes.diy/api/svc/public/vibes-icon.ts
+++ b/vibes.diy/api/svc/public/vibes-icon.ts
@@ -11,8 +11,10 @@ import {
 } from "@adviser/cement";
 import {
   ActiveEntry,
+  EvtIconRepair,
   HttpResponseBodyType,
   HttpResponseJsonType,
+  MsgBase,
   isActiveIcon,
   isFetchErrResult,
   isFetchNotFoundResult,
@@ -62,13 +64,13 @@ export const vibesIcon: EventoHandler<Request, ValidatedIconReq, unknown> = {
         .then((r) => r[0])
     );
     if (rRow.isErr() || !rRow.Ok()) {
-      return notFound(ctx, userSlug, appSlug);
+      return notFound(vctx, ctx, userSlug, appSlug);
     }
 
     const { filtered: entries } = parseArrayWarning((rRow.Ok().settings as unknown[]) ?? [], ActiveEntry);
     const iconEntry = entries.find(isActiveIcon);
     if (!iconEntry) {
-      return notFound(ctx, userSlug, appSlug);
+      return notFound(vctx, ctx, userSlug, appSlug);
     }
 
     const rAsset = await vctx.storage.fetch(iconEntry.cid);
@@ -85,7 +87,7 @@ export const vibesIcon: EventoHandler<Request, ValidatedIconReq, unknown> = {
         } satisfies HttpResponseBodyType);
         break;
       case isFetchNotFoundResult(rAsset):
-        return notFound(ctx, userSlug, appSlug);
+        return notFound(vctx, ctx, userSlug, appSlug);
       case isFetchErrResult(rAsset):
       default:
         await ctx.send.send(ctx, {
@@ -99,10 +101,24 @@ export const vibesIcon: EventoHandler<Request, ValidatedIconReq, unknown> = {
 };
 
 async function notFound(
+  vctx: VibesApiSQLCtx,
   ctx: HandleTriggerCtx<Request, ValidatedIconReq, unknown>,
   userSlug: string,
   appSlug: string
 ): Promise<Result<EventoResultType>> {
+  // Lazy hydration: enqueue a repair event so the icon gets generated on a
+  // future load. The handler dedupes if ActiveIcon already landed between
+  // this call and its turn on the queue.
+  void vctx
+    .postQueue({
+      payload: { type: "vibes.diy.evt-icon-repair", userSlug, appSlug },
+      tid: "queue-event",
+      src: "vibesIcon",
+      dst: "vibes-service",
+      ttl: 1,
+    } satisfies MsgBase<EvtIconRepair>)
+    .catch(() => undefined);
+
   await ctx.send.send(ctx, {
     type: "http.Response.JSON",
     status: 404,

--- a/vibes.diy/api/svc/vibes-req-res-evento.ts
+++ b/vibes.diy/api/svc/vibes-req-res-evento.ts
@@ -13,6 +13,7 @@ import { ReqResEventoEnDecoder } from "@vibes.diy/api-pkg";
 import { HttpResponseJsonType } from "@vibes.diy/api-types";
 import { servEntryPoint } from "./public/serv-entry-point.js";
 import { cidAsset } from "./public/cid-asset.js";
+import { vibesIcon } from "./public/vibes-icon.js";
 
 export const vibesReqResEvento = Lazy(() => {
   const evento = new Evento(new ReqResEventoEnDecoder());
@@ -36,6 +37,7 @@ export const vibesReqResEvento = Lazy(() => {
       },
     },
     cidAsset,
+    vibesIcon,
     servEntryPoint,
     {
       type: EventoType.WildCard,

--- a/vibes.diy/api/types/cf-env.ts
+++ b/vibes.diy/api/types/cf-env.ts
@@ -26,6 +26,9 @@ export interface CFEnv {
   RESEND_API_KEY: string;
   VIBES_DIY_FROM_EMAIL: string;
 
+  LLM_BACKEND_URL: string;
+  LLM_BACKEND_API_KEY: string;
+
   CHAT_SESSIONS: DurableObjectNamespace;
   VIBES_SERVICE: Queue;
   BROWSER: Fetcher; // screenshotter uses Cloudflare's Browser Rendering API, which is accessed via a Fetcher binding

--- a/vibes.diy/api/types/chat.ts
+++ b/vibes.diy/api/types/chat.ts
@@ -236,6 +236,17 @@ export function isEvtNewFsId(obj: unknown): obj is EvtNewFsId {
   return !(evtNewFsId(obj) instanceof type.errors);
 }
 
+export const evtIconRepair = type({
+  type: "'vibes.diy.evt-icon-repair'",
+  userSlug: "string",
+  appSlug: "string",
+});
+export type EvtIconRepair = typeof evtIconRepair.infer;
+
+export function isEvtIconRepair(obj: unknown): obj is EvtIconRepair {
+  return !(evtIconRepair(obj) instanceof type.errors);
+}
+
 export const reqListModels = type({
   type: "'vibes.diy.req-list-models'",
 });

--- a/vibes.diy/api/types/invite.ts
+++ b/vibes.diy/api/types/invite.ts
@@ -300,6 +300,16 @@ export function isActiveSkills(obj: unknown): obj is ActiveSkills {
   return !(ActiveSkills(obj) instanceof type.errors);
 }
 
+export const ActiveIcon = type({
+  type: "'active.icon'",
+  cid: "string",
+  mime: "string",
+});
+export type ActiveIcon = typeof ActiveIcon.infer;
+export function isActiveIcon(obj: unknown): obj is ActiveIcon {
+  return !(ActiveIcon(obj) instanceof type.errors);
+}
+
 export const ActiveModelSettingBase = type({
   type: "'active.model'",
   param: AIParams,
@@ -354,6 +364,7 @@ export const ActiveEntry = EnablePublicAccess.or(ActiveRequest)
   .or(EnableRequest)
   .or(ActiveTitle)
   .or(ActiveSkills)
+  .or(ActiveIcon)
   .or(ActiveModelSetting)
   .or(ActiveEnv);
 

--- a/vibes.diy/api/types/settings.ts
+++ b/vibes.diy/api/types/settings.ts
@@ -195,6 +195,7 @@ export const AppSettings = type({
     settings: {
       "title?": "string",
       "skills?": type("string").array(),
+      "icon?": type({ cid: "string", mime: "string" }),
       "app?": AIParams.partial(),
       "chat?": AIParams.partial(),
       "img?": AIParams.partial(),

--- a/vibes.diy/pkg/app/components/ChatHeaderContent.tsx
+++ b/vibes.diy/pkg/app/components/ChatHeaderContent.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from "react";
+import React, { memo, useEffect, useState } from "react";
 import { PILL_CLEARANCE } from "./PillPortal.js";
 
 interface ChatHeaderContentProps {
@@ -12,18 +12,16 @@ interface ChatHeaderContentProps {
 
 function ChatHeaderContent({ title, promptProcessing, codeReady, remixOf, userSlug, appSlug }: ChatHeaderContentProps) {
   const [iconFailed, setIconFailed] = useState(false);
+  useEffect(() => {
+    setIconFailed(false);
+  }, [userSlug, appSlug]);
   const iconSrc = userSlug && appSlug && !iconFailed ? `/vibes-icon/${userSlug}/${appSlug}` : undefined;
 
   return (
     <div className="flex h-full w-full items-center justify-between p-2 py-4" style={{ paddingLeft: PILL_CLEARANCE }}>
       <div className="text-light-primary dark:text-dark-primary flex items-center gap-2 text-center text-sm">
         {iconSrc ? (
-          <img
-            src={iconSrc}
-            alt=""
-            className="h-5 w-5 rounded-sm"
-            onError={() => setIconFailed(true)}
-          />
+          <img src={iconSrc} alt="" className="h-5 w-5 rounded-sm" onError={() => setIconFailed(true)} />
         ) : null}
         {remixOf ? (
           <span>

--- a/vibes.diy/pkg/app/components/ChatHeaderContent.tsx
+++ b/vibes.diy/pkg/app/components/ChatHeaderContent.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import React, { memo, useState } from "react";
 import { PILL_CLEARANCE } from "./PillPortal.js";
 
 interface ChatHeaderContentProps {
@@ -6,14 +6,27 @@ interface ChatHeaderContentProps {
   promptProcessing: boolean;
   codeReady: boolean;
   remixOf?: string;
+  userSlug?: string;
+  appSlug?: string;
 }
 
-function ChatHeaderContent({ title, promptProcessing, codeReady, remixOf }: ChatHeaderContentProps) {
+function ChatHeaderContent({ title, promptProcessing, codeReady, remixOf, userSlug, appSlug }: ChatHeaderContentProps) {
+  const [iconFailed, setIconFailed] = useState(false);
+  const iconSrc = userSlug && appSlug && !iconFailed ? `/vibes-icon/${userSlug}/${appSlug}` : undefined;
+
   return (
     <div className="flex h-full w-full items-center justify-between p-2 py-4" style={{ paddingLeft: PILL_CLEARANCE }}>
-      <div className="text-light-primary dark:text-dark-primary text-center text-sm">
+      <div className="text-light-primary dark:text-dark-primary flex items-center gap-2 text-center text-sm">
+        {iconSrc ? (
+          <img
+            src={iconSrc}
+            alt=""
+            className="h-5 w-5 rounded-sm"
+            onError={() => setIconFailed(true)}
+          />
+        ) : null}
         {remixOf ? (
-          <>
+          <span>
             <a
               href={`https://${remixOf}.vibesdiy.app/`}
               target="_blank"
@@ -23,9 +36,9 @@ function ChatHeaderContent({ title, promptProcessing, codeReady, remixOf }: Chat
               🔀
             </a>{" "}
             {title}
-          </>
+          </span>
         ) : (
-          title
+          <span>{title}</span>
         )}
       </div>
 
@@ -54,6 +67,8 @@ export default memo(ChatHeaderContent, (prevProps, nextProps) => {
     prevProps.remixOf === nextProps.remixOf &&
     prevProps.title === nextProps.title &&
     prevProps.promptProcessing === nextProps.promptProcessing &&
-    prevProps.codeReady === nextProps.codeReady
+    prevProps.codeReady === nextProps.codeReady &&
+    prevProps.userSlug === nextProps.userSlug &&
+    prevProps.appSlug === nextProps.appSlug
   );
 });

--- a/vibes.diy/pkg/app/components/RecentVibes.tsx
+++ b/vibes.diy/pkg/app/components/RecentVibes.tsx
@@ -13,6 +13,19 @@ interface RecentVibeItem {
   appSlug: string;
 }
 
+function VibeIconThumb({ userSlug, appSlug }: { userSlug: string; appSlug: string }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return <span className="h-6 w-6 flex-shrink-0 rounded-sm bg-black/10 dark:bg-white/10" aria-hidden />;
+  return (
+    <img
+      src={`/vibes-icon/${userSlug}/${appSlug}`}
+      alt=""
+      className="h-6 w-6 flex-shrink-0 rounded-sm bg-black/5 dark:bg-white/5"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
 export function toRecentVibes(items: ResListUserSlugAppSlugItem[], limit: number): RecentVibeItem[] {
   if (limit <= 0) return [];
   const out: RecentVibeItem[] = [];
@@ -81,8 +94,9 @@ export function RecentVibes({ onNavigate }: RecentVibesProps) {
                 <Link
                   to={`/chat/${item.userSlug}/${item.appSlug}`}
                   onClick={onNavigate}
-                  className="flex items-center pl-2 pr-4 py-2 text-sm transition-colors hover:bg-black/5 dark:hover:bg-white/5 border-b border-black/5 dark:border-white/5"
+                  className="flex items-center gap-2 pl-2 pr-4 py-2 text-sm transition-colors hover:bg-black/5 dark:hover:bg-white/5 border-b border-black/5 dark:border-white/5"
                 >
+                  <VibeIconThumb userSlug={item.userSlug} appSlug={item.appSlug} />
                   <span className="flex flex-col min-w-0">
                     <span className="truncate">{item.appSlug}</span>
                     <span className="text-xs truncate opacity-50">{item.userSlug}</span>

--- a/vibes.diy/pkg/app/components/RecentVibes.tsx
+++ b/vibes.diy/pkg/app/components/RecentVibes.tsx
@@ -15,6 +15,9 @@ interface RecentVibeItem {
 
 function VibeIconThumb({ userSlug, appSlug }: { userSlug: string; appSlug: string }) {
   const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    setFailed(false);
+  }, [userSlug, appSlug]);
   if (failed) return <span className="h-6 w-6 flex-shrink-0 rounded-sm bg-black/10 dark:bg-white/10" aria-hidden />;
   return (
     <img

--- a/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
+++ b/vibes.diy/pkg/app/routes/chat/chat.$userSlug.$appSlug.tsx
@@ -432,6 +432,8 @@ export function Chat({ inConstruction = false }: { inConstruction?: boolean }) {
             promptProcessing={promptState.running}
             codeReady={promptState.hasCode}
             title={promptState.title}
+            userSlug={userSlug}
+            appSlug={appSlug}
           />
         }
         headerRight={


### PR DESCRIPTION
## Summary

Revives the b/w app-icon generation that lived in the removed `hosting/` worker (commit `7f2eebfd`), on the v2 queue + `app_settings` stack.

- **Types**: adds `ActiveIcon` (stored in `app_settings.settings` alongside `ActiveTitle`/`ActiveSkills`) and `EvtIconRepair`. Surfaces `active.icon` via the `ensureAppSettings` readback.
- **Queue handler**: sibling to `processScreenShotEvent` on `evt-new-fs-id`; also handles a new `evt-icon-repair`. Calls `LLM_BACKEND_URL` in image-modality mode (`openai/gpt-5-image-mini`, `modalities:[text,image]`), keyed by the app's `active.title` (falls back to `appSlug`). Revives the original prompt: *"Minimal black icon on a white background, enclosed in a circle, representing ${category}. Use clear, text-free imagery to convey the category. Avoid letters or numbers."* Decoded PNG bytes go through `storage.ensure`; the CID lands in an `ActiveIcon` entry on the app-settings row.
- **Dedup**: handler skips if `ActiveIcon` already exists — duplicate `evt-new-fs-id` deliveries and lazy-repair pings are both idempotent.
- **Endpoint**: `GET /vibes-icon/:userSlug/:appSlug` streams the PNG from storage. On 404 (missing/generating) it enqueues `evt-icon-repair` for lazy hydration, so any surface rendering the `<img>` triggers gen.
- **UI**: `ChatHeaderContent` renders `<img src="/vibes-icon/{u}/{a}">` left of the title; each row in the `RecentVibes` sidebar gets the same thumbnail slot. Both hide via `onError` when 404 comes back, so first-load looks clean and refills on re-render once the icon lands.

## Test plan

- [ ] `pnpm check` (build + lint + test) clean locally — 569 pass / 11 skipped (same flake set as #1398, non-deterministic)
- [ ] New chat from home form → within ~20-30s of the code block landing, `GET /vibes-icon/:u/:a` returns 200 with a black-on-white PNG
- [ ] Header refresh shows the icon left of the title
- [ ] Sidebar "Recent Vibes" rows render their icons
- [ ] Open a pre-existing vibe → 404 fires `evt-icon-repair` → icon appears after next render
- [ ] Duplicate `evt-new-fs-id` or rapid reloads → queue handler skips (only one `active.icon` entry ever lands)
- [ ] Block `LLM_BACKEND_URL` → CF queue retries with backoff, no phantom `active.icon` written

## Not in scope

- User-editable icon via settings UI / regenerate button
- Regen on every code update (only on first upload + 404-driven lazy repair)
- Sweeper/cron backfill for every historical vibe

🤖 Generated with [Claude Code](https://claude.com/claude-code)