### PR TITLE
fix(homepage): 'sharable' -> 'shareable' in prompt placeholder

### DIFF
--- a/vibes.diy/pkg/app/components/HomePage.tsx
+++ b/vibes.diy/pkg/app/components/HomePage.tsx
@@ -180,7 +180,7 @@ export default function HomePage() {
                       handleSubmit();
                     }
                   }}
-                  placeholder="Describe your vibe to make it a sharable app."
+                  placeholder="Describe your vibe to make it a shareable app."
                   style={getTextareaStyle()}
                 />
                 <button onClick={handleSubmit} disabled={!input.trim()} style={getSubmitButtonStyle()}>


### PR DESCRIPTION
## Summary

The HomePage prompt textarea's placeholder read \"Describe your vibe to make it a **sharable** app.\" Every other user-visible string (WelcomeScreen \"Shareable in seconds\", \`useShareableDB\` hook, \`ShareableDBInfo\` type) uses the **shareable** spelling. Aligned the placeholder so the homepage wording is consistent.

Closes #1419

## Testing

Single-line text change.