### PR TITLE
feat: add userSlug column to AppDocuments schema

### DIFF
--- a/vibes.diy/api/sql/vibes-diy-api-schema-pg.ts
+++ b/vibes.diy/api/sql/vibes-diy-api-schema-pg.ts
@@ -183,18 +183,19 @@ export const sqlRequestGrants = pgTable(
 export const sqlAppDocuments = pgTable(
   "AppDocuments",
   {
+    userSlug: text().notNull().default("unknown"),
     appSlug: text().notNull(),
     dbName: text().notNull().default("default"), // database namespace within app
     docId: text().notNull(),
-    seq: integer().notNull(), // monotonic per (appSlug, dbName, docId), starts at 1
+    seq: integer().notNull(), // monotonic per (userSlug, appSlug, dbName, docId), starts at 1
     userId: text().notNull().default("unknown"), // authenticated user who made this change
     data: jsonb().notNull(), // document JSON
     deleted: integer().notNull().default(0), // 1 = tombstone
     created: text().notNull(), // ISO timestamp of this revision
   },
   (table) => [
-    primaryKey({ columns: [table.appSlug, table.dbName, table.docId, table.seq] }),
-    index("AppDocuments_latest_idx").on(table.appSlug, table.dbName, table.docId, table.seq),
+    primaryKey({ columns: [table.userSlug, table.appSlug, table.dbName, table.docId, table.seq] }),
+    index("AppDocuments_latest_idx").on(table.userSlug, table.appSlug, table.dbName, table.docId, table.seq),
   ]
 );
 

--- a/vibes.diy/api/sql/vibes-diy-api-schema-sqlite.ts
+++ b/vibes.diy/api/sql/vibes-diy-api-schema-sqlite.ts
@@ -178,18 +178,19 @@ export const sqlRequestGrants = sqliteTable(
 export const sqlAppDocuments = sqliteTable(
   "AppDocuments",
   {
+    userSlug: text().notNull().default("unknown"),
     appSlug: text().notNull(),
     dbName: text().notNull().default("default"), // database namespace within app
     docId: text().notNull(),
-    seq: int().notNull(), // monotonic per (appSlug, dbName, docId), starts at 1
+    seq: int().notNull(), // monotonic per (userSlug, appSlug, dbName, docId), starts at 1
     userId: text().notNull().default("unknown"), // authenticated user who made this change
     data: text({ mode: "json" }).notNull(), // document JSON
     deleted: int().notNull().default(0), // 1 = tombstone
     created: text().notNull(), // ISO timestamp of this revision
   },
   (table) => [
-    primaryKey({ columns: [table.appSlug, table.dbName, table.docId, table.seq] }),
-    index("AppDocuments_latest_idx").on(table.appSlug, table.dbName, table.docId, table.seq),
+    primaryKey({ columns: [table.userSlug, table.appSlug, table.dbName, table.docId, table.seq] }),
+    index("AppDocuments_latest_idx").on(table.userSlug, table.appSlug, table.dbName, table.docId, table.seq),
   ]
 );
 


### PR DESCRIPTION
## Summary
- Adds `userSlug` column to `AppDocuments` table (both SQLite and PG schemas) with `NOT NULL DEFAULT 'unknown'`
- Updates primary key and index to include `userSlug`
- **Schema-only change** — no handler, type, or test modifications. Old code continues to work unchanged.

## Migration plan
1. Deploy this PR → `drizzle-kit push` adds the column and updates PK/index
2. Inspect prod data to map existing appSlugs to userSlugs via AppSlugBindings
3. Backfill `userSlug` on existing rows
4. Follow-up PR: scope handlers/types by `userSlug` for document isolation

## Test plan
- [x] `pnpm check` passes (all 666 tests)
- [ ] Deploy to prod, verify `drizzle-kit push` succeeds
- [ ] Inspect and backfill existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)