### PR TITLE
feat: thread model prop through ImgVibes, fix cache bypass

### DIFF
--- a/use-vibes/types/img-vibes-types.ts
+++ b/use-vibes/types/img-vibes-types.ts
@@ -24,6 +24,7 @@ export interface VersionInfo {
   readonly created: number;
   readonly promptKey?: string; // e.g. "p1"
   readonly assetUrl: string; // "/assets/cid?url=...&mime=image/png"
+  readonly model?: string; // model used to generate this version
 }
 
 export type GenerationPhase = "idle" | "generating" | "complete" | "error";
@@ -35,6 +36,7 @@ export interface UseImgVibesOptions {
   readonly generationId: string;
   readonly skip: boolean;
   readonly inputImage?: File;
+  readonly model?: string;
 }
 
 export interface UseImgVibesResult {

--- a/vibes.diy/base/components/ImgVibes.tsx
+++ b/vibes.diy/base/components/ImgVibes.tsx
@@ -11,6 +11,7 @@ export interface ImgVibesProps {
   alt?: string;
   style?: React.CSSProperties;
   showControls?: boolean;
+  model?: string;
 }
 
 function promptToId(prompt: string): string {
@@ -22,7 +23,17 @@ function promptToId(prompt: string): string {
   return `img-${(hash >>> 0).toString(36)}`;
 }
 
-export function ImgVibes({ prompt, _id: propId, images, database, className, alt, style, showControls = true }: ImgVibesProps) {
+export function ImgVibes({
+  prompt,
+  _id: propId,
+  images,
+  database,
+  className,
+  alt,
+  style,
+  showControls = true,
+  model,
+}: ImgVibesProps) {
   const inputImage = images?.[0];
   const imageKey = inputImage ? `${inputImage.name}-${inputImage.size}-${inputImage.lastModified}` : "";
   const stableId = useMemo(() => propId ?? (prompt ? promptToId(prompt + imageKey) : undefined), [propId, prompt, imageKey]);
@@ -36,6 +47,7 @@ export function ImgVibes({ prompt, _id: propId, images, database, className, alt
     skip: !prompt && !stableId,
     generationId,
     inputImage,
+    model,
   });
 
   const versions = document?.versions ?? [];

--- a/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
+++ b/vibes.diy/base/hooks/img-vibes/use-img-vibes.ts
@@ -11,6 +11,7 @@ export function useImgVibes({
   skip = false,
   generationId,
   inputImage,
+  model,
 }: Partial<UseImgVibesOptions>): UseImgVibesResult {
   const [assetUrl, setAssetUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -26,7 +27,7 @@ export function useImgVibes({
   useEffect(() => {
     if (skip || !_id) return;
 
-    const genKey = `${_id}-${generationId ?? ""}-${inputImage?.name ?? ""}${inputImage?.lastModified ?? ""}`;
+    const genKey = `${_id}-${generationId ?? ""}-${inputImage?.name ?? ""}${inputImage?.lastModified ?? ""}-${model ?? ""}`;
     if (currentGenRef.current === genKey) return;
     currentGenRef.current = genKey;
 
@@ -43,7 +44,10 @@ export function useImgVibes({
       }
 
       // Cache hit: doc exists with versions, and this isn't a regen request or img2img
-      if (existingDoc?.versions?.length && !isRegen && !inputImage) {
+      // Bypass cache when a specific model is requested that differs from the stored version
+      const currentVer = existingDoc?.versions?.[existingDoc?.currentVersion ?? 0];
+      const modelMatch = !model || currentVer?.model === model;
+      if (existingDoc?.versions?.length && !isRegen && !inputImage && modelMatch) {
         const ver = existingDoc.versions[existingDoc.currentVersion ?? 0];
         if (ver?.assetUrl) {
           setDocument(existingDoc);
@@ -70,7 +74,7 @@ export function useImgVibes({
       setError(null);
 
       try {
-        const urls = await imgVibes(promptText, inputImage);
+        const urls = await imgVibes(promptText, inputImage, model);
         const imageUrl = urls[0];
         if (!imageUrl) throw new Error("No image URL received from service");
 
@@ -80,7 +84,7 @@ export function useImgVibes({
         if (existingDoc?._id && isRegen) {
           // Regen: append version to existing doc
           const fresh = (await db.get(existingDoc._id)) as PartialImageDocument;
-          const updated = addNewVersion(fresh as Required<PartialImageDocument>, imageUrl, promptText);
+          const updated = addNewVersion(fresh as Required<PartialImageDocument>, imageUrl, promptText, model);
           await db.put(updated);
           const saved = (await db.get(existingDoc._id)) as PartialImageDocument;
           setDocument(saved);
@@ -93,7 +97,7 @@ export function useImgVibes({
             prompt: promptText,
             created: now,
             currentVersion: 0,
-            versions: [{ id: "v1", created: now, promptKey: "p1", assetUrl: imageUrl }],
+            versions: [{ id: "v1", created: now, promptKey: "p1", assetUrl: imageUrl, ...(model ? { model } : {}) }],
             currentPromptKey: "p1",
             prompts: { p1: { text: promptText, created: now } },
           });
@@ -112,7 +116,7 @@ export function useImgVibes({
     }
 
     run();
-  }, [_id, prompt, generationId, skip, db, inputImage]);
+  }, [_id, prompt, generationId, skip, db, inputImage, model]);
 
   return { assetUrl, loading, progress, error, document };
 }

--- a/vibes.diy/base/hooks/img-vibes/utils.ts
+++ b/vibes.diy/base/hooks/img-vibes/utils.ts
@@ -40,7 +40,7 @@ export function getPromptsFromDocument(document: Partial<ImageDocument>): {
   return { prompts: {}, currentPromptKey: "" };
 }
 
-export function addNewVersion(document: ImageDocument, assetUrl: string, newPrompt?: string): ImageDocument {
+export function addNewVersion(document: ImageDocument, assetUrl: string, newPrompt?: string, model?: string): ImageDocument {
   const { versions } = getVersionsFromDocument(document);
   const versionCount = versions.length + 1;
   const newVersionId = generateVersionId(versionCount);
@@ -61,7 +61,10 @@ export function addNewVersion(document: ImageDocument, assetUrl: string, newProm
   return {
     ...document,
     currentVersion: versionCount - 1,
-    versions: [...versions, { id: newVersionId, created: Date.now(), promptKey: updatedCurrentPromptKey, assetUrl }],
+    versions: [
+      ...versions,
+      { id: newVersionId, created: Date.now(), promptKey: updatedCurrentPromptKey, assetUrl, ...(model ? { model } : {}) },
+    ],
     prompts: updatedPrompts,
     currentPromptKey: updatedCurrentPromptKey,
   };

--- a/vibes.diy/vibe/runtime/img-vibes.tsx
+++ b/vibes.diy/vibe/runtime/img-vibes.tsx
@@ -5,15 +5,15 @@ import { resizeImageToBase64 } from "./resize-image.js";
 // Re-export ImgVibes component from @vibes.diy/base so sandbox apps can import { ImgVibes } from "use-vibes"
 export { ImgVibes, useImgVibes } from "@vibes.diy/base";
 
-export let imgVibes: (prompt: string, inputImage?: File) => Promise<string[]>;
+export let imgVibes: (prompt: string, inputImage?: File, model?: string) => Promise<string[]>;
 
 export function registerImgVibes(vibeApi: VibeSandboxApi): void {
-  imgVibes = async (prompt: string, inputImage?: File): Promise<string[]> => {
+  imgVibes = async (prompt: string, inputImage?: File, model?: string): Promise<string[]> => {
     let inputImageBase64: string | undefined;
     if (inputImage) {
       inputImageBase64 = await resizeImageToBase64(inputImage);
     }
-    const rResult = await vibeApi.imgVibes(prompt, inputImageBase64);
+    const rResult = await vibeApi.imgVibes(prompt, inputImageBase64, model);
     if (rResult.isErr()) {
       throw rResult.Err();
     }

--- a/vibes.diy/vibe/runtime/register-dependencies.ts
+++ b/vibes.diy/vibe/runtime/register-dependencies.ts
@@ -108,12 +108,13 @@ export class VibeSandboxApi {
     );
   }
 
-  imgVibes(prompt: string, inputImageBase64?: string): Promise<Result<ResImgVibes>> {
+  imgVibes(prompt: string, inputImageBase64?: string, model?: string): Promise<Result<ResImgVibes>> {
     return this.request<ReqImgVibes, ResImgVibes>(
       {
         type: "vibe.req.imgVibes",
         prompt,
         ...(inputImageBase64 ? { inputImageBase64 } : {}),
+        ...(model ? { model } : {}),
         ...this.svc.vibeApp,
       },
       { wait: isResImgVibes, timeout: 120000 }

--- a/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
+++ b/vibes.diy/vibe/srv-sandbox/srv-sandbox.ts
@@ -411,7 +411,10 @@ function vibeImageGen(sandbox: vibesDiySrvSandbox): EventoHandler {
           const rPrompt = await rChat
             .Ok()
             .prompt(
-              { messages: [{ role: "user", content: [{ type: "text", text: ctx.validated.prompt }] }] },
+              {
+                messages: [{ role: "user", content: [{ type: "text", text: ctx.validated.prompt }] }],
+                ...(ctx.validated.model ? { model: ctx.validated.model } : {}),
+              },
               ctx.validated.inputImageBase64 ? { inputImageBase64: ctx.validated.inputImageBase64 } : undefined
             );
           if (rPrompt.isErr()) {

--- a/vibes.diy/vibe/types/index.ts
+++ b/vibes.diy/vibe/types/index.ts
@@ -221,6 +221,7 @@ export const ReqImgVibes = type({
   appSlug: "string",
   prompt: "string",
   "inputImageBase64?": "string",
+  "model?": "string",
 }).and(Base);
 
 export type ReqImgVibes = typeof ReqImgVibes.infer;


### PR DESCRIPTION
## Summary
- Adds `model` prop to `<ImgVibes>` and `useImgVibes`, threaded through runtime → sandbox API → server prompt
- Stores `model` on each `VersionInfo` so the cache can compare against the requested model
- Bypasses cache when a specific model is requested that differs from the stored version's model
- Server already supported `req.prompt.model` (prompt-chat-section.ts:580) — this change wires it up from the client

## Test plan
- [ ] `pnpm check` passes (format + build + test + lint)
- [ ] `<ImgVibes prompt="a cat" />` generates and caches as before (no model = accepts any cached version)
- [ ] `<ImgVibes _id="hero" prompt="a cat" model="openai/gpt-5-image-mini" />` regenerates even if `hero` was previously cached with Prodia
- [ ] Reverting the model prop shows the original cached version

🤖 Generated with [Claude Code](https://claude.com/claude-code)