### PR TITLE
fix(api): drain pending access requests when auto-accept is enabled

### DIFF
--- a/vibes.diy/api/svc/public/ensure-app-settings.ts
+++ b/vibes.diy/api/svc/public/ensure-app-settings.ts
@@ -244,11 +244,14 @@ export async function ensureAppSettings(
       );
 
       if (!res.error && !prevAutoAccept && nextAutoAccept) {
-        await approveAllPendingRequests(vctx, {
+        const drained = await approveAllPendingRequests(vctx, {
           userId: res.userId,
           appSlug: res.appSlug,
           userSlug: res.userSlug,
         });
+        if (drained.isErr()) {
+          res.error = drained.Err().message;
+        }
       }
       break;
     }

--- a/vibes.diy/api/svc/public/ensure-app-settings.ts
+++ b/vibes.diy/api/svc/public/ensure-app-settings.ts
@@ -40,6 +40,7 @@ import { VibesApiSQLCtx } from "../types.js";
 import { optAuth } from "../check-auth.js";
 import { eq, and } from "drizzle-orm/sql/expressions";
 import { getModelDefaults } from "../intern/get-model-defaults.js";
+import { approveAllPendingRequests } from "./request-flow.js";
 // import { buildEnsureEntryResult } from "../intern/application-settings.js";
 
 export function buildEnsureEntryResult(entries: ActiveEntry[]): AppSettings {
@@ -225,7 +226,10 @@ export async function ensureAppSettings(
       );
       break;
 
-    case isReqRequest(req):
+    case isReqRequest(req): {
+      const prevAutoAccept = settings.find(isEnableRequest)?.autoAcceptViewRequest === true;
+      const nextAutoAccept = req.request.autoAcceptViewRequest === true;
+
       [res.settings, res.error] = await sqlUpsert(
         vctx,
         res,
@@ -238,7 +242,16 @@ export async function ensureAppSettings(
             autoAcceptViewRequest: req.request.autoAcceptViewRequest,
           }) satisfies EnableRequest
       );
+
+      if (!res.error && !prevAutoAccept && nextAutoAccept) {
+        await approveAllPendingRequests(vctx, {
+          userId: res.userId,
+          appSlug: res.appSlug,
+          userSlug: res.userSlug,
+        });
+      }
       break;
+    }
 
     case isReqEnsureAppSettingsTitle(req):
       [res.settings, res.error] = await sqlUpsert(

--- a/vibes.diy/api/svc/public/request-flow.ts
+++ b/vibes.diy/api/svc/public/request-flow.ts
@@ -55,6 +55,66 @@ async function sendUpdateEvent(vctx: VibesApiSQLCtx, value: Omit<EvtRequestGrant
   } satisfies MsgBase<EvtRequestGrant>);
 }
 
