### PR TITLE
perf: immutable cache headers for hashed static assets

### DIFF
--- a/vibes.diy/pkg/workers/app.ts
+++ b/vibes.diy/pkg/workers/app.ts
@@ -127,7 +127,18 @@ export default {
       return res;
     }
 
-    // console.log("Handling request for", cfCtx.vibesCtx.params);
+    // Hashed static assets (Vite fingerprinted) — cache immutably
+    if (url.pathname.startsWith("/assets/") && !url.pathname.startsWith("/assets/cid")) {
+      const assetResponse = await env.ASSETS.fetch(request);
+      if (assetResponse.ok) {
+        const headers = new Headers(Object.fromEntries(assetResponse.headers.entries()));
+        headers.set("Cache-Control", "public, max-age=31536000, immutable");
+        return new Response(assetResponse.body as unknown as BodyInit, {
+          status: assetResponse.status,
+          headers,
+        }) as unknown as CFResponse;
+      }
+    }
 
     // Delegate to React Router for SSR
     return requestHandler(request as unknown as Parameters<typeof requestHandler>[0], {


### PR DESCRIPTION
## Summary
- Intercept `/assets/*` requests in the Cloudflare Worker and set `Cache-Control: public, max-age=31536000, immutable` on Vite-fingerprinted files
- Excludes `/assets/cid` which is already handled separately for vibe content-addressed assets
- Previously these files got Cloudflare's default `max-age=0, must-revalidate` despite having content hashes in filenames

## Test plan
- [x] `pnpm check` passes (90 test files, 710 tests)
- [ ] Deploy to dev/preview and verify `root-*.css` response headers show `immutable`
- [ ] Re-run Chrome DevTools performance trace to confirm render-blocking CSS savings (~85ms LCP estimated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)