### PR TITLE
feat: add OG and Twitter Card meta tags to vibe pages

### DIFF
--- a/vibes.diy/api/svc/intern/components/vibe-page.tsx
+++ b/vibes.diy/api/svc/intern/components/vibe-page.tsx
@@ -29,6 +29,17 @@ export function Meta({ metaProps }: VibesDiyServCtx) {
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>{metaProps.title}</title>
       <meta name="description" content={metaProps.description} />
+
+      <meta property="og:type" content="website" />
+      <meta property="og:title" content={metaProps.title} />
+      <meta property="og:description" content={metaProps.description} />
+      {metaProps.canonicalUrl && <meta property="og:url" content={metaProps.canonicalUrl} />}
+      {metaProps.imageUrl && <meta property="og:image" content={metaProps.imageUrl} />}
+
+      <meta name="twitter:card" content={metaProps.imageUrl ? "summary_large_image" : "summary"} />
+      <meta name="twitter:title" content={metaProps.title} />
+      <meta name="twitter:description" content={metaProps.description} />
+      {metaProps.imageUrl && <meta name="twitter:image" content={metaProps.imageUrl} />}
     </>
   );
 }

--- a/vibes.diy/api/svc/intern/render-vibe.ts
+++ b/vibes.diy/api/svc/intern/render-vibe.ts
@@ -4,6 +4,9 @@ import {
   HttpResponseBodyType,
   isFetchErrResult,
   isFetchNotFoundResult,
+  isMetaScreenShot,
+  isMetaTitle,
+  MetaItem,
   VibesDiyServCtx,
   vibeImportMap,
   vibeUserEnv,
@@ -108,23 +111,35 @@ export async function renderVibe({ ctx, fs, fsItems, pkgRepos }: RenderVibesOpts
   //   return Result.Err(env.toLocaleString());
   // }
 
+  const metaItems = (fs.meta as MetaItem[]) || [];
+  const metaTitle = metaItems.find(isMetaTitle);
+  const metaScreenShot = metaItems.find(isMetaScreenShot);
+
+  const requestUrl = new URL(ctx.request.url);
+  const canonicalUrl = `${requestUrl.protocol}//${requestUrl.host}/`;
+
+  let imageUrl: string | undefined;
+  if (metaScreenShot) {
+    const assetPath = `/assets/cid/?url=${encodeURIComponent(metaScreenShot.assetUrl)}&mime=${encodeURIComponent(metaScreenShot.mime)}`;
+    imageUrl = `${requestUrl.protocol}//${requestUrl.host}${assetPath}`;
+  }
+
+  const title = metaTitle?.title ?? fs.appSlug;
+
   const vsctx = {
     wrapper: {
       state: "waiting",
     },
-    // bindings: {
-    //   appSlug: fs.appSlug,
-    //   userSlug: fs.userSlug,
-    //   fsId: fs.fsId,
-    // },
     usrEnv,
     svcEnv: vctx.params.vibes.env,
     importMap: {
       imports: importMap,
     },
     metaProps: {
-      title: "we need a title",
-      description: "we need a description",
+      title,
+      description: `${title} - built on vibes.diy`,
+      imageUrl,
+      canonicalUrl,
     },
     mountJS: [
       `import { mountVibe, registerDependencies } from '@vibes.diy/vibe-runtime';`,

--- a/vibes.diy/api/svc/public/serv-entry-point.ts
+++ b/vibes.diy/api/svc/public/serv-entry-point.ts
@@ -270,17 +270,6 @@ export const servEntryPoint: EventoHandler<Request, ExtractedHostToBindings, unk
         return sendFetchOk(ctx, selectedFsItem, possiblePath);
       }
     }
-    // console.log("-6servEntryPoint triggered with URL:", uri.toString())
-    const selectedEntryPoint = fileSystem.find((i) => i.entryPoint);
-    if (selectedEntryPoint) {
-      const entryPointPath = await vctx.storage.fetch(selectedEntryPoint.assetURI);
-      if (isFetchErrResult(entryPointPath)) {
-        return Result.Err(entryPointPath.error);
-      }
-      if (isFetchOkResult(entryPointPath)) {
-        return sendFetchOk(ctx, selectedEntryPoint, entryPointPath);
-      }
-    }
     // Serve screenshot from meta for social media cards
     if (ctx.validated.path === "/screenshot.png" || ctx.validated.path === "/screenshot.jpg") {
       const metaItems = (fs.meta as MetaItem[]) || [];
@@ -310,6 +299,17 @@ export const servEntryPoint: EventoHandler<Request, ExtractedHostToBindings, unk
       return Result.Ok(EventoResult.Stop);
     }
 
+    // console.log("-6servEntryPoint triggered with URL:", uri.toString())
+    const selectedEntryPoint = fileSystem.find((i) => i.entryPoint);
+    if (selectedEntryPoint) {
+      const entryPointPath = await vctx.storage.fetch(selectedEntryPoint.assetURI);
+      if (isFetchErrResult(entryPointPath)) {
+        return Result.Err(entryPointPath.error);
+      }
+      if (isFetchOkResult(entryPointPath)) {
+        return sendFetchOk(ctx, selectedEntryPoint, entryPointPath);
+      }
+    }
     // console.log("-7servEntryPoint triggered with URL:", uri.toString())
     if (ctx.validated.path === "/" || ctx.validated.path === "/index.html") {
       const npmUrl = captureNpmUrl(vctx, ctx.request);

--- a/vibes.diy/api/svc/public/serv-entry-point.ts
+++ b/vibes.diy/api/svc/public/serv-entry-point.ts
@@ -19,6 +19,8 @@ import {
   HttpResponseJsonType,
   isFetchErrResult,
   isFetchOkResult,
+  isMetaScreenShot,
+  MetaItem,
 } from "@vibes.diy/api-types";
 import { type } from "arktype";
 import { renderVibe } from "../intern/render-vibe.js";
@@ -279,6 +281,35 @@ export const servEntryPoint: EventoHandler<Request, ExtractedHostToBindings, unk
         return sendFetchOk(ctx, selectedEntryPoint, entryPointPath);
       }
     }
+    // Serve screenshot from meta for social media cards
+    if (ctx.validated.path === "/screenshot.png" || ctx.validated.path === "/screenshot.jpg") {
+      const metaItems = (fs.meta as MetaItem[]) || [];
+      const shot = metaItems.find(isMetaScreenShot);
+      if (shot) {
+        const shotFetch = await vctx.storage.fetch(shot.assetUrl);
+        if (isFetchOkResult(shotFetch)) {
+          const assetRes = new Response(shotFetch.data);
+          const asset = await assetRes.arrayBuffer();
+          await ctx.send.send(ctx, {
+            type: "http.Response.Body",
+            status: 200,
+            headers: {
+              "Content-Type": shot.mime,
+              "Cache-Control": "public, max-age=86400",
+            },
+            body: asset,
+          } satisfies HttpResponseBodyType);
+          return Result.Ok(EventoResult.Stop);
+        }
+      }
+      await ctx.send.send(ctx, {
+        type: "http.Response.JSON",
+        status: 404,
+        json: { type: "error", message: "No screenshot available" },
+      } satisfies HttpResponseJsonType);
+      return Result.Ok(EventoResult.Stop);
+    }
+
     // console.log("-7servEntryPoint triggered with URL:", uri.toString())
     if (ctx.validated.path === "/" || ctx.validated.path === "/index.html") {
       const npmUrl = captureNpmUrl(vctx, ctx.request);

--- a/vibes.diy/api/types/vibes-diy-serv-ctx.ts
+++ b/vibes.diy/api/types/vibes-diy-serv-ctx.ts
@@ -32,6 +32,8 @@ export type VibesSvcEnv = typeof vibesSvcEnv.infer;
 const metaProps = type({
   title: "string",
   description: "string",
+  "imageUrl?": "string",
+  "canonicalUrl?": "string",
 });
 
 export type MetaProps = typeof metaProps.infer;

--- a/vibes.diy/pkg/app/routes/vibe.$userSlug.$appSlug.tsx
+++ b/vibes.diy/pkg/app/routes/vibe.$userSlug.$appSlug.tsx
@@ -17,6 +17,27 @@ import { toast } from "react-hot-toast";
 import { getAppByFsIdEvento } from "@vibes.diy/api-svc/public/get-app-by-fsid.js";
 import { isMetaScreenShot, isMetaTitle } from "@vibes.diy/api-types";
 
+export function meta({ params, matches }: { params: Record<string, string>; matches: { data: unknown }[] }) {
+  const { userSlug, appSlug } = params;
+  const rootData = matches[0]?.data as { env?: { VIBES_SVC_HOSTNAME_BASE?: string } } | undefined;
+  const hostnameBase = rootData?.env?.VIBES_SVC_HOSTNAME_BASE?.replace(/^\./, "") ?? "vibes.diy";
+  const imageUrl = `https://${appSlug}--${userSlug}.${hostnameBase}/screenshot.jpg`;
+  const title = appSlug ?? "Vibe";
+
+  return [
+    { title: `${title} - vibes.diy` },
+    { name: "description", content: `${title} - built on vibes.diy` },
+    { property: "og:type", content: "website" },
+    { property: "og:title", content: title },
+    { property: "og:description", content: `${title} - built on vibes.diy` },
+    { property: "og:image", content: imageUrl },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: title },
+    { name: "twitter:description", content: `${title} - built on vibes.diy` },
+    { name: "twitter:image", content: imageUrl },
+  ];
+}
+
 export default function VibeIframeWrapper() {
   const { userSlug, appSlug, fsId } = useParams<{ userSlug: string; appSlug: string; fsId?: string }>();
   useDocumentTitle(`${userSlug} - ${appSlug} - vibes.diy`);


### PR DESCRIPTION
## Summary
- Thread screenshot and title metadata from the `apps` DB `meta` column into server-rendered vibe page HTML
- Add Open Graph (`og:title`, `og:description`, `og:image`, `og:url`) and Twitter Card meta tags
- Uses `summary_large_image` card type when a screenshot exists, falls back to `summary`
- Title falls back to `appSlug` when no `MetaTitle` meta item is present

## Test plan
- [ ] Deploy to preview and view page source on a published vibe — verify OG/Twitter meta tags are present
- [ ] Test a vibe with a screenshot — confirm `og:image` has an absolute URL pointing to `/assets/cid/`
- [ ] Test a vibe without a screenshot — confirm image tags are absent and twitter:card is `summary`
- [ ] Validate with Twitter Card Validator or Facebook Sharing Debugger

🤖 Generated with [Claude Code](https://claude.com/claude-code)