+export async function approveAllPendingRequests(
+  vctx: VibesApiSQLCtx,
+  ref: { userId: string; appSlug: string; userSlug: string }
+): Promise<Result<number>> {
+  const now = new Date().toISOString();
+
+  const rows = await vctx.sql.db
+    .select({
+      foreignUserId: vctx.sql.tables.requestGrants.foreignUserId,
+      foreignInfo: vctx.sql.tables.requestGrants.foreignInfo,
+      created: vctx.sql.tables.requestGrants.created,
+    })
+    .from(vctx.sql.tables.requestGrants)
+    .where(
+      and(
+        eq(vctx.sql.tables.requestGrants.userId, ref.userId),
+        eq(vctx.sql.tables.requestGrants.appSlug, ref.appSlug),
+        eq(vctx.sql.tables.requestGrants.userSlug, ref.userSlug),
+        eq(vctx.sql.tables.requestGrants.state, "pending")
+      )
+    );
+
+  if (rows.length === 0) return Result.Ok(0);
+
+  const rUpd = await exception2Result(() =>
+    vctx.sql.db
+      .update(vctx.sql.tables.requestGrants)
+      .set({ state: "approved", role: "viewer", updated: now })
+      .where(
+        and(
+          eq(vctx.sql.tables.requestGrants.userId, ref.userId),
+          eq(vctx.sql.tables.requestGrants.appSlug, ref.appSlug),
+          eq(vctx.sql.tables.requestGrants.userSlug, ref.userSlug),
+          eq(vctx.sql.tables.requestGrants.state, "pending")
+        )
+      )
+  );
+  if (rUpd.isErr()) return Result.Err(rUpd);
+
+  for (const row of rows) {
+    await sendUpdateEvent(vctx, {
+      op: "upsert",
+      userId: ref.userId,
+      grant: {
+        type: "vibes.diy.res-request-access",
+        appSlug: ref.appSlug,
+        userSlug: ref.userSlug,
+        foreignUserId: row.foreignUserId,
+        foreignInfo: row.foreignInfo as ForeignInfo,
+        role: "viewer",
+        state: "approved",
+        updated: now,
+        created: row.created,
+      },
+    });
+  }
+
+  return Result.Ok(rows.length);
+}
+
 export async function hasAccessRequest(
   vctx: VibesApiSQLCtx,
   req: { foreignUserId: string; appSlug: string; userSlug: string }

--- a/vibes.diy/api/svc/public/request-flow.ts
+++ b/vibes.diy/api/svc/public/request-flow.ts
@@ -61,24 +61,6 @@ export async function approveAllPendingRequests(
 ): Promise<Result<number>> {
   const now = new Date().toISOString();
 
-  const rows = await vctx.sql.db
-    .select({
-      foreignUserId: vctx.sql.tables.requestGrants.foreignUserId,
-      foreignInfo: vctx.sql.tables.requestGrants.foreignInfo,
-      created: vctx.sql.tables.requestGrants.created,
-    })
-    .from(vctx.sql.tables.requestGrants)
-    .where(
-      and(
-        eq(vctx.sql.tables.requestGrants.userId, ref.userId),
-        eq(vctx.sql.tables.requestGrants.appSlug, ref.appSlug),
-        eq(vctx.sql.tables.requestGrants.userSlug, ref.userSlug),
-        eq(vctx.sql.tables.requestGrants.state, "pending")
-      )
-    );
-
-  if (rows.length === 0) return Result.Ok(0);
-
   const rUpd = await exception2Result(() =>
     vctx.sql.db
       .update(vctx.sql.tables.requestGrants)
@@ -91,10 +73,16 @@ export async function approveAllPendingRequests(
           eq(vctx.sql.tables.requestGrants.state, "pending")
         )
       )
+      .returning({
+        foreignUserId: vctx.sql.tables.requestGrants.foreignUserId,
+        foreignInfo: vctx.sql.tables.requestGrants.foreignInfo,
+        created: vctx.sql.tables.requestGrants.created,
+      })
   );
   if (rUpd.isErr()) return Result.Err(rUpd);
+  const updated = rUpd.Ok();
 
-  for (const row of rows) {
+  for (const row of updated) {
     await sendUpdateEvent(vctx, {
       op: "upsert",
       userId: ref.userId,
@@ -112,7 +100,7 @@ export async function approveAllPendingRequests(
     });
   }
 
-  return Result.Ok(rows.length);
+  return Result.Ok(updated.length);
 }
 
 export async function hasAccessRequest(

--- a/vibes.diy/api/tests/api.test.ts
+++ b/vibes.diy/api/tests/api.test.ts
@@ -1000,6 +1000,59 @@ describe("VibesDiyApi", { timeout: (inject("DB_FLAVOUR" as never) as string) ===
       const listEditor = (await api.listRequestGrants({ appSlug, userSlug, pager: {} })).Ok();
       expect(listEditor.items[0].role).toBe("editor");
     });
+
+    it("drains pending queue when auto-accept is enabled", async () => {
+      const { appSlug, userSlug } = await createApp();
+
+      await api.ensureAppSettings({ appSlug, userSlug, request: { enable: true } });
+
+      const pending = (await api2.requestAccess({ appSlug, userSlug })).Ok();
+      expect(pending.state).toBe("pending");
+
+      const before = (await api.listRequestGrants({ appSlug, userSlug, pager: {} })).Ok();
+      expect(before.items).toHaveLength(1);
+      expect(before.items[0].state).toBe("pending");
+
+      await api.ensureAppSettings({
+        appSlug,
+        userSlug,
+        request: { enable: true, autoAcceptViewRequest: true },
+      });
+
+      const after = (await api.listRequestGrants({ appSlug, userSlug, pager: {} })).Ok();
+      expect(after.items).toHaveLength(1);
+      expect(after.items[0].state).toBe("approved");
+      expect(after.items[0].role).toBe("viewer");
+
+      const access = (await api2.hasAccessRequest({ appSlug, userSlug })).Ok();
+      if (!isResHasAccessRequestApproved(access)) {
+        assert.fail("Expected hasAccessRequest to be approved, got: " + JSON.stringify(access));
+      }
+      expect(access.state).toBe("approved");
+      expect(access.role).toBe("viewer");
+    });
+
+    it("does not re-approve revoked requests when auto-accept is enabled", async () => {
+      const { appSlug, userSlug } = await createApp();
+
+      await api.ensureAppSettings({ appSlug, userSlug, request: { enable: true } });
+
+      const requested = (await api2.requestAccess({ appSlug, userSlug })).Ok();
+      const foreignUserId = requested.foreignUserId;
+
+      await api.approveRequest({ appSlug, userSlug, foreignUserId, role: "viewer" });
+      await api.revokeRequest({ appSlug, userSlug, foreignUserId });
+
+      await api.ensureAppSettings({
+        appSlug,
+        userSlug,
+        request: { enable: true, autoAcceptViewRequest: true },
+      });
+
+      const after = (await api.listRequestGrants({ appSlug, userSlug, pager: {} })).Ok();
+      expect(after.items).toHaveLength(1);
+      expect(after.items[0].state).toBe("revoked");
+    });
   });
 
   describe("invite flow", () => {


### PR DESCRIPTION
Closes #1430.

## Summary
- Flipping `autoAcceptViewRequest` off → on now approves any existing `state='pending'` rows as `viewer` and emits an `evt-request-grant` upsert for each, so the auto-join toggle catches up the queue instead of stranding prior requesters.
- New helper `approveAllPendingRequests` in `vibes.diy/api/svc/public/request-flow.ts` handles the select → bulk update → per-row event emission (keeps the `state='pending'` predicate on the UPDATE to avoid racing concurrent revokes).
- `ensure-app-settings.ts` detects the off → on transition on the `isReqRequest` branch by comparing prior settings to the incoming request, and only drains when the flag is actually flipping on.
- Revoked rows are intentionally untouched — a prior explicit revoke is an admin decision to keep.

## Test plan
- [x] `cd vibes.diy/api/tests && pnpm test` — 79 passing (two new integration tests):
  - `drains pending queue when auto-accept is enabled`
  - `does not re-approve revoked requests when auto-accept is enabled`
- [x] `pnpm build` — typecheck clean
- [x] `pnpm lint` — clean
- [ ] Manual: queue a pending request on an app, flip the auto-join toggle on in the share modal, confirm `RequestsSection` shows the row as approved without reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)