### PR TITLE
perf: fix seq scans in queryDocs and ensureAppSettings

### DIFF
--- a/vibes.diy/api/sql/vibes-diy-api-schema-pg.ts
+++ b/vibes.diy/api/sql/vibes-diy-api-schema-pg.ts
@@ -193,10 +193,7 @@ export const sqlAppDocuments = pgTable(
     deleted: integer().notNull().default(0), // 1 = tombstone
     created: text().notNull(), // ISO timestamp of this revision
   },
-  (table) => [
-    primaryKey({ columns: [table.userSlug, table.appSlug, table.dbName, table.docId, table.seq] }),
-    index("AppDocuments_latest_idx").on(table.userSlug, table.appSlug, table.dbName, table.docId, table.seq),
-  ]
+  (table) => [primaryKey({ columns: [table.userSlug, table.appSlug, table.dbName, table.docId, table.seq] })]
 );
 
 export const sqlInviteGrants = pgTable(

--- a/vibes.diy/api/sql/vibes-diy-api-schema-sqlite.ts
+++ b/vibes.diy/api/sql/vibes-diy-api-schema-sqlite.ts
@@ -188,10 +188,7 @@ export const sqlAppDocuments = sqliteTable(
     deleted: int().notNull().default(0), // 1 = tombstone
     created: text().notNull(), // ISO timestamp of this revision
   },
-  (table) => [
-    primaryKey({ columns: [table.userSlug, table.appSlug, table.dbName, table.docId, table.seq] }),
-    index("AppDocuments_latest_idx").on(table.userSlug, table.appSlug, table.dbName, table.docId, table.seq),
-  ]
+  (table) => [primaryKey({ columns: [table.userSlug, table.appSlug, table.dbName, table.docId, table.seq] })]
 );
 
 export const sqlInviteGrants = sqliteTable(

--- a/vibes.diy/api/svc/public/app-documents.ts
+++ b/vibes.diy/api/svc/public/app-documents.ts
@@ -292,20 +292,21 @@ export const queryDocsEvento: EventoHandler<W3CWebSocketEvent, MsgBase<ReqQueryD
 
       const t = vctx.sql.tables.appDocuments;
 
-      // Fetch all rows for this app, ordered by docId + seq desc
-      // Then deduplicate in JS to get the latest revision per docId
+      // Fetch all rows for this app, ordered by docId + seq asc (matches PK index)
+      // Then deduplicate in JS — last row per docId is the latest revision
       const rows = await vctx.sql.db
         .select()
         .from(t)
         .where(and(eq(t.userSlug, req.userSlug), eq(t.appSlug, req.appSlug), eq(t.dbName, req.dbName)))
-        .orderBy(sql`${t.docId}, ${t.seq} desc`);
+        .orderBy(sql`${t.docId}, ${t.seq}`);
 
-      // Keep only the latest revision per docId, skip deleted
-      const seen = new Set<string>();
-      const docs: ({ _id: string } & Record<string, unknown>)[] = [];
+      // Last row per docId wins (highest seq), skip deleted
+      const latest = new Map<string, (typeof rows)[0]>();
       for (const row of rows) {
-        if (seen.has(row.docId)) continue;
-        seen.add(row.docId);
+        latest.set(row.docId, row);
+      }
+      const docs: ({ _id: string } & Record<string, unknown>)[] = [];
+      for (const row of latest.values()) {
         if (row.deleted === 1) continue;
         docs.push({
           _id: row.docId,

--- a/vibes.diy/api/svc/public/ensure-app-settings.ts
+++ b/vibes.diy/api/svc/public/ensure-app-settings.ts
@@ -133,8 +133,9 @@ export async function ensureAppSettings(
       .leftJoin(
         vctx.sql.tables.appSettings,
         and(
-          eq(vctx.sql.tables.appSettings.userSlug, vctx.sql.tables.userSlugBinding.userSlug),
-          eq(vctx.sql.tables.appSettings.appSlug, req.appSlug)
+          eq(vctx.sql.tables.appSettings.userId, vctx.sql.tables.userSlugBinding.userId),
+          eq(vctx.sql.tables.appSettings.appSlug, req.appSlug),
+          eq(vctx.sql.tables.appSettings.userSlug, vctx.sql.tables.userSlugBinding.userSlug)
         )
       )
       .where(


### PR DESCRIPTION
## Summary
- **queryDocs**: Change ORDER BY to `(docId ASC, seq ASC)` to match PK index direction, eliminating in-memory sort. JS dedup changed from Set (first wins) to Map (last wins).
- **ensureAppSettings**: Add `userId` to AppSettings LEFT JOIN so Postgres uses the PK `(userId, appSlug, userSlug)` instead of seq scanning. This was the #2 seq scan source at 14,857 scans / 1.2M tuples read.
- **Remove duplicate index**: `AppDocuments_latest_idx` was identical to the PK and had only 1 scan ever.

## Evidence
```
AppSettings:      14,857 seq scans, 1,210,906 tuples read, 366 idx scans
AppDocuments:      2,105 seq scans, 1,189,978 tuples read, 229 idx scans
UserSlugBindings: 30,037 seq scans (tiny table, cost-based choice — ok)
```

## Test plan
- [x] `pnpm check` — all 710 tests pass
- [ ] Deploy, then reset `pg_stat_user_tables` and compare seq_scan counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)