### PR TITLE
fix: cache-bust vibe-pkg URLs with deploy commit SHA

### DIFF
--- a/vibes.diy/actions/deploy/action.yaml
+++ b/vibes.diy/actions/deploy/action.yaml
@@ -119,7 +119,7 @@ runs:
         NEON_DATABASE_URL: ${{ inputs.NEON_DATABASE_URL }}
         NEON_DATABASE_ADMIN_URL: ${{ inputs.NEON_DATABASE_ADMIN_URL }}
         MAX_APP_SLUG_PER_USER_ID: ${{ inputs.MAX_APP_SLUG_PER_USER_ID }}
-        WORKSPACE_NPM_URL: ${{ inputs.WORKSPACE_NPM_URL }}
+        WORKSPACE_NPM_URL: ${{ inputs.WORKSPACE_NPM_URL }}?v=${{ github.sha }}
         VIBES_DIY_API_URL: ${{ inputs.VIBES_DIY_API_URL }}
         PRODIA_TOKEN: ${{ inputs.PRODIA_TOKEN }}
       run: |


### PR DESCRIPTION
## Summary
- Append `?v=$GITHUB_SHA` to `WORKSPACE_NPM_URL` in the deploy action
- CF edge cache keys include query params, so each deploy gets fresh vibe-runtime/call-ai/etc
- Fixes stale cached vibe-runtime serving old code after deploys (caused white screenshots)

## Test plan
- [ ] Deploy via `vibes-diy@c` tag, verify import map URLs have `?v=` param
- [ ] Confirm vibe-runtime code is fresh (no `window.parent !== window` guard)
- [ ] Push a vibe and verify screenshot renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)